### PR TITLE
Remove background color from default test host app

### DIFF
--- a/rules/test_host_app/main.m
+++ b/rules/test_host_app/main.m
@@ -15,7 +15,6 @@
 {
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     self.window.rootViewController = [UIViewController new];
-    self.window.rootViewController.view.backgroundColor = UIColor.purpleColor;
 
     [self.window makeKeyAndVisible];
 


### PR DESCRIPTION
It was left in accidentally from debugging months ago

The cocoapods-generated app host does not set a background color, so we shouldnt either