### PR TITLE
Generated xcodeproj improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.xcodeproj/ linguist-generated=true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,11 @@ jobs:
       - name: Select Xcode 11.2
         run: sudo xcode-select -s /Applications/Xcode_11.2.app
       - name: Generate Xcode projects and compare against existing record
-        run: (bazelisk query 'kind(xcodeproj, tests/macos/xcodeproj/...)' | xargs -n 1 bazelisk run) && git diff --exit-code tests/macos/xcodeproj
+        run: |
+          set -euo pipefail
+          bazelisk query 'kind(xcodeproj, tests/macos/xcodeproj/...)' | xargs -n 1 bazelisk run
+          bazel query 'attr(executable, 1, kind(genrule, tests/macos/xcodeproj/...))' | xargs -n 1 bazelisk run
+          git diff --exit-code tests/macos/xcodeproj
       - name: Run Xcode builds
         run: ./tests/macos/xcodeproj/build.sh
       - name: Run Unit tests

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -1,10 +1,6 @@
 """Definitions for handling Bazel repositories used by the Apple rules."""
 
 load(
-    "@bazel_tools//tools/build_defs/repo:git.bzl",
-    "git_repository",
-)
-load(
     "@bazel_tools//tools/build_defs/repo:http.bzl",
     "http_archive",
     "http_file",
@@ -22,32 +18,58 @@ def _maybe(repo_rule, name, **kwargs):
     if not native.existing_rule(name):
         repo_rule(name = name, **kwargs)
 
+def github_repo(name, project, repo, ref, sha256 = None):
+    """Downloads a repository from GitHub as a tarball.
+
+    Args:
+        name: The name of the repository.
+        project: The project (user or organization) on GitHub that hosts the repository.
+        repo: The name of the repository on GitHub.
+        ref: The reference to be downloaded. Can be any named ref, e.g. a commit, branch, or tag.
+        sha256: The sha256 of the downloaded tarball.
+    """
+
+    github_url = "https://github.com/{project}/{repo}/archive/{ref}.zip".format(
+        project = project,
+        repo = repo,
+        ref = ref,
+    )
+    http_archive(
+        name = name,
+        strip_prefix = "%s-%s" % (repo, ref.replace("/", "-")),
+        url = github_url,
+        sha256 = sha256,
+        canonical_id = github_url,
+    )
+
 def rules_ios_dependencies():
     """Fetches repositories that are dependencies of the `rules_apple` workspace.
     """
     _maybe(
-        git_repository,
+        github_repo,
         name = "build_bazel_rules_apple",
-        commit = "74eca5857a136b9f1e2020886be76b791eb08231",
-        # TODO: Investigate why enabling this causes an analysis failure
-        # shallow_since = "1590530217 -0700",
-        remote = "https://github.com/bazelbuild/rules_apple.git",
+        ref = "eadfa72e26dd8b459038dc83fc440759daff65c6",
+        project = "bazelbuild",
+        repo = "rules_apple",
+        sha256 = "be2e2e26d85dff61d4f9ae11e74be656a231389629474b39db887baa407a6f7d",
     )
 
     _maybe(
-        git_repository,
+        github_repo,
         name = "build_bazel_rules_swift",
-        commit = "6408d85da799ec2af053c4e2883dce3ce6d30f08",
-        shallow_since = "1589833120 -0700",
-        remote = "https://github.com/bazelbuild/rules_swift.git",
+        ref = "15d2b18ac7a71796984c4064fc0b570260969ac3",
+        project = "bazelbuild",
+        repo = "rules_swift",
+        sha256 = "566bfce66201c9264bfc4bc5a84260c8039858158432eda012ec9907feceff41",
     )
 
     _maybe(
-        git_repository,
+        github_repo,
         name = "build_bazel_apple_support",
-        commit = "501b4afb27745c4813a88ffa28acd901408014e4",
-        shallow_since = "1577729628 -0800",
-        remote = "https://github.com/bazelbuild/apple_support.git",
+        ref = "501b4afb27745c4813a88ffa28acd901408014e4",
+        project = "bazelbuild",
+        repo = "apple_support",
+        sha256 = "8aa07a6388e121763c0164624feac9b20841afa2dd87bac0ba0c3ed1d56feb70",
     )
 
     _maybe(
@@ -92,7 +114,7 @@ native_binary(
     visibility = ["//visibility:public"],
 )
 """,
-        canonical_id = "xcodegen-2.15.2",
+        canonical_id = "xcodegen-2.15.1",
         sha256 = "0a53aef09e1b93c5307fc1c411c52a034305ccfd87255c01de7f9ff5141e0d86",
         strip_prefix = "xcodegen",
         urls = ["https://github.com/yonaskolb/XcodeGen/releases/download/2.15.1/xcodegen.zip"],

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -336,6 +336,7 @@ $BAZEL_INSTALLER
             "$(infoplist_stub)": ctx.file._infoplist_stub.short_path,
             "$(output_processor_path)": ctx.file.output_processor.short_path,
             "$(workspacesettings_xcsettings_short_path)": ctx.file._workspace_xcsettings.short_path,
+            "$(ideworkspacechecks_plist_short_path)": ctx.file._workspace_checks.short_path,
         },
         is_executable = True,
     )
@@ -354,6 +355,7 @@ $BAZEL_INSTALLER
                          ctx.files._infoplist_stub +
                          ctx.files.print_json_leaf_nodes +
                          ctx.files._workspace_xcsettings +
+                         ctx.files._workspace_checks +
                          ctx.files.output_processor,
                 transitive = [ctx.attr.installer[DefaultInfo].default_runfiles.files],
             )),
@@ -371,6 +373,7 @@ xcodeproj = rule(
         "_xcodeproj_installer_template": attr.label(executable = False, default = Label("//tools/xcodeproj_shims:xcodeproj-installer.sh"), allow_single_file = ["sh"]),
         "_infoplist_stub": attr.label(executable = False, default = Label("//rules/test_host_app:Info.plist"), allow_single_file = ["plist"]),
         "_workspace_xcsettings": attr.label(executable = False, default = Label("//tools/xcodeproj_shims:WorkspaceSettings.xcsettings"), allow_single_file = ["xcsettings"]),
+        "_workspace_checks": attr.label(executable = False, default = Label("//tools/xcodeproj_shims:IDEWorkspaceChecks.plist"), allow_single_file = ["plist"]),
         "output_processor": attr.label(executable = True, default = Label("//tools/xcodeproj_shims:output-processor.rb"), cfg = "host", allow_single_file = True),
         "_xcodegen": attr.label(executable = True, default = Label("@com_github_yonaskolb_xcodegen//:xcodegen"), cfg = "host"),
         "index_import": attr.label(executable = True, default = Label("@com_github_lyft_index_import//:index_import"), cfg = "host"),

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -176,6 +176,7 @@ def _xcodeproj_impl(ctx):
         "createIntermediateGroups": True,
         "defaultConfig": "Debug",
         "groupSortPosition": "none",
+        "settingPresets": "none",
     }
     proj_settings = {
         "BAZEL_BUILD_EXEC": "$BAZEL_STUBS_DIR/build-wrapper",

--- a/tests/macos/xcodeproj/BUILD.bazel
+++ b/tests/macos/xcodeproj/BUILD.bazel
@@ -82,3 +82,23 @@ xcodeproj(
         "//tests/ios/unit-test/test-imports-app:TestImports-Unit-Tests",
     ],
 )
+
+genrule(
+    name = "Test-Project-Regeneration",
+    testonly = True,
+    outs = ["Test-Project-Regeneration.sh"],
+    cmd = """
+cat <<'EOS' > $@
+#!/bin/sh
+set -euxo pipefail
+rm -fr {package_name}/{target_name}.xcodeproj
+bazel run {package_name}:{target_name}
+bazel run {package_name}:{target_name}
+EOS
+    """.format(
+        package_name = package_name(),
+        target_name = "Single-Application-Project-DirectTargetsOnly",
+    ),
+    executable = True,
+    tools = [":Single-Application-Project-DirectTargetsOnly"],
+)

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		78FAC8B505DC9C839473A482 /* iOS-12.0-AppHost.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "iOS-12.0-AppHost.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7ABD95023B71172929B010EE /* common.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = common.pch; path = ../../../rules/library/common.pch; sourceTree = "<group>"; };
 		908EFE5EAE901D6B372D68F7 /* ios.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = ios.entitlements; path = ../../../rules/test_host_app/ios.entitlements; sourceTree = "<group>"; };
+		A05E016687115D20E64A5C60 /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = BUILD.bazel; sourceTree = "<group>"; };
+		BA5C2481E04D8592323A7AD9 /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = ../../../rules/test_host_app/BUILD.bazel; sourceTree = "<group>"; };
 		BFC300E7CF04688067094BFF /* Contents.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = Contents.json; path = ../../../rules/test_host_app/AssetCatalogFixture.xcassets/Contents.json; sourceTree = "<group>"; };
 		EEB1C98DB4C8E24414A69917 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = main.m; path = ../../../rules/test_host_app/main.m; sourceTree = "<group>"; };
 		EFADB1CE81C3F97F647C9255 /* Single-Application-UnitTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = "Single-Application-UnitTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -38,6 +40,7 @@
 			isa = PBXGroup;
 			children = (
 				7CCE59C7822E18EBC1CD9D6D /* AssetCatalogFixture.xcassets */,
+				BA5C2481E04D8592323A7AD9 /* BUILD.bazel */,
 				908EFE5EAE901D6B372D68F7 /* ios.entitlements */,
 				EEB1C98DB4C8E24414A69917 /* main.m */,
 			);
@@ -99,6 +102,7 @@
 		F237C982F1E8CD4A105006B4 /* xcodeproj */ = {
 			isa = PBXGroup;
 			children = (
+				A05E016687115D20E64A5C60 /* BUILD.bazel */,
 				F1162A80978C527830EDADEE /* test.swift */,
 			);
 			name = xcodeproj;

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
@@ -16,11 +16,13 @@
 		0BD63CC255956E60D898C7B7 /* test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = test.swift; path = test.swift; sourceTree = "<group>"; };
 		2B41830721183AA100B23D64 /* ios.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = ios.entitlements; path = ../../../rules/test_host_app/ios.entitlements; sourceTree = "<group>"; };
 		2DA260AA799ED8A57078C331 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = main.m; path = ../../../rules/test_host_app/main.m; sourceTree = "<group>"; };
+		4936F4D0B63B32AD09E63C43 /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = BUILD.bazel; sourceTree = "<group>"; };
 		58D47D35D8B8E34549EE944E /* Contents.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = Contents.json; path = ../../../rules/test_host_app/AssetCatalogFixture.xcassets/Contents.json; sourceTree = "<group>"; };
 		712BB7D3F966AAE042C40E4E /* iOS-12.0-AppHost.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "iOS-12.0-AppHost.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9735D50F44B3B4D188BA18BF /* Single-Application-RunnableTestSuite.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = "Single-Application-RunnableTestSuite.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CF248CD4BA2D7D91429E9BCB /* common.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = common.pch; path = ../../../rules/library/common.pch; sourceTree = "<group>"; };
 		E94B0DB5FD5082DE73F52008 /* Single-Application-UnitTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = "Single-Application-UnitTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		EAEB79BE70BFB649A6FBC92C /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = ../../../rules/test_host_app/BUILD.bazel; sourceTree = "<group>"; };
 		F689E871A09EA979611C589A /* resource_bundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = resource_bundle.plist; path = ../../../rules/library/resource_bundle.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -56,6 +58,7 @@
 			isa = PBXGroup;
 			children = (
 				D46477D0666FC1C236EDC486 /* AssetCatalogFixture.xcassets */,
+				EAEB79BE70BFB649A6FBC92C /* BUILD.bazel */,
 				2B41830721183AA100B23D64 /* ios.entitlements */,
 				2DA260AA799ED8A57078C331 /* main.m */,
 			);
@@ -99,6 +102,7 @@
 		F4FF0CBD8A1F7A37DB68252E /* xcodeproj */ = {
 			isa = PBXGroup;
 			children = (
+				4936F4D0B63B32AD09E63C43 /* BUILD.bazel */,
 				0BD63CC255956E60D898C7B7 /* test.swift */,
 			);
 			name = xcodeproj;

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
@@ -43,10 +43,13 @@
 		2238C255CB7ED2E848A7FC51 /* common.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = common.pch; path = ../../../rules/library/common.pch; sourceTree = "<group>"; };
 		2263A980666D293D7413BE92 /* test.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = test.m; path = "../../ios/unit-test/test-imports-app/test.m"; sourceTree = "<group>"; };
 		246AA4985E50044D3CD8228A /* test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = test.swift; path = "../../ios/unit-test/test-imports-app/test.swift"; sourceTree = "<group>"; };
+		300321A84FA667D38500A4EE /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = ../../../rules/test_host_app/BUILD.bazel; sourceTree = "<group>"; };
 		31B65EED0A5FCC9038424593 /* empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = empty.swift; path = "../../ios/unit-test/empty.swift"; sourceTree = "<group>"; };
+		36C5066BFCF7F5E1A169E184 /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = "../../ios/unit-test/BUILD.bazel"; sourceTree = "<group>"; };
 		61CE3CBBAD0BFAFC0953377B /* TestImports-App.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "TestImports-App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6725F1A1E5A5BAFC1EE01F00 /* Header2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Header2.h; path = "../../ios/unit-test/test-imports-app/Header2.h"; sourceTree = "<group>"; };
 		9E7E8177A9991D407C446EF6 /* TestImports-Unit-Tests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = "TestImports-Unit-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BC8493575E7FDD7052346981 /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = "../../ios/unit-test/test-imports-app/BUILD.bazel"; sourceTree = "<group>"; };
 		BCDD3D2387B5DA5045A0D600 /* Contents.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = Contents.json; path = ../../../rules/test_host_app/AssetCatalogFixture.xcassets/Contents.json; sourceTree = "<group>"; };
 		CD38E215541F1766D3CAFBEE /* ios.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = ios.entitlements; path = ../../../rules/test_host_app/ios.entitlements; sourceTree = "<group>"; };
 		F42CC7E6159DCCC28D045A6C /* empty.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = empty.m; path = "../../ios/unit-test/empty.m"; sourceTree = "<group>"; };
@@ -77,6 +80,7 @@
 		47EF8E9B0D250B2E77846871 /* test-imports-app */ = {
 			isa = PBXGroup;
 			children = (
+				BC8493575E7FDD7052346981 /* BUILD.bazel */,
 				035030AE3B7F41C97A1EE910 /* empty.swift */,
 				08D20BAAC5B1A41903E13B27 /* Header.h */,
 				6725F1A1E5A5BAFC1EE01F00 /* Header2.h */,
@@ -125,6 +129,7 @@
 			isa = PBXGroup;
 			children = (
 				50E12C023D675E3BA9A6FDFA /* AssetCatalogFixture.xcassets */,
+				300321A84FA667D38500A4EE /* BUILD.bazel */,
 				CD38E215541F1766D3CAFBEE /* ios.entitlements */,
 				FE939800D5E84FA4B194548D /* main.m */,
 			);
@@ -134,6 +139,7 @@
 		D09C5AAC3E8F31379C981C8F /* unit-test */ = {
 			isa = PBXGroup;
 			children = (
+				36C5066BFCF7F5E1A169E184 /* BUILD.bazel */,
 				F42CC7E6159DCCC28D045A6C /* empty.m */,
 				31B65EED0A5FCC9038424593 /* empty.swift */,
 				47EF8E9B0D250B2E77846871 /* test-imports-app */,

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/tools/xcodeproj_shims/BUILD.bazel
+++ b/tools/xcodeproj_shims/BUILD.bazel
@@ -48,7 +48,8 @@ sh_binary(
 )
 
 exports_files([
-    "xcodeproj-installer.sh",
-    "WorkspaceSettings.xcsettings",
+    "IDEWorkspaceChecks.plist",
     "output-processor.rb",
+    "WorkspaceSettings.xcsettings",
+    "xcodeproj-installer.sh",
 ])

--- a/tools/xcodeproj_shims/IDEWorkspaceChecks.plist
+++ b/tools/xcodeproj_shims/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/tools/xcodeproj_shims/xcodeproj-installer.sh
+++ b/tools/xcodeproj_shims/xcodeproj-installer.sh
@@ -39,6 +39,7 @@ cp "$(output_processor_path)" "${stubs_dir}/output-processor.rb"
 # Therefore, we force xcode to use the legacy build system by adding the contents of WorkspaceSettings.xcsettings to the generated project.
 mkdir -p "$tmp_dest/project.xcworkspace/xcshareddata/"
 cp "$(workspacesettings_xcsettings_short_path)" "$tmp_dest/project.xcworkspace/xcshareddata/"
+cp "$(ideworkspacechecks_plist_short_path)" "$tmp_dest/project.xcworkspace/xcshareddata/"
 
 chmod -R +w "${tmp_dest}"
 

--- a/tools/xcodeproj_shims/xcodeproj-installer.sh
+++ b/tools/xcodeproj_shims/xcodeproj-installer.sh
@@ -16,7 +16,7 @@ chmod -R +w "${tmp_dest}"
 readonly stubs_dir="${tmp_dest}/bazelstubs"
 mkdir -p "${stubs_dir}"
 
-readonly installers_dir="${dest}/bazelinstallers"
+readonly installers_dir="${tmp_dest}/bazelinstallers"
 mkdir -p "${installers_dir}"
 
 for INSTALLER_PATH in $(installer_runfile_short_paths)
@@ -34,15 +34,15 @@ cp "$(infoplist_stub)" "${stubs_dir}/Info-stub.plist"
 cp "$(build_wrapper_path)" "${stubs_dir}/build-wrapper"
 cp "$(output_processor_path)" "${stubs_dir}/output-processor.rb"
 
+# The new build system leaves a subdirectory called XCBuildData in the DerivedData directory which causes incremental build and test attempts to fail at launch time.
+# The error message says "Cannot attach to pid." This error seems to happen in the Xcode IDE, not when the project is tested from the xcodebuild command.
+# Therefore, we force xcode to use the legacy build system by adding the contents of WorkspaceSettings.xcsettings to the generated project.
+mkdir -p "$tmp_dest/project.xcworkspace/xcshareddata/"
+cp "$(workspacesettings_xcsettings_short_path)" "$tmp_dest/project.xcworkspace/xcshareddata/"
+
 chmod -R +w "${tmp_dest}"
 
 # always trim three ../ from path, since that's "bazel-out/darwin-fastbuild/bin"
 sed -i.bak -E -e 's|([ "])../../../|\1|g' "${tmp_dest}/project.pbxproj"
 rm "${tmp_dest}/project.pbxproj.bak"
 rsync --recursive --quiet --copy-links "${tmp_dest}" "${dest}"
-
-# The new build system leaves a subdirectory called XCBuildData in the DerivedData directory which causes incremental build and test attempts to fail at launch time.
-# The error message says "Cannot attach to pid." This error seems to happen in the Xcode IDE, not when the project is tested from the xcodebuild command.
-# Therefore, we force xcode to use the legacy build system by adding the contents of WorkspaceSettings.xcsettings to the generated project.
-mkdir -p "$dest/project.xcworkspace/xcshareddata/"
-cp "$(workspacesettings_xcsettings_short_path)" "$dest/project.xcworkspace/xcshareddata/"


### PR DESCRIPTION
* Mark xcodeproj directories as generated
  
  This way, github will collapse diffs & have more accurate repo stats

* Write all xcodeproj files into the tmp_dest
  
  This way, everything will get chmod’d
  
  This fixes back-to-back runs of the installer failing due to permission issues

* Add a test that verifies that projects can regenerate without error

* Add support for specifying additional (non-srcs) files to be included in the project
  
  This would allow a project to, for example, include a README as a file reference, even though it isnt a src belonging to any particular target

* Download GitHub repos via http_archive

* Add IDEWorkspaceChecks.plist to generated projects
  
  So opening the project in Xcode doesn’t add a new file

* Include BUILD files in generated Xcode projects

* Explicitly opt out of xcodeproj settings presets
  
  It avoids the warning of the presets not being found

