### PR TITLE
Only move indexstores generated by build

### DIFF
--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -263,6 +263,7 @@ def _xcodeproj_impl(ctx):
 set -euxo pipefail
 cd $BAZEL_WORKSPACE_ROOT
 
+export bazel_build_event_text_filename=$(mktemp -d)/build_event.txt
 $BAZEL_BUILD_EXEC {bazel_build_target_name}
 $BAZEL_INSTALLER
 """.format(bazel_build_target_name = target_info.bazel_build_target_name),

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -263,7 +263,7 @@ def _xcodeproj_impl(ctx):
 set -euxo pipefail
 cd $BAZEL_WORKSPACE_ROOT
 
-export bazel_build_event_text_filename=$(mktemp -d)/build_event.txt
+export BAZEL_BUILD_EVENT_TEXT_FILENAME=$(mktemp -d)/build_event.txt
 $BAZEL_BUILD_EXEC {bazel_build_target_name}
 $BAZEL_INSTALLER
 """.format(bazel_build_target_name = target_info.bazel_build_target_name),

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/indexstores.sh
@@ -4,11 +4,23 @@ set -euo pipefail
 
 # See `_indexstore.sh` for full details.
 
-# Make sure add these to bazel build target copts for objective-c
-find "$BAZEL_WORKSPACE_ROOT/bazel-out"/*/bin/ \
-     -type d \
-     -name "*.indexstore" \
-     -print0 \
-    | xargs -0 "$BAZEL_INSTALLERS_DIR/_indexstore.sh"
+echo "Start remapping index files at `date`"
 
-echo "Finish remapping index files"
+FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $bazel_build_event_text_filename || true`
+declare -a EXISTING_INDEXSTORES=()
+for i in $FOUND_INDEXSTORES
+do
+if [ -d $i ]
+then
+EXISTING_INDEXSTORES+=($i)
+fi
+done
+
+if [ ${#EXISTING_INDEXSTORES[@]} -ne 0 ]
+then
+  "$BAZEL_INSTALLERS_DIR/_indexstore.sh" $EXISTING_INDEXSTORES
+else
+  echo "No indexstores found"
+fi
+
+echo "Finish remapping index files at `date`"

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/indexstores.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 echo "Start remapping index files at `date`"
 
 FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $BAZEL_BUILD_EVENT_TEXT_FILENAME || true`
+
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
 do
@@ -15,6 +16,8 @@ do
     EXISTING_INDEXSTORES+=($i)
   fi
 done
+
+echo "Found ${#EXISTING_INDEXSTORES[@]} existing indexstores"
 
 if [ ${#EXISTING_INDEXSTORES[@]} -ne 0 ]
 then

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,14 +6,14 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $bazel_build_event_text_filename || true`
+FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $BAZEL_BUILD_EVENT_TEXT_FILENAME || true`
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
 do
-if [ -d $i ]
-then
-EXISTING_INDEXSTORES+=($i)
-fi
+  if [ -d $i ]
+  then
+    EXISTING_INDEXSTORES+=($i)
+  fi
 done
 
 if [ ${#EXISTING_INDEXSTORES[@]} -ne 0 ]

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
@@ -204,7 +204,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport bazel_build_event_text_filename=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-RunnableTestSuite_iPad-Air-2__12.4\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-RunnableTestSuite_iPad-Air-2__12.4\n$BAZEL_INSTALLER\n";
 		};
 		8C9FD347EEDF21022077C21D /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -222,7 +222,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport bazel_build_event_text_filename=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC rules/test_host_app:iOS-12.0-AppHost\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC rules/test_host_app:iOS-12.0-AppHost\n$BAZEL_INSTALLER\n";
 		};
 		CEFFC66550AFA438E8952334 /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -240,7 +240,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport bazel_build_event_text_filename=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-UnitTests\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-UnitTests\n$BAZEL_INSTALLER\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
@@ -204,7 +204,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-RunnableTestSuite_iPad-Air-2__12.4\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport bazel_build_event_text_filename=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-RunnableTestSuite_iPad-Air-2__12.4\n$BAZEL_INSTALLER\n";
 		};
 		8C9FD347EEDF21022077C21D /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -222,7 +222,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_BUILD_EXEC rules/test_host_app:iOS-12.0-AppHost\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport bazel_build_event_text_filename=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC rules/test_host_app:iOS-12.0-AppHost\n$BAZEL_INSTALLER\n";
 		};
 		CEFFC66550AFA438E8952334 /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -240,7 +240,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-UnitTests\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport bazel_build_event_text_filename=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-UnitTests\n$BAZEL_INSTALLER\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/indexstores.sh
@@ -4,11 +4,23 @@ set -euo pipefail
 
 # See `_indexstore.sh` for full details.
 
-# Make sure add these to bazel build target copts for objective-c
-find "$BAZEL_WORKSPACE_ROOT/bazel-out"/*/bin/ \
-     -type d \
-     -name "*.indexstore" \
-     -print0 \
-    | xargs -0 "$BAZEL_INSTALLERS_DIR/_indexstore.sh"
+echo "Start remapping index files at `date`"
 
-echo "Finish remapping index files"
+FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $bazel_build_event_text_filename || true`
+declare -a EXISTING_INDEXSTORES=()
+for i in $FOUND_INDEXSTORES
+do
+if [ -d $i ]
+then
+EXISTING_INDEXSTORES+=($i)
+fi
+done
+
+if [ ${#EXISTING_INDEXSTORES[@]} -ne 0 ]
+then
+  "$BAZEL_INSTALLERS_DIR/_indexstore.sh" $EXISTING_INDEXSTORES
+else
+  echo "No indexstores found"
+fi
+
+echo "Finish remapping index files at `date`"

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/indexstores.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 echo "Start remapping index files at `date`"
 
 FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $BAZEL_BUILD_EVENT_TEXT_FILENAME || true`
+
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
 do
@@ -15,6 +16,8 @@ do
     EXISTING_INDEXSTORES+=($i)
   fi
 done
+
+echo "Found ${#EXISTING_INDEXSTORES[@]} existing indexstores"
 
 if [ ${#EXISTING_INDEXSTORES[@]} -ne 0 ]
 then

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,14 +6,14 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $bazel_build_event_text_filename || true`
+FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $BAZEL_BUILD_EVENT_TEXT_FILENAME || true`
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
 do
-if [ -d $i ]
-then
-EXISTING_INDEXSTORES+=($i)
-fi
+  if [ -d $i ]
+  then
+    EXISTING_INDEXSTORES+=($i)
+  fi
 done
 
 if [ ${#EXISTING_INDEXSTORES[@]} -ne 0 ]

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
@@ -204,7 +204,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-RunnableTestSuite_iPad-Air-2__12.4\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport bazel_build_event_text_filename=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-RunnableTestSuite_iPad-Air-2__12.4\n$BAZEL_INSTALLER\n";
 		};
 		B6158A7B27A31249CCAFEC9E /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -222,7 +222,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_BUILD_EXEC rules/test_host_app:iOS-12.0-AppHost\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport bazel_build_event_text_filename=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC rules/test_host_app:iOS-12.0-AppHost\n$BAZEL_INSTALLER\n";
 		};
 		D318F6F09E06731B996B9EF2 /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -240,7 +240,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-UnitTests\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport bazel_build_event_text_filename=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-UnitTests\n$BAZEL_INSTALLER\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
@@ -204,7 +204,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport bazel_build_event_text_filename=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-RunnableTestSuite_iPad-Air-2__12.4\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-RunnableTestSuite_iPad-Air-2__12.4\n$BAZEL_INSTALLER\n";
 		};
 		B6158A7B27A31249CCAFEC9E /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -222,7 +222,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport bazel_build_event_text_filename=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC rules/test_host_app:iOS-12.0-AppHost\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC rules/test_host_app:iOS-12.0-AppHost\n$BAZEL_INSTALLER\n";
 		};
 		D318F6F09E06731B996B9EF2 /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -240,7 +240,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport bazel_build_event_text_filename=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-UnitTests\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-UnitTests\n$BAZEL_INSTALLER\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -4,11 +4,23 @@ set -euo pipefail
 
 # See `_indexstore.sh` for full details.
 
-# Make sure add these to bazel build target copts for objective-c
-find "$BAZEL_WORKSPACE_ROOT/bazel-out"/*/bin/ \
-     -type d \
-     -name "*.indexstore" \
-     -print0 \
-    | xargs -0 "$BAZEL_INSTALLERS_DIR/_indexstore.sh"
+echo "Start remapping index files at `date`"
 
-echo "Finish remapping index files"
+FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $bazel_build_event_text_filename || true`
+declare -a EXISTING_INDEXSTORES=()
+for i in $FOUND_INDEXSTORES
+do
+if [ -d $i ]
+then
+EXISTING_INDEXSTORES+=($i)
+fi
+done
+
+if [ ${#EXISTING_INDEXSTORES[@]} -ne 0 ]
+then
+  "$BAZEL_INSTALLERS_DIR/_indexstore.sh" $EXISTING_INDEXSTORES
+else
+  echo "No indexstores found"
+fi
+
+echo "Finish remapping index files at `date`"

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 echo "Start remapping index files at `date`"
 
 FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $BAZEL_BUILD_EVENT_TEXT_FILENAME || true`
+
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
 do
@@ -15,6 +16,8 @@ do
     EXISTING_INDEXSTORES+=($i)
   fi
 done
+
+echo "Found ${#EXISTING_INDEXSTORES[@]} existing indexstores"
 
 if [ ${#EXISTING_INDEXSTORES[@]} -ne 0 ]
 then

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,14 +6,14 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $bazel_build_event_text_filename || true`
+FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $BAZEL_BUILD_EVENT_TEXT_FILENAME || true`
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
 do
-if [ -d $i ]
-then
-EXISTING_INDEXSTORES+=($i)
-fi
+  if [ -d $i ]
+  then
+    EXISTING_INDEXSTORES+=($i)
+  fi
 done
 
 if [ ${#EXISTING_INDEXSTORES[@]} -ne 0 ]

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
@@ -270,7 +270,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport bazel_build_event_text_filename=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/ios/unit-test/test-imports-app:TestImports-Unit-Tests\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/ios/unit-test/test-imports-app:TestImports-Unit-Tests\n$BAZEL_INSTALLER\n";
 		};
 		2756FB505F15157D82C9069E /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -288,7 +288,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport bazel_build_event_text_filename=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC rules/test_host_app:iOS-10.0-AppHost\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC rules/test_host_app:iOS-10.0-AppHost\n$BAZEL_INSTALLER\n";
 		};
 		3D60A491CE72F7D799EC0383 /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -306,7 +306,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport bazel_build_event_text_filename=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/ios/unit-test/test-imports-app:TestImports-App\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/ios/unit-test/test-imports-app:TestImports-App\n$BAZEL_INSTALLER\n";
 		};
 		6DBC122A6C2C8B5D5805E16D /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -324,7 +324,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport bazel_build_event_text_filename=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/ios/unit-test:DefaultHosted\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/ios/unit-test:DefaultHosted\n$BAZEL_INSTALLER\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
@@ -270,7 +270,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_BUILD_EXEC tests/ios/unit-test/test-imports-app:TestImports-Unit-Tests\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport bazel_build_event_text_filename=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/ios/unit-test/test-imports-app:TestImports-Unit-Tests\n$BAZEL_INSTALLER\n";
 		};
 		2756FB505F15157D82C9069E /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -288,7 +288,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_BUILD_EXEC rules/test_host_app:iOS-10.0-AppHost\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport bazel_build_event_text_filename=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC rules/test_host_app:iOS-10.0-AppHost\n$BAZEL_INSTALLER\n";
 		};
 		3D60A491CE72F7D799EC0383 /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -306,7 +306,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_BUILD_EXEC tests/ios/unit-test/test-imports-app:TestImports-App\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport bazel_build_event_text_filename=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/ios/unit-test/test-imports-app:TestImports-App\n$BAZEL_INSTALLER\n";
 		};
 		6DBC122A6C2C8B5D5805E16D /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -324,7 +324,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\n$BAZEL_BUILD_EXEC tests/ios/unit-test:DefaultHosted\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport bazel_build_event_text_filename=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/ios/unit-test:DefaultHosted\n$BAZEL_INSTALLER\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/tools/xcodeproj_shims/build-wrapper.sh
+++ b/tools/xcodeproj_shims/build-wrapper.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euxo pipefail
 
-$BAZEL_PATH build $1 2>&1 | $BAZEL_OUTPUT_PROCESSOR
+$BAZEL_PATH build --build_event_text_file=$bazel_build_event_text_filename --build_event_publish_all_actions $1 2>&1 | $BAZEL_OUTPUT_PROCESSOR

--- a/tools/xcodeproj_shims/build-wrapper.sh
+++ b/tools/xcodeproj_shims/build-wrapper.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euxo pipefail
 
-$BAZEL_PATH build --build_event_text_file=$bazel_build_event_text_filename --build_event_publish_all_actions $1 2>&1 | $BAZEL_OUTPUT_PROCESSOR
+$BAZEL_PATH build --build_event_text_file=$BAZEL_BUILD_EVENT_TEXT_FILENAME --build_event_publish_all_actions $1 2>&1 | $BAZEL_OUTPUT_PROCESSOR

--- a/tools/xcodeproj_shims/installers/indexstores.sh
+++ b/tools/xcodeproj_shims/installers/indexstores.sh
@@ -4,11 +4,23 @@ set -euo pipefail
 
 # See `_indexstore.sh` for full details.
 
-# Make sure add these to bazel build target copts for objective-c
-find "$BAZEL_WORKSPACE_ROOT/bazel-out"/*/bin/ \
-     -type d \
-     -name "*.indexstore" \
-     -print0 \
-    | xargs -0 "$BAZEL_INSTALLERS_DIR/_indexstore.sh"
+echo "Start remapping index files at `date`"
 
-echo "Finish remapping index files"
+FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $bazel_build_event_text_filename || true`
+declare -a EXISTING_INDEXSTORES=()
+for i in $FOUND_INDEXSTORES
+do
+if [ -d $i ]
+then
+EXISTING_INDEXSTORES+=($i)
+fi
+done
+
+if [ ${#EXISTING_INDEXSTORES[@]} -ne 0 ]
+then
+  "$BAZEL_INSTALLERS_DIR/_indexstore.sh" $EXISTING_INDEXSTORES
+else
+  echo "No indexstores found"
+fi
+
+echo "Finish remapping index files at `date`"

--- a/tools/xcodeproj_shims/installers/indexstores.sh
+++ b/tools/xcodeproj_shims/installers/indexstores.sh
@@ -6,15 +6,18 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $bazel_build_event_text_filename || true`
+FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $BAZEL_BUILD_EVENT_TEXT_FILENAME || true`
+
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
 do
-if [ -d $i ]
-then
-EXISTING_INDEXSTORES+=($i)
-fi
+  if [ -d $i ]
+  then
+    EXISTING_INDEXSTORES+=($i)
+  fi
 done
+
+echo "Found ${#EXISTING_INDEXSTORES[@]} existing indexstores"
 
 if [ ${#EXISTING_INDEXSTORES[@]} -ne 0 ]
 then


### PR DESCRIPTION
Use BEP to determine which indexstore paths were generated by the compilation steps of the build. Only move those over, so we don't move every generated indexstore. This was a suggestion from other engineers at ios-dev-at-scale to make index remapping more efficient.