### PR TITLE
Adds a build wrapper script for Bazel build processing

### DIFF
--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -348,7 +348,7 @@ xcodeproj = rule(
         "_xcodeproj_installer_template": attr.label(executable = False, default = Label("//tools/xcodeproj_shims:xcodeproj-installer.sh"), allow_single_file = ["sh"]),
         "_infoplist_stub": attr.label(executable = False, default = Label("//rules/test_host_app:Info.plist"), allow_single_file = ["plist"]),
         "_workspace_xcsettings": attr.label(executable = False, default = Label("//tools/xcodeproj_shims:WorkspaceSettings.xcsettings"), allow_single_file = ["xcsettings"]),
-        "output_processor": attr.label(executable = True, default = Label("//tools/xcodeproj_shims:output-processor.rb"), cfg = "host", allow_single_file = ["rb"]),
+        "output_processor": attr.label(executable = True, default = Label("//tools/xcodeproj_shims:output-processor.rb"), cfg = "host", allow_single_file = True),
         "_xcodegen": attr.label(executable = True, default = Label("@com_github_yonaskolb_xcodegen//:xcodegen"), cfg = "host"),
         "clang_stub": attr.label(executable = True, default = Label("//tools/xcodeproj_shims:clang-stub"), cfg = "host"),
         "ld_stub": attr.label(executable = True, default = Label("//tools/xcodeproj_shims:ld-stub"), cfg = "host"),

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -166,6 +166,8 @@ def _xcodeproj_impl(ctx):
         "groupSortPosition": "none",
     }
     proj_settings = {
+        "BAZEL_BUILD_EXEC": "$BAZEL_STUBS_DIR/build-wrapper",
+        "BAZEL_OUTPUT_PROCESSOR": "$BAZEL_STUBS_DIR/output-processor.rb",
         "BAZEL_PATH": ctx.attr.bazel_path,
         "BAZEL_WORKSPACE_ROOT": "$SRCROOT/%s" % script_dot_dots,
         "BAZEL_STUBS_DIR": "$PROJECT_FILE_PATH/bazelstubs",
@@ -234,10 +236,10 @@ def _xcodeproj_impl(ctx):
             "preBuildScripts": [{
                 "name": "Build with bazel",
                 "script": """
-set -eux
+set -euxo pipefail
 cd $BAZEL_WORKSPACE_ROOT
 
-$BAZEL_PATH build {bazel_build_target_name}
+$BAZEL_BUILD_EXEC {bazel_build_target_name}
 $BAZEL_INSTALLER
 """.format(bazel_build_target_name = target_info.bazel_build_target_name),
             }],
@@ -308,7 +310,9 @@ $BAZEL_INSTALLER
             "$(clang_stub_ld_path)": ctx.executable.ld_stub.short_path,
             "$(clang_stub_swiftc_path)": ctx.executable.swiftc_stub.short_path,
             "$(print_json_leaf_nodes_path)": ctx.executable.print_json_leaf_nodes.short_path,
+            "$(build_wrapper_path)": ctx.executable.build_wrapper.short_path,
             "$(infoplist_stub)": ctx.file._infoplist_stub.short_path,
+            "$(output_processor_path)": ctx.file.output_processor.short_path,
             "$(workspacesettings_xcsettings_short_path)": ctx.file._workspace_xcsettings.short_path,
         },
         is_executable = True,
@@ -319,13 +323,15 @@ $BAZEL_INSTALLER
             executable = install_script,
             files = depset([xcodegen_jsonfile, project]),
             runfiles = ctx.runfiles(files = [xcodegen_jsonfile, project], transitive_files = depset(
-                direct = ctx.files.installer +
+                direct = ctx.files.build_wrapper +
+                         ctx.files.installer +
                          ctx.files.clang_stub +
                          ctx.files.ld_stub +
                          ctx.files.swiftc_stub +
                          ctx.files._infoplist_stub +
                          ctx.files.print_json_leaf_nodes +
-                         ctx.files._workspace_xcsettings,
+                         ctx.files._workspace_xcsettings +
+                         ctx.files.output_processor,
                 transitive = [ctx.attr.installer[DefaultInfo].default_runfiles.files],
             )),
         ),
@@ -342,12 +348,14 @@ xcodeproj = rule(
         "_xcodeproj_installer_template": attr.label(executable = False, default = Label("//tools/xcodeproj_shims:xcodeproj-installer.sh"), allow_single_file = ["sh"]),
         "_infoplist_stub": attr.label(executable = False, default = Label("//rules/test_host_app:Info.plist"), allow_single_file = ["plist"]),
         "_workspace_xcsettings": attr.label(executable = False, default = Label("//tools/xcodeproj_shims:WorkspaceSettings.xcsettings"), allow_single_file = ["xcsettings"]),
+        "output_processor": attr.label(executable = True, default = Label("//tools/xcodeproj_shims:output-processor.rb"), cfg = "host", allow_single_file = ["rb"]),
         "_xcodegen": attr.label(executable = True, default = Label("@com_github_yonaskolb_xcodegen//:xcodegen"), cfg = "host"),
         "clang_stub": attr.label(executable = True, default = Label("//tools/xcodeproj_shims:clang-stub"), cfg = "host"),
         "ld_stub": attr.label(executable = True, default = Label("//tools/xcodeproj_shims:ld-stub"), cfg = "host"),
         "swiftc_stub": attr.label(executable = True, default = Label("//tools/xcodeproj_shims:swiftc-stub"), cfg = "host"),
         "print_json_leaf_nodes": attr.label(executable = True, default = Label("//tools/xcodeproj_shims:print_json_leaf_nodes"), cfg = "host"),
         "installer": attr.label(executable = True, default = Label("//tools/xcodeproj_shims:installer"), cfg = "host"),
+        "build_wrapper": attr.label(executable = True, default = Label("//tools/xcodeproj_shims:build-wrapper"), cfg = "host"),
     },
     executable = True,
 )

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
@@ -201,7 +201,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -eux\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_PATH build tests/macos/xcodeproj:Single-Application-RunnableTestSuite_iPad-Air-2__12.4\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-RunnableTestSuite_iPad-Air-2__12.4\n$BAZEL_INSTALLER\n";
 		};
 		8C9FD347EEDF21022077C21D /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -219,7 +219,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -eux\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_PATH build rules/test_host_app:iOS-12.0-AppHost\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_BUILD_EXEC rules/test_host_app:iOS-12.0-AppHost\n$BAZEL_INSTALLER\n";
 		};
 		CEFFC66550AFA438E8952334 /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -237,7 +237,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -eux\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_PATH build tests/macos/xcodeproj:Single-Application-UnitTests\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-UnitTests\n$BAZEL_INSTALLER\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -304,7 +304,9 @@
 		68A16F2D813AF1A4ADB2C835 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BAZEL_BUILD_EXEC = "$BAZEL_STUBS_DIR/build-wrapper";
 				BAZEL_INSTALLER = $BAZEL_STUBS_DIR/tools/xcodeproj_shims/installer;
+				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
@@ -325,7 +327,9 @@
 		91DFFF9DBCE87E057346921A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BAZEL_BUILD_EXEC = "$BAZEL_STUBS_DIR/build-wrapper";
 				BAZEL_INSTALLER = $BAZEL_STUBS_DIR/tools/xcodeproj_shims/installer;
+				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
@@ -201,7 +201,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -eux\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_PATH build tests/macos/xcodeproj:Single-Application-RunnableTestSuite_iPad-Air-2__12.4\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-RunnableTestSuite_iPad-Air-2__12.4\n$BAZEL_INSTALLER\n";
 		};
 		B6158A7B27A31249CCAFEC9E /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -219,7 +219,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -eux\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_PATH build rules/test_host_app:iOS-12.0-AppHost\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_BUILD_EXEC rules/test_host_app:iOS-12.0-AppHost\n$BAZEL_INSTALLER\n";
 		};
 		D318F6F09E06731B996B9EF2 /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -237,7 +237,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -eux\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_PATH build tests/macos/xcodeproj:Single-Application-UnitTests\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-UnitTests\n$BAZEL_INSTALLER\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -292,7 +292,9 @@
 		537B13DA69FE2CF8CE352102 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BAZEL_BUILD_EXEC = "$BAZEL_STUBS_DIR/build-wrapper";
 				BAZEL_INSTALLER = $BAZEL_STUBS_DIR/tools/xcodeproj_shims/installer;
+				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
@@ -345,7 +347,9 @@
 		AAAEE6E10977303B66545B5D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BAZEL_BUILD_EXEC = "$BAZEL_STUBS_DIR/build-wrapper";
 				BAZEL_INSTALLER = $BAZEL_STUBS_DIR/tools/xcodeproj_shims/installer;
+				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
@@ -274,7 +274,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -eux\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_PATH build tests/ios/unit-test/test-imports-app:TestImports-Unit-Tests\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_BUILD_EXEC tests/ios/unit-test/test-imports-app:TestImports-Unit-Tests\n$BAZEL_INSTALLER\n";
 		};
 		2756FB505F15157D82C9069E /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -292,7 +292,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -eux\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_PATH build rules/test_host_app:iOS-10.0-AppHost\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_BUILD_EXEC rules/test_host_app:iOS-10.0-AppHost\n$BAZEL_INSTALLER\n";
 		};
 		3D60A491CE72F7D799EC0383 /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -310,7 +310,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -eux\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_PATH build tests/ios/unit-test/test-imports-app:TestImports-App\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_BUILD_EXEC tests/ios/unit-test/test-imports-app:TestImports-App\n$BAZEL_INSTALLER\n";
 		};
 		6DBC122A6C2C8B5D5805E16D /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -328,7 +328,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -eux\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_PATH build tests/ios/unit-test:DefaultHosted\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_BUILD_EXEC tests/ios/unit-test:DefaultHosted\n$BAZEL_INSTALLER\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -448,7 +448,9 @@
 		83C6FAF9D19E66ABD6FC3866 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BAZEL_BUILD_EXEC = "$BAZEL_STUBS_DIR/build-wrapper";
 				BAZEL_INSTALLER = $BAZEL_STUBS_DIR/tools/xcodeproj_shims/installer;
+				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
@@ -491,7 +493,9 @@
 		AD55644E2B6185FA4E29AA4F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BAZEL_BUILD_EXEC = "$BAZEL_STUBS_DIR/build-wrapper";
 				BAZEL_INSTALLER = $BAZEL_STUBS_DIR/tools/xcodeproj_shims/installer;
+				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;

--- a/tools/xcodeproj_shims/BUILD.bazel
+++ b/tools/xcodeproj_shims/BUILD.bazel
@@ -33,7 +33,16 @@ sh_binary(
     visibility = STUB_VISIBILITY,
 )
 
+sh_binary(
+    name = "build-wrapper",
+    srcs = [
+        "build-wrapper.sh",
+    ],
+    visibility = STUB_VISIBILITY,
+)
+
 exports_files([
     "xcodeproj-installer.sh",
     "WorkspaceSettings.xcsettings",
+    "output-processor.rb",
 ])

--- a/tools/xcodeproj_shims/build-wrapper.sh
+++ b/tools/xcodeproj_shims/build-wrapper.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euxo pipefail
+
+$BAZEL_PATH build $1 2>&1 | $BAZEL_OUTPUT_PROCESSOR

--- a/tools/xcodeproj_shims/output-processor.rb
+++ b/tools/xcodeproj_shims/output-processor.rb
@@ -2,7 +2,6 @@
 
 BAZEL_WORKSPACE = ENV['BAZEL_WORKSPACE_ROOT'].freeze
 
-# Documentation
 class BazelOutputLine
   attr_reader :text
 
@@ -22,7 +21,6 @@ class BazelOutputLine
   end
 end
 
-# Documentation
 class RegexMatchLine < BazelOutputLine
   attr_reader :regex, :match_data
 
@@ -36,21 +34,20 @@ class RegexMatchLine < BazelOutputLine
   end
 end
 
-# Documentation
 class StarlarkLine < RegexMatchLine
   def initialize(line)
-    @regex = /^DEBUG: (.+.bzl)(:\d+:\d+:) (.+)$/
+
+    @regex = /^DEBUG: (.+(.bzl|.bazel))(:\d+:\d+): (.+)$/
 
     super(line)
 
     return unless (@match_data = line.match(@regex))
 
-    starlark_file, file_line, message = @match_data.captures
-    @text = "warning: #{message}"
+    starlark_file, file_ext, file_line, message = @match_data.captures
+    @text = "warning: #{message} (from #{starlark_file}#{file_line})"
   end
 end
 
-# Documentation
 class CompilerMessageLine < RegexMatchLine
   def initialize(line)
     @regex = /^(.+:) (error:|warning:|note:) (.+)/

--- a/tools/xcodeproj_shims/output-processor.rb
+++ b/tools/xcodeproj_shims/output-processor.rb
@@ -1,0 +1,77 @@
+#!/usr/bin/env ruby
+
+BAZEL_WORKSPACE = ENV['BAZEL_WORKSPACE_ROOT'].freeze
+
+# Documentation
+class BazelOutputLine
+  attr_reader :text
+
+  def initialize(line)
+    @text = line
+  end
+
+  # Try to create a processed line based on a match rule, or a pass-through
+  def self.from(line)
+    if (message_line = MessageLine.create_from(line))
+      message_line
+    elsif (snapshot_line = SnapshotLine.create_from(line))
+      snapshot_line
+    else
+      BazelOutputLine.new(line)
+    end
+  end
+end
+
+# Documentation
+class RegexMatchLine < BazelOutputLine
+  attr_reader :regex, :match_data
+
+  @regex = nil
+  @match_data = nil
+
+  def self.create_from(line)
+    rule = new(line)
+
+    rule.match_data.nil? ? nil : rule
+  end
+end
+
+# Documentation
+class SnapshotLine < RegexMatchLine
+  def initialize(line)
+    @regex = /^DEBUG: .+ Snapshot test (.+) (\(.+\)) does not specify it uses an app host$/
+
+    super(line)
+
+    return unless (@match_data = line.match(@regex))
+
+    test_name, test_path = @match_data.captures
+    @text = "warning: Snapshot test #{test_name} #{test_path} does not specify it uses an app host"
+  end
+end
+
+# Documentation
+class MessageLine < RegexMatchLine
+  def initialize(line)
+    @regex = /^(.+:) (error:|warning:|note:) (.+)/
+
+    super(line)
+
+    return unless (@match_data = line.match(@regex))
+
+    file_path, error_level, message = match_data.captures
+    full_file_path = "#{BAZEL_WORKSPACE}/#{file_path}"
+
+    full_output_line = "#{full_file_path} #{error_level} #{message}"
+    @text = full_output_line
+  end
+end
+
+if BAZEL_WORKSPACE.nil? || BAZEL_WORKSPACE.empty?
+  raise "ERROR: Missing 'BAZEL_WORKSPACE_ROOT'"
+end
+
+while (raw_input = gets)
+  output = BazelOutputLine.from(raw_input)
+  puts output.text
+end

--- a/tools/xcodeproj_shims/output-processor.rb
+++ b/tools/xcodeproj_shims/output-processor.rb
@@ -12,10 +12,10 @@ class BazelOutputLine
 
   # Try to create a processed line based on a match rule, or a pass-through
   def self.from(line)
-    if (message_line = MessageLine.create_from(line))
+    if (message_line = CompilerMessageLine.create_from(line))
       message_line
-    elsif (snapshot_line = SnapshotLine.create_from(line))
-      snapshot_line
+    elsif (starlark_line = StarlarkLine.create_from(line))
+      starlark_line
     else
       BazelOutputLine.new(line)
     end
@@ -37,21 +37,21 @@ class RegexMatchLine < BazelOutputLine
 end
 
 # Documentation
-class SnapshotLine < RegexMatchLine
+class StarlarkLine < RegexMatchLine
   def initialize(line)
-    @regex = /^DEBUG: .+ Snapshot test (.+) (\(.+\)) does not specify it uses an app host$/
+    @regex = /^DEBUG: (.+.bzl)(:\d+:\d+:) (.+)$/
 
     super(line)
 
     return unless (@match_data = line.match(@regex))
 
-    test_name, test_path = @match_data.captures
-    @text = "warning: Snapshot test #{test_name} #{test_path} does not specify it uses an app host"
+    starlark_file, file_line, message = @match_data.captures
+    @text = "warning: #{message}"
   end
 end
 
 # Documentation
-class MessageLine < RegexMatchLine
+class CompilerMessageLine < RegexMatchLine
   def initialize(line)
     @regex = /^(.+:) (error:|warning:|note:) (.+)/
 

--- a/tools/xcodeproj_shims/xcodeproj-installer.sh
+++ b/tools/xcodeproj_shims/xcodeproj-installer.sh
@@ -19,6 +19,8 @@ cp "$(clang_stub_ld_path)" "${stubs_dir}/ld-stub"
 cp "$(clang_stub_swiftc_path)" "${stubs_dir}/swiftc-stub"
 cp "$(print_json_leaf_nodes_path)" "${stubs_dir}/print_json_leaf_nodes"
 cp "$(infoplist_stub)" "${stubs_dir}/Info-stub.plist"
+cp "$(build_wrapper_path)" "${stubs_dir}/build-wrapper"
+cp "$(output_processor_path)" "${stubs_dir}/output-processor.rb"
 
 rm -fr "${tmp_dest}"
 mkdir -p "$(dirname $tmp_dest)"


### PR DESCRIPTION
## What Changed & Why
This PR changes the xcodeproj Bazel file to include an additional build wrapper that allows us to call an output processor.

The output processor is needed because:
1. Bazel outputs all build progress information to `STDERR`, causing Xcode to think that there was an error building the project.
2. Bazel outputs some of its build progress in a way that Xcode interprets as build error
3. The issue navigator in Xcode doesn't work with the way Bazel outputs the paths for files when building using Bazel. We can post-process each line of output to prepend the full path to `BAZEL_WORKSPACE_ROOT` to correct this.

Finally, developers are able to click an error or warning in the issue navigator and be directed to the corresponding warning / error.

## Screenshot
![Screen Shot 2020-06-01 at 12 21 38 PM](https://user-images.githubusercontent.com/728690/83435903-f711f980-a40a-11ea-8203-204bf20ce754.png)

![Screen Shot 2020-06-01 at 12 21 59 PM](https://user-images.githubusercontent.com/728690/83435904-f7aa9000-a40a-11ea-9bfe-be481d558d62.png)