### PR TITLE
Separate objective-c indexstore units and records by objc_library

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           set -euo pipefail
           bazelisk query 'kind(xcodeproj, tests/macos/xcodeproj/...)' | xargs -n 1 bazelisk run
-          bazel query 'attr(executable, 1, kind(genrule, tests/macos/xcodeproj/...))' | xargs -n 1 bazelisk run
+          bazelisk query 'attr(executable, 1, kind(genrule, tests/macos/xcodeproj/...))' | xargs -n 1 bazelisk run
           git diff --exit-code tests/macos/xcodeproj
       - name: Run Xcode builds
         run: ./tests/macos/xcodeproj/build.sh

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -563,7 +563,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
 
     objc_copts.append("-I.")
 
-    objc_copts.extend(("-index-store-path", "$(GENDIR)/rules_ios_apple_library_objc.indexstore"))
+    objc_copts.extend(("-index-store-path", "$(GENDIR)/rules_ios_objc_library_{}.indexstore".format(objc_libname)))
     objc_library(
         name = objc_libname,
         srcs = objc_sources + objc_private_hdrs + objc_non_exported_hdrs,

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -564,8 +564,9 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
     objc_copts.append("-I.")
 
     objc_copts.extend(("-index-store-path", "$(GENDIR)/{package}/rules_ios_objc_library_{libname}.indexstore".format(
-      package = native.package_name(),
-      libname = objc_libname)))
+        package = native.package_name(),
+        libname = objc_libname,
+    )))
     objc_library(
         name = objc_libname,
         srcs = objc_sources + objc_private_hdrs + objc_non_exported_hdrs,

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -563,7 +563,9 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
 
     objc_copts.append("-I.")
 
-    objc_copts.extend(("-index-store-path", "$(GENDIR)/rules_ios_objc_library_{}.indexstore".format(objc_libname)))
+    objc_copts.extend(("-index-store-path", "$(GENDIR)/{package}/rules_ios_objc_library_{libname}.indexstore".format(
+      package = native.package_name(),
+      libname = objc_libname)))
     objc_library(
         name = objc_libname,
         srcs = objc_sources + objc_private_hdrs + objc_non_exported_hdrs,

--- a/tests/macos/xcodeproj/BUILD.bazel
+++ b/tests/macos/xcodeproj/BUILD.bazel
@@ -92,8 +92,8 @@ cat <<'EOS' > $@
 #!/bin/sh
 set -euxo pipefail
 rm -fr {package_name}/{target_name}.xcodeproj
-bazel run {package_name}:{target_name}
-bazel run {package_name}:{target_name}
+bazelisk run {package_name}:{target_name}
+bazelisk run {package_name}:{target_name}
 EOS
     """.format(
         package_name = package_name(),


### PR DESCRIPTION
This behavior is similar to swift_library: https://github.com/bazelbuild/rules_swift/blob/master/swift/internal/derived_files.bzl#L66 (See its invocation of `actions.declare_directory` from `_indexstore_directory`.)

We observed an issue where it took a long time for index-import to remap bazel-generated indexstores. The slowdown was actually a result of the fact that all objective-c indexstores were being placed in the same .indexstore directory. When we broke them apart by objective-c library, things got considerably faster. Before these changes, it took 3 minutes to remap for a larger project, but now it takes 3 seconds.

There is an alternative approach we can take. This approach has been taken by Brentley here: https://github.com/lyft/index-import/pull/46 This PR is open right now, but once it lands, we can consider it, if we still see performance issues.
1. Group index unit/record files into the same indexstore directory.
2. Invoke index-import and have it run on parallel across units themselves, rather than indexstore directories.

