### PR TITLE
Copy compilation context from objc provider to CcInfo

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -1,9 +1,7 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:types.bzl", "types")
-load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_common")
+load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo", "swift_common")
 load("//rules:library.bzl", "PrivateHeaders", "apple_library")
-load("//rules/vfs_overlay:vfs_overlay.bzl", "VFSOverlay")
 
 def apple_framework(name, apple_library = apple_library, **kwargs):
     """Builds and packages an Apple framework.
@@ -297,8 +295,13 @@ def _apple_framework_packaging_impl(ctx):
             swift_common.create_module(name = swiftmodule_name, swift = swift_module),
         ]
 
+    # Eventually we need to remove any reference to objc provider
+    # and use CcInfo instead, see this issue for more details: https://github.com/bazelbuild/bazel/issues/10674
+    objc_provider = apple_common.new_objc_provider(**objc_provider_fields)
+    cc_info_provider = CcInfo(compilation_context = objc_provider.compilation_context)
     return [
-        apple_common.new_objc_provider(**objc_provider_fields),
+        objc_provider,
+        cc_info_provider,
         swift_common.create_swift_info(**swift_info_fields),
         DefaultInfo(files = depset(framework_files)),
     ]

--- a/rules/hmap.bzl
+++ b/rules/hmap.bzl
@@ -87,10 +87,12 @@ def _make_headermap_impl(ctx):
         header = depset([ctx.outputs.headermap]),
     )
     cc_info_provider = CcInfo(compilation_context = objc_provider.compilation_context)
-    return [
-        objc_provider,
-        cc_info_provider,
-    ]
+    return struct(
+        files = depset([ctx.outputs.headermap]),
+        providers = [objc_provider, cc_info_provider],
+        objc = objc_provider,
+        headers = depset([ctx.outputs.headermap]),
+    )
 
 # Derive a headermap from transitive headermaps
 # hdrs: a file group containing headers for this rule

--- a/rules/hmap.bzl
+++ b/rules/hmap.bzl
@@ -86,9 +86,10 @@ def _make_headermap_impl(ctx):
     objc_provider = apple_common.new_objc_provider(
         header = depset([ctx.outputs.headermap]),
     )
+    cc_info_provider = CcInfo(compilation_context = objc_provider.compilation_context)
     return struct(
         files = depset([ctx.outputs.headermap]),
-        providers = [objc_provider],
+        providers = [objc_provider, cc_info_provider],
         objc = objc_provider,
         headers = depset([ctx.outputs.headermap]),
     )

--- a/rules/hmap.bzl
+++ b/rules/hmap.bzl
@@ -87,12 +87,10 @@ def _make_headermap_impl(ctx):
         header = depset([ctx.outputs.headermap]),
     )
     cc_info_provider = CcInfo(compilation_context = objc_provider.compilation_context)
-    return struct(
-        files = depset([ctx.outputs.headermap]),
-        providers = [objc_provider, cc_info_provider],
-        objc = objc_provider,
-        headers = depset([ctx.outputs.headermap]),
-    )
+    return [
+        objc_provider,
+        cc_info_provider,
+    ]
 
 # Derive a headermap from transitive headermaps
 # hdrs: a file group containing headers for this rule

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -27,16 +27,16 @@ def rules_ios_dependencies():
     _maybe(
         git_repository,
         name = "build_bazel_rules_apple",
-        commit = "2c24d057f6597846fcdb957d0e9f0d452bb336c9",
-        shallow_since = "1587565310 -0700",
+        commit = "193d258479e891bf286bf884d52ac779c83be206",
+        shallow_since = "1589211273 -0700",
         remote = "https://github.com/bazelbuild/rules_apple.git",
     )
 
     _maybe(
         git_repository,
         name = "build_bazel_rules_swift",
-        commit = "cf5857a353a1fdc2db6e642807ceff83d7969bd0",
-        shallow_since = "1587584958 -0700",
+        commit = "35ef1d6ebd7adb8d20c096bb4355cf41c9a0b5cf",
+        shallow_since = "1588778892 -0700",
         remote = "https://github.com/bazelbuild/rules_swift.git",
     )
 

--- a/tests/test/ios/test-imports-app/BUILD.bazel
+++ b/tests/test/ios/test-imports-app/BUILD.bazel
@@ -1,6 +1,12 @@
 load("//rules:app.bzl", "ios_application")
-load("//rules:framework.bzl", "apple_framework_packaging")
+load("//rules:framework.bzl", "apple_framework", "apple_framework_packaging")
 load("//rules:test.bzl", "ios_unit_test")
+
+apple_framework(
+    name = "SomeFramework",
+    srcs = glob(["SomeFramework/*.swift"]),
+    visibility = ["//visibility:public"],
+)
 
 ios_application(
     name = "TestImports-App",
@@ -14,6 +20,9 @@ ios_application(
     minimum_os_version = "12.0",
     module_name = "TestImports_App",
     sdk_frameworks = ["UIKit"],
+    deps = [
+        ":SomeFramework",
+    ],
 )
 
 # Implicitly generate a framework without a binary so tests can

--- a/tests/test/ios/test-imports-app/SomeFramework/Foo.swift
+++ b/tests/test/ios/test-imports-app/SomeFramework/Foo.swift
@@ -1,0 +1,3 @@
+struct Foo {
+    var bar: Int
+}

--- a/tests/test/ios/test-imports-app/empty.swift
+++ b/tests/test/ios/test-imports-app/empty.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SomeFramework
 
 @objc public class EmptyClass: NSObject {}
 internal struct EmptyStruct {}


### PR DESCRIPTION
Since rules_swift is doing a migration from objc provider to ccInfo's compilation context,
we need to match on our side with what they do so build is still successful.

The test added will fail without the addition of CcInfo inside framework.bzl.
Error was: `no such module 'SomeFramework'`

Also point to latest commit on master branch of `rules_swift` and `rules_apple`