### PR TITLE
Refer to actual generated swift header when making swift hmap

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,3 @@
 # We can't create a bzl_library for rules-swift because of its visibility,
 # so circumvent by not using the sandbox
-common --strategy=Stardoc=standalone
+build --strategy=Stardoc=standalone

--- a/docs/hmap_doc.md
+++ b/docs/hmap_doc.md
@@ -5,7 +5,7 @@
 ## headermap
 
 <pre>
-headermap(<a href="#headermap-name">name</a>, <a href="#headermap-flatten_headers">flatten_headers</a>, <a href="#headermap-hdr_providers">hdr_providers</a>, <a href="#headermap-hdrs">hdrs</a>, <a href="#headermap-namespace">namespace</a>)
+headermap(<a href="#headermap-name">name</a>, <a href="#headermap-direct_hdr_providers">direct_hdr_providers</a>, <a href="#headermap-flatten_headers">flatten_headers</a>, <a href="#headermap-hdr_providers">hdr_providers</a>, <a href="#headermap-hdrs">hdrs</a>, <a href="#headermap-namespace">namespace</a>)
 </pre>
 
 Creates a binary headermap file from the given headers,
@@ -21,6 +21,7 @@ regardless of the package structure being used.
 | Name  | Description | Type | Mandatory | Default |
 | :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
 | name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| direct_hdr_providers |  Targets whose direct headers should be added to the list of hdrs   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | flatten_headers |  Whether headers should be importable with the namespace as a prefix   | Boolean | required |  |
 | hdr_providers |  Targets that provide headers. Targets must have either an Objc or CcInfo provider.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | hdrs |  The list of headers included in the headermap   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |

--- a/rules/hmap.bzl
+++ b/rules/hmap.bzl
@@ -58,7 +58,6 @@ def _make_headermap_impl(ctx):
     )
 
     # Add a list of headermaps in text or hmap format
-    mappings = []
     merge_hmaps = {}
     inputs = [input_f]
     args = []
@@ -79,14 +78,6 @@ def _make_headermap_impl(ctx):
                 # Add headermaps
                 merge_hmaps[hdr] = True
 
-    if mappings:
-        mappings_file = ctx.actions.declare_file(ctx.label.name + ".add_mappings")
-        inputs.append(mappings_file)
-        ctx.actions.write(
-            content = "\n".join(mappings) + "\n",
-            output = mappings_file,
-        )
-        args += ["--add-mappings", mappings_file.path]
     if merge_hmaps:
         paths = []
         for hdr in merge_hmaps.keys():


### PR DESCRIPTION
Before, the file in hdrs referred to a non-existant source file

We can see the fix in effect by the xcodeproj build not failing, since the `-Swift.h` header is no longer getting added to the xcode project !

cc @wileykestner