### PR TITLE
Add support for specifying a dict of infoplist values

### DIFF
--- a/docs/app_doc.md
+++ b/docs/app_doc.md
@@ -20,3 +20,26 @@ ios_application(<a href="#ios_application-name">name</a>, <a href="#ios_applicat
 | kwargs |  Arguments passed to the apple_library and ios_application rules as appropriate.   |  none |
 
 
+<a name="#write_info_plists_if_needed"></a>
+
+## write_info_plists_if_needed
+
+<pre>
+write_info_plists_if_needed(<a href="#write_info_plists_if_needed-name">name</a>, <a href="#write_info_plists_if_needed-plists">plists</a>)
+</pre>
+
+    Writes info plists for an app if needed.
+
+Given a list of infoplists, will write out any plists that are passed as a
+dict, and will add a default app Info.plist if no non-dict plists are passed.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :-------------: | :-------------: | :-------------: |
+| name |  The name of the app target these infoplists are for.   |  none |
+| plists |  A list of either labels or dicts.   |  none |
+
+

--- a/docs/library_doc.md
+++ b/docs/library_doc.md
@@ -38,8 +38,8 @@ Writes out a file verbatim
 | Name  | Description | Type | Mandatory | Default |
 | :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
 | name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| content |  -   | String | optional | "" |
-| destination |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| content |  -   | String | required |  |
+| destination |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 
 <a name="#PrivateHeaders"></a>

--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -14,6 +14,16 @@ _IOS_APPLICATION_KWARGS = [
 ]
 
 def write_info_plists_if_needed(name, plists):
+    """
+    Writes info plists for an app if needed.
+
+    Given a list of infoplists, will write out any plists that are passed as a
+    dict, and will add a default app Info.plist if no non-dict plists are passed.
+
+    Args:
+        name: The name of the app target these infoplists are for.
+        plists: A list of either labels or dicts.
+    """
     already_written_plists = []
     written_plists = []
     for idx, plist in enumerate(plists):

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -42,8 +42,8 @@ def _write_file_impl(ctx):
 write_file = rule(
     implementation = _write_file_impl,
     attrs = {
-        "content": attr.string(),
-        "destination": attr.output(),
+        "content": attr.string(mandatory = True),
+        "destination": attr.output(mandatory = True),
     },
     doc = "Writes out a file verbatim",
 )

--- a/tests/app/ios/App/main.m
+++ b/tests/app/ios/App/main.m
@@ -1,6 +1,6 @@
 @import FW;
 @import OnlySources;
 
-int main() {
-    exit(0);
+int main(int argc, char **argv) {
+    return UIApplicationMain(argc, argv, nil, nil);
 }

--- a/tests/app/ios/BUILD.bazel
+++ b/tests/app/ios/BUILD.bazel
@@ -1,5 +1,6 @@
 load("//rules:framework.bzl", "apple_framework")
 load("//rules:app.bzl", "ios_application")
+load("//rules:test.bzl", "ios_unit_test")
 
 apple_framework(
     name = "FW",
@@ -26,4 +27,35 @@ ios_application(
         ":FW",
         ":OnlySources",
     ],
+)
+
+ios_application(
+    name = "AppWithInfoPlist",
+    srcs = ["App/main.m"],
+    bundle_id = "com.example.app",
+    infoplists = [{
+        "NSPhotoLibraryAddUsageDescription": "This app requires access to the photo library.",
+        "NSPhotoLibraryUsageDescription": "This app requires access to the photo library.",
+        "UISupportedExternalAccessoryProtocols": [
+            "com.example.eap",
+        ],
+        "Int": 1,
+        "Dict": {
+            "A": "a",
+            "B": "b",
+        },
+    }],
+    minimum_os_version = "10.0",
+    deps = [
+        ":Empty",
+        ":FW",
+        ":OnlySources",
+    ],
+)
+
+ios_unit_test(
+    name = "TestAppWithInfoPlist",
+    srcs = ["infoplist_test.m"],
+    minimum_os_version = "10.0",
+    test_host = ":AppWithInfoPlist",
 )

--- a/tests/app/ios/infoplist_test.m
+++ b/tests/app/ios/infoplist_test.m
@@ -1,0 +1,30 @@
+@import XCTest;
+
+@interface EmptyTests : XCTestCase
+
+@end
+
+@implementation EmptyTests
+
+- (void)test_infoplist_values {
+    NSDictionary *expected = @{
+      @"NSPhotoLibraryAddUsageDescription": @"This app requires access to the photo library.",
+      @"NSPhotoLibraryUsageDescription": @"This app requires access to the photo library.",
+      @"UISupportedExternalAccessoryProtocols": @[
+        @"com.example.eap",
+      ],
+      @"Int": @1,
+      @"Dict": @{
+          @"A": @"a",
+          @"B": @"b",
+      },
+    };
+
+    NSDictionary *actual = NSBundle.mainBundle.infoDictionary;
+
+    [expected enumerateKeysAndObjectsUsingBlock:^(NSString *key, id object, BOOL *stop){
+        XCTAssertEqualObjects(object, [actual objectForKey:key], @"Expected value for %@ to be the same", key);
+    }];
+}
+
+@end


### PR DESCRIPTION
This allows specifying entries directly in the BUILD file,
rather than requiring users to write out a plist file themselves

This will allow cocoapods-bazel to emit `app_spec.info_plist`
specifications into BUILD files, keeping the behavior whereby no
files outside of BUILD files need to be written
