### PR TITLE
Remove test_host from list of deps to avoid including extra sources during compile sources phase

### DIFF
--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -25,7 +25,6 @@ def _xcodeproj_aspect_impl(target, ctx):
     deps += getattr(ctx.rule.attr, "deps", [])
     deps += getattr(ctx.rule.attr, "infoplists", [])
     deps.append(getattr(ctx.rule.attr, "entitlements", None))
-    deps.append(getattr(ctx.rule.attr, "test_host", None))
 
     # TODO: handle apple_resource_bundle targets
     test_env_vars = ()

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
@@ -7,15 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		27550490979301B3C6C0E22F /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FE939800D5E84FA4B194548D /* main.m */; };
 		4541759E59ED815D18798894 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FE939800D5E84FA4B194548D /* main.m */; };
 		48C6C9814CEEF1CACD6D55A0 /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035030AE3B7F41C97A1EE910 /* empty.swift */; };
-		50B299F156375674909D044A /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035030AE3B7F41C97A1EE910 /* empty.swift */; };
 		55E46FEA2FF714E40EA51316 /* test.m in Sources */ = {isa = PBXBuildFile; fileRef = 2263A980666D293D7413BE92 /* test.m */; };
 		68F6C55581B050CEA9AB6AFF /* test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246AA4985E50044D3CD8228A /* test.swift */; };
 		B8F9F9CA8BCC4CFF09734974 /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B65EED0A5FCC9038424593 /* empty.swift */; };
 		E2DE5A172CF0A78BF06C0140 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C55810C4D90EF86058DB06A /* main.m */; };
-		E8357250994F43CFA07418DF /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C55810C4D90EF86058DB06A /* main.m */; };
 		EB57E581728375686EE2959C /* empty.m in Sources */ = {isa = PBXBuildFile; fileRef = F42CC7E6159DCCC28D045A6C /* empty.m */; };
 /* End PBXBuildFile section */
 
@@ -330,8 +327,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				50B299F156375674909D044A /* empty.swift in Sources */,
-				E8357250994F43CFA07418DF /* main.m in Sources */,
 				55E46FEA2FF714E40EA51316 /* test.m in Sources */,
 				68F6C55581B050CEA9AB6AFF /* test.swift in Sources */,
 			);
@@ -343,7 +338,6 @@
 			files = (
 				EB57E581728375686EE2959C /* empty.m in Sources */,
 				B8F9F9CA8BCC4CFF09734974 /* empty.swift in Sources */,
-				27550490979301B3C6C0E22F /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This PR undoes adding the `test_host` to the list of dependencies in order to prevent it's sources from being included in other target's compile sources build phase.

After discussion with @segiddins and @amberdixon, we considered preventing `_SrcInfo` from being appended to the list of providers, but after testing, that still didn't work.

See PR #46 for original context.

**Before**
![Screen Shot 2020-06-03 at 4 27 36 PM](https://user-images.githubusercontent.com/728690/83686720-b657e300-a5b8-11ea-801c-2f12d45cdabc.png)

**Now**
![Screen Shot 2020-06-03 at 4 38 38 PM](https://user-images.githubusercontent.com/728690/83686721-b6f07980-a5b8-11ea-9210-aceae3dcfbd4.png)