### PR TITLE
NFC: Cleanups

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   integration_tests:
     name: Build and Test
-    runs-on: macOS-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode 11.2
@@ -21,9 +21,9 @@ jobs:
         with:
           name: bazel-testlogs
           path: bazel-testlogs
-  check_docs:
+  buildifier:
     name: Check Starlark
-    runs-on: macOS-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode 11.2
@@ -31,8 +31,8 @@ jobs:
       - name: Install buildifier
         run: brew install buildifier
       - name: buildifier
-        run: find . -type f \( -name 'WORKSPACE' -o -name '*.bzl' -o -name '*.bazel' \) | xargs buildifier --mode=diff
-  buildifier:
+        run: find . -type f \( -name 'WORKSPACE' -o -name '*.bzl' -o -name '*.bazel' \) | xargs buildifier -lint=fix && git diff --exit-code
+  check_docs:
     name: Check Docs
     runs-on: macOS-latest
     steps:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+    // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+    // List of extensions which should be recommended for users of this workspace.
+    "recommendations": [
+        "bazelbuild.vscode-bazel",
+        "github.vscode-pull-request-github",
+        "ms-vscode.cpptools",
+    ],
+    // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+    "unwantedRecommendations": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.exclude": {
+        "bazel-*": true
+    },
+    "editor.formatOnSave": true,
+}

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -1,8 +1,7 @@
-package(default_visibility = ["//visibility:private"])
-
 load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
-load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+package(default_visibility = ["//visibility:private"])
 
 _RULES = [
     "app",

--- a/docs/hmap_doc.md
+++ b/docs/hmap_doc.md
@@ -27,3 +27,21 @@ regardless of the package structure being used.
 | namespace |  The prefix to be used for header imports when flatten_headers is true   | String | required |  |
 
 
+<a name="#HeaderMapInfo"></a>
+
+## HeaderMapInfo
+
+<pre>
+HeaderMapInfo(<a href="#HeaderMapInfo-files">files</a>)
+</pre>
+
+Propagates header maps
+
+**FIELDS**
+
+
+| Name  | Description |
+| :-------------: | :-------------: |
+| files |  depset with headermaps    |
+
+

--- a/docs/library_doc.md
+++ b/docs/library_doc.md
@@ -42,12 +42,12 @@ Writes out a file verbatim
 | destination |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 
-<a name="#PrivateHeaders"></a>
+<a name="#PrivateHeadersInfo"></a>
 
-## PrivateHeaders
+## PrivateHeadersInfo
 
 <pre>
-PrivateHeaders(<a href="#PrivateHeaders-headers">headers</a>)
+PrivateHeadersInfo(<a href="#PrivateHeadersInfo-headers">headers</a>)
 </pre>
 
 Propagates private headers, so they can be accessed if necessary
@@ -82,81 +82,10 @@ reasonable defaults that mimic Xcode's behavior.
 | :-------------: | :-------------: | :-------------: |
 | name |  The base name for all of the underlying targets.   |  none |
 | library_tools |  An optional dictionary containing overrides for                 default behaviors.   |  <code>{}</code> |
-| export_private_headers |  Whether private headers should be exported via                         a <code>PrivateHeaders</code> provider.   |  <code>True</code> |
+| export_private_headers |  Whether private headers should be exported via                         a <code>PrivateHeadersInfo</code> provider.   |  <code>True</code> |
 | namespace_is_module_name |  Whether the module name should be used as the                           namespace for header imports, instead of the target name.   |  <code>True</code> |
 | default_xcconfig_name |  The name of a default xcconfig to be applied to this target.   |  <code>None</code> |
 | xcconfig |  A dictionary of Xcode build settings to be applied to this target in the           form of different <code>copt</code> attributes.   |  <code>{}</code> |
-| kwargs |  <p align="center"> - </p>   |  none |
-
-
-<a name="#generate_resource_bundles"></a>
-
-## generate_resource_bundles
-
-<pre>
-generate_resource_bundles(<a href="#generate_resource_bundles-name">name</a>, <a href="#generate_resource_bundles-library_tools">library_tools</a>, <a href="#generate_resource_bundles-module_name">module_name</a>, <a href="#generate_resource_bundles-resource_bundles">resource_bundles</a>, <a href="#generate_resource_bundles-kwargs">kwargs</a>)
-</pre>
-
-
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
-| name |  <p align="center"> - </p>   |  none |
-| library_tools |  <p align="center"> - </p>   |  none |
-| module_name |  <p align="center"> - </p>   |  none |
-| resource_bundles |  <p align="center"> - </p>   |  none |
-| kwargs |  <p align="center"> - </p>   |  none |
-
-
-<a name="#write_modulemap"></a>
-
-## write_modulemap
-
-<pre>
-write_modulemap(<a href="#write_modulemap-name">name</a>, <a href="#write_modulemap-library_tools">library_tools</a>, <a href="#write_modulemap-umbrella_header">umbrella_header</a>, <a href="#write_modulemap-public_headers">public_headers</a>, <a href="#write_modulemap-private_headers">private_headers</a>, <a href="#write_modulemap-module_name">module_name</a>,
-                <a href="#write_modulemap-framework">framework</a>, <a href="#write_modulemap-kwargs">kwargs</a>)
-</pre>
-
-
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
-| name |  <p align="center"> - </p>   |  none |
-| library_tools |  <p align="center"> - </p>   |  none |
-| umbrella_header |  <p align="center"> - </p>   |  <code>None</code> |
-| public_headers |  <p align="center"> - </p>   |  <code>[]</code> |
-| private_headers |  <p align="center"> - </p>   |  <code>[]</code> |
-| module_name |  <p align="center"> - </p>   |  <code>None</code> |
-| framework |  <p align="center"> - </p>   |  <code>False</code> |
-| kwargs |  <p align="center"> - </p>   |  none |
-
-
-<a name="#write_umbrella_header"></a>
-
-## write_umbrella_header
-
-<pre>
-write_umbrella_header(<a href="#write_umbrella_header-name">name</a>, <a href="#write_umbrella_header-library_tools">library_tools</a>, <a href="#write_umbrella_header-public_headers">public_headers</a>, <a href="#write_umbrella_header-private_headers">private_headers</a>, <a href="#write_umbrella_header-module_name">module_name</a>, <a href="#write_umbrella_header-kwargs">kwargs</a>)
-</pre>
-
-
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
-| name |  <p align="center"> - </p>   |  none |
-| library_tools |  <p align="center"> - </p>   |  none |
-| public_headers |  <p align="center"> - </p>   |  <code>[]</code> |
-| private_headers |  <p align="center"> - </p>   |  <code>[]</code> |
-| module_name |  <p align="center"> - </p>   |  <code>None</code> |
-| kwargs |  <p align="center"> - </p>   |  none |
+| kwargs |  keyword arguments.   |  none |
 
 

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -1,7 +1,8 @@
+"""Framework rules"""
+
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@bazel_skylib//lib:types.bzl", "types")
 load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo", "swift_common")
-load("//rules:library.bzl", "PrivateHeaders", "apple_library")
+load("//rules:library.bzl", "PrivateHeadersInfo", "apple_library")
 
 def apple_framework(name, apple_library = apple_library, **kwargs):
     """Builds and packages an Apple framework.
@@ -9,8 +10,9 @@ def apple_framework(name, apple_library = apple_library, **kwargs):
     Args:
         name: The name of the framework.
         apple_library: The macro used to package sources into a library.
-        kwargs: Arguments passed to the apple_library and apple_framework_packaging rules as appropriate.
+        **kwargs: Arguments passed to the apple_library and apple_framework_packaging rules as appropriate.
     """
+
     library = apple_library(name = name, **kwargs)
     apple_framework_packaging(
         name = name,
@@ -126,8 +128,8 @@ def _apple_framework_packaging_impl(ctx):
                     arch + ".swiftdoc",
                 )]
 
-        if PrivateHeaders in dep:
-            for hdr in dep[PrivateHeaders].headers.to_list():
+        if PrivateHeadersInfo in dep:
+            for hdr in dep[PrivateHeadersInfo].headers.to_list():
                 private_header_in.append(hdr)
                 destination = paths.join(framework_dir, "PrivateHeaders", hdr.basename)
                 private_header_out.append(destination)

--- a/rules/framework/BUILD.bazel
+++ b/rules/framework/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_python//python:defs.bzl", "py_binary")
+
 py_binary(
     name = "framework_packaging",
     srcs = ["framework_packaging.py"],

--- a/rules/framework/framework_packaging.py
+++ b/rules/framework/framework_packaging.py
@@ -101,7 +101,7 @@ def _clean(framework_root, manifest_file, output_manifest_file):
         dirs_to_keep = set((framework_root,))
         for file in manifest_lines:
             files_to_keep.add(file)
-            
+
             dir = os.path.dirname(file)
             while dir not in dirs_to_keep:
                 dirs_to_keep.add(dir)
@@ -130,7 +130,7 @@ class Args(argparse.Namespace):
 def main():
     """Main function."""
     actions = {
-        "header": 
+        "header":
             lambda args: _copy_headers(args.framework_root, args.inputs),
         "private_header":
             lambda args: _copy_private_headers(args.framework_root, args.inputs),
@@ -153,7 +153,7 @@ def main():
     parser.add_argument('--inputs', type = str, nargs='*')
     parser.add_argument('--outputs', type = str, nargs='*')
     args = parser.parse_args(namespace=Args())
-    
+
     action = actions[args.action]
     action(args)
 

--- a/rules/hmap/.clang-format
+++ b/rules/hmap/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: Google
+IndentWidth: 4

--- a/rules/hmap/BUILD.bazel
+++ b/rules/hmap/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
+
 HMAP_COPTS = [
     "-DHASH_FUNCTION=HASH_MUR",
     "-DHASH_USING_NO_STRICT_ALIASING",

--- a/rules/hmap/hmap.c
+++ b/rules/hmap/hmap.c
@@ -1,4 +1,5 @@
 #include "hmap.h"
+
 #include <assert.h>
 #include <ctype.h>
 #include <fcntl.h>

--- a/rules/hmap/hmapdump.c
+++ b/rules/hmap/hmapdump.c
@@ -6,15 +6,15 @@
 #include "hmap.h"
 
 int main(int ac, char** av) {
-  if (ac < 2) {
-    fprintf(stderr, "usage: hmapdump <file>\n");
-    return 1;
-  }
+    if (ac < 2) {
+        fprintf(stderr, "usage: hmapdump <file>\n");
+        return 1;
+    }
 
-  HeaderMap* hmap = hmap_open(av[1], "r");
-  if (!hmap) {
-    fprintf(stderr, "hmap failed for '%s': %s\n", av[1], strerror(errno));
-  }
-  hmap_dump(hmap);
-  hmap_close(hmap);
+    HeaderMap* hmap = hmap_open(av[1], "r");
+    if (!hmap) {
+        fprintf(stderr, "hmap failed for '%s': %s\n", av[1], strerror(errno));
+    }
+    hmap_dump(hmap);
+    hmap_close(hmap);
 }

--- a/rules/vfs_overlay/BUILD.bazel
+++ b/rules/vfs_overlay/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_python//python:defs.bzl", "py_binary")
+
 py_binary(
     name = "vfs_overlay",
     srcs = ["vfs_overlay.py"],

--- a/tests/xcconfig/tests.bzl
+++ b/tests/xcconfig/tests.bzl
@@ -1,5 +1,5 @@
 load("//rules/library:xcconfig.bzl", "settings_from_xcconfig")
-load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("@bazel_skylib//lib:types.bzl", "types")
 
 _Settings = provider()


### PR DESCRIPTION
This PR standardizes the C formatting using clang-format, and fixes a bunch of errors flagged by buildifier. It also removes some dead code. It is a non-functional change.

I was finishing  #52 but kept mixing up formatting changes with the actual changes so I figured I'd do the cleanups first and then rebase #52 on top of this.