### PR TITLE
Avoid generating a CompileAssetCatalog build phase

### DIFF
--- a/rules/test_host_app/AssetCatalogFixture.xcassets/Contents.json
+++ b/rules/test_host_app/AssetCatalogFixture.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/rules/test_host_app/BUILD.bazel
+++ b/rules/test_host_app/BUILD.bazel
@@ -9,6 +9,7 @@ exports_files([
     ios_application(
         name = "iOS-%s-AppHost" % version,
         srcs = ["main.m"],
+        resource_bundles = {"iOS-AppHost-Resources": glob(["AssetCatalogFixture.xcassets/**"])},
         bundle_id = "com.example.ios-app-host-%s" % version,
         entitlements = "ios.entitlements",
         families = [

--- a/rules/test_host_app/BUILD.bazel
+++ b/rules/test_host_app/BUILD.bazel
@@ -9,7 +9,6 @@ exports_files([
     ios_application(
         name = "iOS-%s-AppHost" % version,
         srcs = ["main.m"],
-        resource_bundles = {"iOS-AppHost-Resources": glob(["AssetCatalogFixture.xcassets/**"])},
         bundle_id = "com.example.ios-app-host-%s" % version,
         entitlements = "ios.entitlements",
         families = [
@@ -18,6 +17,7 @@ exports_files([
         ],
         launch_storyboard = "LaunchScreen.storyboard",
         minimum_os_version = version,
+        resource_bundles = {"iOS-AppHost-Resources": glob(["AssetCatalogFixture.xcassets/**"])},
         visibility = ["//visibility:public"],
     )
     for version in [

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -81,7 +81,7 @@ def _xcodeproj_aspect_impl(target, ctx):
         srcs = []
         asset_srcs = []
         for attr in _dir(ctx.rule.files):
-            if attr == 'srcs':
+            if attr == "srcs":
                 srcs += getattr(ctx.rule.files, attr, [])
             else:
                 asset_srcs += getattr(ctx.rule.files, attr, [])
@@ -164,15 +164,15 @@ def _xcodeproj_impl(ctx):
     for target_info in targets:
         target_macho_type = "staticlib" if target_info.product_type == "framework" else "$(inherited)"
         compiled_sources = [{
-                            "path": paths.join(src_dot_dots, s.short_path),
-                            "group": paths.dirname(s.short_path),
-                            "optional": True,
+            "path": paths.join(src_dot_dots, s.short_path),
+            "group": paths.dirname(s.short_path),
+            "optional": True,
         } for s in target_info.srcs.to_list()]
         asset_sources = [{
-                            "path": paths.join(src_dot_dots, s.short_path),
-                            "group": paths.dirname(s.short_path),
-                            "optional": True,
-                            "buildPhase": "none",
+            "path": paths.join(src_dot_dots, s.short_path),
+            "group": paths.dirname(s.short_path),
+            "optional": True,
+            "buildPhase": "none",
         } for s in target_info.asset_srcs.to_list()]
         xcodeproj_targets_by_name[target_info.name] = {
             "sources": compiled_sources + asset_sources,

--- a/tests/xcodeproj/Single-Application-Project.xcodeproj/project.pbxproj
+++ b/tests/xcodeproj/Single-Application-Project.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		48A8F4B41EF706F8BEEC7ACB /* Single-Application-UnitTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = "Single-Application-UnitTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5FF81A9585DBB110EBD9CAC0 /* test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = test.swift; path = test.swift; sourceTree = "<group>"; };
 		8DBB99CE021DEB0B97F196EA /* common.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = common.pch; path = ../../rules/library/common.pch; sourceTree = "<group>"; };
+		AB7BB9505A64B479DA80B398 /* resource_bundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = resource_bundle.plist; path = ../../rules/library/resource_bundle.plist; sourceTree = "<group>"; };
+		C7D23D76EAC581CB42F9ECC8 /* Contents.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = Contents.json; path = ../../rules/test_host_app/AssetCatalogFixture.xcassets/Contents.json; sourceTree = "<group>"; };
 		E8189BFE61671DD0C36CBACF /* ios.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = ios.entitlements; path = ../../rules/test_host_app/ios.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -41,6 +43,7 @@
 		21BA00DCD3A39A744A656EFC /* test_host_app */ = {
 			isa = PBXGroup;
 			children = (
+				995075BD7E686FB0D1912DF2 /* AssetCatalogFixture.xcassets */,
 				E8189BFE61671DD0C36CBACF /* ios.entitlements */,
 				219EC613C66D223DC34C2B88 /* main.m */,
 			);
@@ -73,10 +76,19 @@
 			);
 			sourceTree = "<group>";
 		};
+		995075BD7E686FB0D1912DF2 /* AssetCatalogFixture.xcassets */ = {
+			isa = PBXGroup;
+			children = (
+				C7D23D76EAC581CB42F9ECC8 /* Contents.json */,
+			);
+			name = AssetCatalogFixture.xcassets;
+			sourceTree = "<group>";
+		};
 		D099E71665C7B6C5389FAEDF /* library */ = {
 			isa = PBXGroup;
 			children = (
 				8DBB99CE021DEB0B97F196EA /* common.pch */,
+				AB7BB9505A64B479DA80B398 /* resource_bundle.plist */,
 			);
 			name = library;
 			sourceTree = "<group>";


### PR DESCRIPTION
For xcasset sources, we do not want xcode to run actool. I'm not sure how to stub out the CompileAssetCatalog command, so it's easier to just load xcasset files into the xcodeproject, but not associate them with any build phase.