### PR TITLE
Pass 'app_icons' to rules_apple's ios_application

### DIFF
--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -11,6 +11,7 @@ _IOS_APPLICATION_KWARGS = [
     "entitlements",
     "visibility",
     "launch_storyboard",
+    "app_icons",
 ]
 
 def write_info_plists_if_needed(name, plists):


### PR DESCRIPTION
Adding another keyword argument to pass through to `rules_apple`'s `ios_application` rule.

Documented at: https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-ios.md#ios_application