### PR TITLE
Fix swift's clang importer being able to see hmaps

### DIFF
--- a/docs/hmap_doc.md
+++ b/docs/hmap_doc.md
@@ -5,7 +5,7 @@
 ## headermap
 
 <pre>
-headermap(<a href="#headermap-name">name</a>, <a href="#headermap-direct_hdr_providers">direct_hdr_providers</a>, <a href="#headermap-flatten_headers">flatten_headers</a>, <a href="#headermap-hdr_providers">hdr_providers</a>, <a href="#headermap-hdrs">hdrs</a>, <a href="#headermap-namespace">namespace</a>)
+headermap(<a href="#headermap-name">name</a>, <a href="#headermap-direct_hdr_providers">direct_hdr_providers</a>, <a href="#headermap-flatten_headers">flatten_headers</a>, <a href="#headermap-hdrs">hdrs</a>, <a href="#headermap-namespace">namespace</a>)
 </pre>
 
 Creates a binary headermap file from the given headers,
@@ -23,7 +23,6 @@ regardless of the package structure being used.
 | name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | direct_hdr_providers |  Targets whose direct headers should be added to the list of hdrs   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | flatten_headers |  Whether headers should be importable with the namespace as a prefix   | Boolean | required |  |
-| hdr_providers |  Targets that provide headers. Targets must have either an Objc or CcInfo provider.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | hdrs |  The list of headers included in the headermap   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
 | namespace |  The prefix to be used for header imports when flatten_headers is true   | String | required |  |
 

--- a/rules/hmap.bzl
+++ b/rules/hmap.bzl
@@ -46,7 +46,7 @@ def _make_headermap_impl(ctx):
     for provider in ctx.attr.direct_hdr_providers:
         if apple_common.Objc in provider:
             all_hdrs += provider[apple_common.Objc].direct_headers
-        elif CcInfo in hdr_provider:
+        elif CcInfo in provider:
             all_hdrs += provider[CcInfo].compilation_context.direct_headers
         else:
             fail("direct_hdr_provider %s must contain either 'CcInfo' or 'objc' provider" % provider)

--- a/rules/hmap.bzl
+++ b/rules/hmap.bzl
@@ -62,22 +62,6 @@ def _make_headermap_impl(ctx):
     inputs = [input_f]
     args = []
 
-    # Extract propagated headermaps
-    for hdr_provider in ctx.attr.hdr_providers:
-        hdrs = []
-        if apple_common.Objc in hdr_provider:
-            hdrs.extend(hdr_provider[apple_common.Objc].header.to_list())
-        elif CcInfo in hdr_provider:
-            hdrs.extend(hdr_provider[CcInfo].compilation_context.headers.to_list())
-        else:
-            fail("hdr_provider must contain either 'CcInfo' or 'objc' provider")
-
-        for hdr in hdrs:
-            # only merge public header maps
-            if hdr.path.endswith("public_hmap.hmap"):
-                # Add headermaps
-                merge_hmaps[hdr] = True
-
     if merge_hmaps:
         paths = []
         for hdr in merge_hmaps.keys():
@@ -112,7 +96,6 @@ def _make_headermap_impl(ctx):
 # Derive a headermap from transitive headermaps
 # hdrs: a file group containing headers for this rule
 # namespace: the Apple style namespace these header should be under
-# hdr_providers: rules providing headers. i.e. an `objc_library`
 headermap = rule(
     implementation = _make_headermap_impl,
     output_to_genfiles = True,
@@ -133,13 +116,6 @@ headermap = rule(
         "flatten_headers": attr.bool(
             mandatory = True,
             doc = "Whether headers should be importable with the namespace as a prefix",
-        ),
-        "hdr_providers": attr.label_list(
-            mandatory = False,
-            doc = """\
-Targets that provide headers.
-Targets must have either an Objc or CcInfo provider.""",
-            providers = [[apple_common.Objc], [CcInfo]],
         ),
         "_headermap_builder": attr.label(
             executable = True,

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -396,7 +396,6 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
         name = public_hmap_name,
         namespace = namespace,
         hdrs = [public_hdrs_filegroup],
-        hdr_providers = deps,
         flatten_headers = True,
         tags = _MANUAL,
     )

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -208,8 +208,10 @@ def _prepend_copts(copts_struct, objc_copts, cc_copts, swift_copts, linkopts, ib
     _prepend(copts_struct.mapc_copts, mapc_copts)
 
 def _append_headermap_copts(hmap, flag, objc_copts, swift_copts, cc_copts):
-    copt = flag + '"$(execpath :{hmap})"'.format(hmap = hmap)
+    copt = flag + "$(execpath :{hmap})".format(hmap = hmap)
+
     objc_copts.append(copt)
+    cc_copts.append(copt)
     swift_copts.extend(("-Xcc", copt))
 
 def _uppercase_string(s):

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -36,7 +36,7 @@ def rules_ios_dependencies():
         git_repository,
         name = "build_bazel_rules_swift",
         commit = "2ebfc403ffdb428befd38e25e236ae181aa1a49b",
-        shallow_since = "1580525034 -0800",
+        shallow_since = "1586818875 -0700",
         remote = "https://github.com/bazelbuild/rules_swift.git",
     )
 


### PR DESCRIPTION
* Remove public hmap propagation
  It can only confuse clang, since all public headers are now visible via frameworks

* Update shallow_since for rules_swift

* Fix typo in hmap impl

* Stop quoting the path to hmaps
  objc_library already have the quotes stripped, and the extra quotes break swift_library from actually seeing the headermaps