### PR TITLE
Collect diagnostics about indexing so we can debug problems more easily

### DIFF
--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -263,7 +263,11 @@ def _xcodeproj_impl(ctx):
 set -euxo pipefail
 cd $BAZEL_WORKSPACE_ROOT
 
-export BAZEL_BUILD_EVENT_TEXT_FILENAME=$(mktemp -d)/build_event.txt
+export BAZEL_DIAGNOSTICS_DIR="$BUILD_DIR/../../bazel-xcode-diagnostics/"
+mkdir -p $BAZEL_DIAGNOSTICS_DIR
+export DATE_SUFFIX="$(date +%Y%m%d.%H%M%S%L)"
+export BAZEL_BUILD_EVENT_TEXT_FILENAME="$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt"
+export BAZEL_BUILD_EXECUTION_LOG_FILENAME="$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log"
 $BAZEL_BUILD_EXEC {bazel_build_target_name}
 $BAZEL_INSTALLER
 """.format(bazel_build_target_name = target_info.bazel_build_target_name),

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/indexstores.sh
@@ -27,3 +27,5 @@ else
 fi
 
 echo "Finish remapping index files at `date`"
+
+ls -ltR $BUILD_DIR/../../Index/DataStore/ > $BAZEL_DIAGNOSTICS_DIR/indexstores-contents-$DATE_SUFFIX.log

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/install.sh
@@ -9,13 +9,8 @@
 
 set -eux
 
-
-diagnostics_dir="$TARGET_BUILD_DIR/../../../bazel-xcode-diagnostics/"
-mkdir -p $diagnostics_dir
-
 # Delete all logfiles that are older than 7 days
-find $diagnostics_dir -type f -atime +7d -delete
-date_suffix="$(date +%Y%m%d.%H%M%S%L)"
+find $BAZEL_DIAGNOSTICS_DIR -type f -atime +7d -delete
 
 case ${PRODUCT_TYPE} in
     com.apple.product-type.framework)
@@ -45,13 +40,13 @@ fi
 
 rsync \
     --recursive --chmod=u+w --delete \
-    "$input" "$output" > $diagnostics_dir/rsync-stdout-$date_suffix.log 2> $diagnostics_dir/rsync-stderr-$date_suffix.log
+    "$input" "$output" > $BAZEL_DIAGNOSTICS_DIR/rsync-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/rsync-stderr-$DATE_SUFFIX.log
 
 
 # Part of the build intermediary output will be swiftmodule files
 # which XCode will use for indexing. Let's keep those.
-$BAZEL_INSTALLERS_DIR/swiftmodules.sh > $diagnostics_dir/swiftmodules-stdout-$date_suffix.log 2> $diagnostics_dir/swiftmodules-stderr-$date_suffix.log &
-$BAZEL_INSTALLERS_DIR/indexstores.sh > $diagnostics_dir/indexstores-stdout-$date_suffix.log 2> $diagnostics_dir/indexstores-stderr-$date_suffix.log &
-$BAZEL_INSTALLERS_DIR/lldb-settings.sh  > $diagnostics_dir/lldb-stdout-$date_suffix.log 2> $diagnostics_dir/lldb-stderr-$date_suffix.log &
+$BAZEL_INSTALLERS_DIR/swiftmodules.sh > $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stderr-$DATE_SUFFIX.log &
+$BAZEL_INSTALLERS_DIR/indexstores.sh > $BAZEL_DIAGNOSTICS_DIR/indexstores-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/indexstores-stderr-$DATE_SUFFIX.log &
+$BAZEL_INSTALLERS_DIR/lldb-settings.sh  > $BAZEL_DIAGNOSTICS_DIR/lldb-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/lldb-stderr-$DATE_SUFFIX.log &
 
 

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/installer
@@ -9,13 +9,8 @@
 
 set -eux
 
-
-diagnostics_dir="$TARGET_BUILD_DIR/../../../bazel-xcode-diagnostics/"
-mkdir -p $diagnostics_dir
-
 # Delete all logfiles that are older than 7 days
-find $diagnostics_dir -type f -atime +7d -delete
-date_suffix="$(date +%Y%m%d.%H%M%S%L)"
+find $BAZEL_DIAGNOSTICS_DIR -type f -atime +7d -delete
 
 case ${PRODUCT_TYPE} in
     com.apple.product-type.framework)
@@ -45,13 +40,13 @@ fi
 
 rsync \
     --recursive --chmod=u+w --delete \
-    "$input" "$output" > $diagnostics_dir/rsync-stdout-$date_suffix.log 2> $diagnostics_dir/rsync-stderr-$date_suffix.log
+    "$input" "$output" > $BAZEL_DIAGNOSTICS_DIR/rsync-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/rsync-stderr-$DATE_SUFFIX.log
 
 
 # Part of the build intermediary output will be swiftmodule files
 # which XCode will use for indexing. Let's keep those.
-$BAZEL_INSTALLERS_DIR/swiftmodules.sh > $diagnostics_dir/swiftmodules-stdout-$date_suffix.log 2> $diagnostics_dir/swiftmodules-stderr-$date_suffix.log &
-$BAZEL_INSTALLERS_DIR/indexstores.sh > $diagnostics_dir/indexstores-stdout-$date_suffix.log 2> $diagnostics_dir/indexstores-stderr-$date_suffix.log &
-$BAZEL_INSTALLERS_DIR/lldb-settings.sh  > $diagnostics_dir/lldb-stdout-$date_suffix.log 2> $diagnostics_dir/lldb-stderr-$date_suffix.log &
+$BAZEL_INSTALLERS_DIR/swiftmodules.sh > $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stderr-$DATE_SUFFIX.log &
+$BAZEL_INSTALLERS_DIR/indexstores.sh > $BAZEL_DIAGNOSTICS_DIR/indexstores-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/indexstores-stderr-$DATE_SUFFIX.log &
+$BAZEL_INSTALLERS_DIR/lldb-settings.sh  > $BAZEL_DIAGNOSTICS_DIR/lldb-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/lldb-stderr-$DATE_SUFFIX.log &
 
 

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
@@ -204,7 +204,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-RunnableTestSuite_iPad-Air-2__12.4\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-RunnableTestSuite_iPad-Air-2__12.4\n$BAZEL_INSTALLER\n";
 		};
 		8C9FD347EEDF21022077C21D /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -222,7 +222,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC rules/test_host_app:iOS-12.0-AppHost\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\n$BAZEL_BUILD_EXEC rules/test_host_app:iOS-12.0-AppHost\n$BAZEL_INSTALLER\n";
 		};
 		CEFFC66550AFA438E8952334 /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -240,7 +240,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-UnitTests\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-UnitTests\n$BAZEL_INSTALLER\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/indexstores.sh
@@ -27,3 +27,5 @@ else
 fi
 
 echo "Finish remapping index files at `date`"
+
+ls -ltR $BUILD_DIR/../../Index/DataStore/ > $BAZEL_DIAGNOSTICS_DIR/indexstores-contents-$DATE_SUFFIX.log

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/install.sh
@@ -9,13 +9,8 @@
 
 set -eux
 
-
-diagnostics_dir="$TARGET_BUILD_DIR/../../../bazel-xcode-diagnostics/"
-mkdir -p $diagnostics_dir
-
 # Delete all logfiles that are older than 7 days
-find $diagnostics_dir -type f -atime +7d -delete
-date_suffix="$(date +%Y%m%d.%H%M%S%L)"
+find $BAZEL_DIAGNOSTICS_DIR -type f -atime +7d -delete
 
 case ${PRODUCT_TYPE} in
     com.apple.product-type.framework)
@@ -45,13 +40,13 @@ fi
 
 rsync \
     --recursive --chmod=u+w --delete \
-    "$input" "$output" > $diagnostics_dir/rsync-stdout-$date_suffix.log 2> $diagnostics_dir/rsync-stderr-$date_suffix.log
+    "$input" "$output" > $BAZEL_DIAGNOSTICS_DIR/rsync-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/rsync-stderr-$DATE_SUFFIX.log
 
 
 # Part of the build intermediary output will be swiftmodule files
 # which XCode will use for indexing. Let's keep those.
-$BAZEL_INSTALLERS_DIR/swiftmodules.sh > $diagnostics_dir/swiftmodules-stdout-$date_suffix.log 2> $diagnostics_dir/swiftmodules-stderr-$date_suffix.log &
-$BAZEL_INSTALLERS_DIR/indexstores.sh > $diagnostics_dir/indexstores-stdout-$date_suffix.log 2> $diagnostics_dir/indexstores-stderr-$date_suffix.log &
-$BAZEL_INSTALLERS_DIR/lldb-settings.sh  > $diagnostics_dir/lldb-stdout-$date_suffix.log 2> $diagnostics_dir/lldb-stderr-$date_suffix.log &
+$BAZEL_INSTALLERS_DIR/swiftmodules.sh > $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stderr-$DATE_SUFFIX.log &
+$BAZEL_INSTALLERS_DIR/indexstores.sh > $BAZEL_DIAGNOSTICS_DIR/indexstores-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/indexstores-stderr-$DATE_SUFFIX.log &
+$BAZEL_INSTALLERS_DIR/lldb-settings.sh  > $BAZEL_DIAGNOSTICS_DIR/lldb-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/lldb-stderr-$DATE_SUFFIX.log &
 
 

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/installer
@@ -9,13 +9,8 @@
 
 set -eux
 
-
-diagnostics_dir="$TARGET_BUILD_DIR/../../../bazel-xcode-diagnostics/"
-mkdir -p $diagnostics_dir
-
 # Delete all logfiles that are older than 7 days
-find $diagnostics_dir -type f -atime +7d -delete
-date_suffix="$(date +%Y%m%d.%H%M%S%L)"
+find $BAZEL_DIAGNOSTICS_DIR -type f -atime +7d -delete
 
 case ${PRODUCT_TYPE} in
     com.apple.product-type.framework)
@@ -45,13 +40,13 @@ fi
 
 rsync \
     --recursive --chmod=u+w --delete \
-    "$input" "$output" > $diagnostics_dir/rsync-stdout-$date_suffix.log 2> $diagnostics_dir/rsync-stderr-$date_suffix.log
+    "$input" "$output" > $BAZEL_DIAGNOSTICS_DIR/rsync-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/rsync-stderr-$DATE_SUFFIX.log
 
 
 # Part of the build intermediary output will be swiftmodule files
 # which XCode will use for indexing. Let's keep those.
-$BAZEL_INSTALLERS_DIR/swiftmodules.sh > $diagnostics_dir/swiftmodules-stdout-$date_suffix.log 2> $diagnostics_dir/swiftmodules-stderr-$date_suffix.log &
-$BAZEL_INSTALLERS_DIR/indexstores.sh > $diagnostics_dir/indexstores-stdout-$date_suffix.log 2> $diagnostics_dir/indexstores-stderr-$date_suffix.log &
-$BAZEL_INSTALLERS_DIR/lldb-settings.sh  > $diagnostics_dir/lldb-stdout-$date_suffix.log 2> $diagnostics_dir/lldb-stderr-$date_suffix.log &
+$BAZEL_INSTALLERS_DIR/swiftmodules.sh > $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stderr-$DATE_SUFFIX.log &
+$BAZEL_INSTALLERS_DIR/indexstores.sh > $BAZEL_DIAGNOSTICS_DIR/indexstores-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/indexstores-stderr-$DATE_SUFFIX.log &
+$BAZEL_INSTALLERS_DIR/lldb-settings.sh  > $BAZEL_DIAGNOSTICS_DIR/lldb-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/lldb-stderr-$DATE_SUFFIX.log &
 
 

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
@@ -204,7 +204,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-RunnableTestSuite_iPad-Air-2__12.4\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-RunnableTestSuite_iPad-Air-2__12.4\n$BAZEL_INSTALLER\n";
 		};
 		B6158A7B27A31249CCAFEC9E /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -222,7 +222,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC rules/test_host_app:iOS-12.0-AppHost\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\n$BAZEL_BUILD_EXEC rules/test_host_app:iOS-12.0-AppHost\n$BAZEL_INSTALLER\n";
 		};
 		D318F6F09E06731B996B9EF2 /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -240,7 +240,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-UnitTests\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\n$BAZEL_BUILD_EXEC tests/macos/xcodeproj:Single-Application-UnitTests\n$BAZEL_INSTALLER\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -27,3 +27,5 @@ else
 fi
 
 echo "Finish remapping index files at `date`"
+
+ls -ltR $BUILD_DIR/../../Index/DataStore/ > $BAZEL_DIAGNOSTICS_DIR/indexstores-contents-$DATE_SUFFIX.log

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/install.sh
@@ -9,13 +9,8 @@
 
 set -eux
 
-
-diagnostics_dir="$TARGET_BUILD_DIR/../../../bazel-xcode-diagnostics/"
-mkdir -p $diagnostics_dir
-
 # Delete all logfiles that are older than 7 days
-find $diagnostics_dir -type f -atime +7d -delete
-date_suffix="$(date +%Y%m%d.%H%M%S%L)"
+find $BAZEL_DIAGNOSTICS_DIR -type f -atime +7d -delete
 
 case ${PRODUCT_TYPE} in
     com.apple.product-type.framework)
@@ -45,13 +40,13 @@ fi
 
 rsync \
     --recursive --chmod=u+w --delete \
-    "$input" "$output" > $diagnostics_dir/rsync-stdout-$date_suffix.log 2> $diagnostics_dir/rsync-stderr-$date_suffix.log
+    "$input" "$output" > $BAZEL_DIAGNOSTICS_DIR/rsync-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/rsync-stderr-$DATE_SUFFIX.log
 
 
 # Part of the build intermediary output will be swiftmodule files
 # which XCode will use for indexing. Let's keep those.
-$BAZEL_INSTALLERS_DIR/swiftmodules.sh > $diagnostics_dir/swiftmodules-stdout-$date_suffix.log 2> $diagnostics_dir/swiftmodules-stderr-$date_suffix.log &
-$BAZEL_INSTALLERS_DIR/indexstores.sh > $diagnostics_dir/indexstores-stdout-$date_suffix.log 2> $diagnostics_dir/indexstores-stderr-$date_suffix.log &
-$BAZEL_INSTALLERS_DIR/lldb-settings.sh  > $diagnostics_dir/lldb-stdout-$date_suffix.log 2> $diagnostics_dir/lldb-stderr-$date_suffix.log &
+$BAZEL_INSTALLERS_DIR/swiftmodules.sh > $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stderr-$DATE_SUFFIX.log &
+$BAZEL_INSTALLERS_DIR/indexstores.sh > $BAZEL_DIAGNOSTICS_DIR/indexstores-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/indexstores-stderr-$DATE_SUFFIX.log &
+$BAZEL_INSTALLERS_DIR/lldb-settings.sh  > $BAZEL_DIAGNOSTICS_DIR/lldb-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/lldb-stderr-$DATE_SUFFIX.log &
 
 

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/installer
@@ -9,13 +9,8 @@
 
 set -eux
 
-
-diagnostics_dir="$TARGET_BUILD_DIR/../../../bazel-xcode-diagnostics/"
-mkdir -p $diagnostics_dir
-
 # Delete all logfiles that are older than 7 days
-find $diagnostics_dir -type f -atime +7d -delete
-date_suffix="$(date +%Y%m%d.%H%M%S%L)"
+find $BAZEL_DIAGNOSTICS_DIR -type f -atime +7d -delete
 
 case ${PRODUCT_TYPE} in
     com.apple.product-type.framework)
@@ -45,13 +40,13 @@ fi
 
 rsync \
     --recursive --chmod=u+w --delete \
-    "$input" "$output" > $diagnostics_dir/rsync-stdout-$date_suffix.log 2> $diagnostics_dir/rsync-stderr-$date_suffix.log
+    "$input" "$output" > $BAZEL_DIAGNOSTICS_DIR/rsync-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/rsync-stderr-$DATE_SUFFIX.log
 
 
 # Part of the build intermediary output will be swiftmodule files
 # which XCode will use for indexing. Let's keep those.
-$BAZEL_INSTALLERS_DIR/swiftmodules.sh > $diagnostics_dir/swiftmodules-stdout-$date_suffix.log 2> $diagnostics_dir/swiftmodules-stderr-$date_suffix.log &
-$BAZEL_INSTALLERS_DIR/indexstores.sh > $diagnostics_dir/indexstores-stdout-$date_suffix.log 2> $diagnostics_dir/indexstores-stderr-$date_suffix.log &
-$BAZEL_INSTALLERS_DIR/lldb-settings.sh  > $diagnostics_dir/lldb-stdout-$date_suffix.log 2> $diagnostics_dir/lldb-stderr-$date_suffix.log &
+$BAZEL_INSTALLERS_DIR/swiftmodules.sh > $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stderr-$DATE_SUFFIX.log &
+$BAZEL_INSTALLERS_DIR/indexstores.sh > $BAZEL_DIAGNOSTICS_DIR/indexstores-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/indexstores-stderr-$DATE_SUFFIX.log &
+$BAZEL_INSTALLERS_DIR/lldb-settings.sh  > $BAZEL_DIAGNOSTICS_DIR/lldb-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/lldb-stderr-$DATE_SUFFIX.log &
 
 

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
@@ -270,7 +270,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/ios/unit-test/test-imports-app:TestImports-Unit-Tests\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\n$BAZEL_BUILD_EXEC tests/ios/unit-test/test-imports-app:TestImports-Unit-Tests\n$BAZEL_INSTALLER\n";
 		};
 		2756FB505F15157D82C9069E /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -288,7 +288,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC rules/test_host_app:iOS-10.0-AppHost\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\n$BAZEL_BUILD_EXEC rules/test_host_app:iOS-10.0-AppHost\n$BAZEL_INSTALLER\n";
 		};
 		3D60A491CE72F7D799EC0383 /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -306,7 +306,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/ios/unit-test/test-imports-app:TestImports-App\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\n$BAZEL_BUILD_EXEC tests/ios/unit-test/test-imports-app:TestImports-App\n$BAZEL_INSTALLER\n";
 		};
 		6DBC122A6C2C8B5D5805E16D /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -324,7 +324,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=$(mktemp -d)/build_event.txt\n$BAZEL_BUILD_EXEC tests/ios/unit-test:DefaultHosted\n$BAZEL_INSTALLER\n";
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\n$BAZEL_BUILD_EXEC tests/ios/unit-test:DefaultHosted\n$BAZEL_INSTALLER\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/tools/xcodeproj_shims/build-wrapper.sh
+++ b/tools/xcodeproj_shims/build-wrapper.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euxo pipefail
 
-$BAZEL_PATH build --build_event_text_file=$BAZEL_BUILD_EVENT_TEXT_FILENAME --build_event_publish_all_actions $1 2>&1 | $BAZEL_OUTPUT_PROCESSOR
+$BAZEL_PATH build --experimental_execution_log_file=$BAZEL_BUILD_EXECUTION_LOG_FILENAME --build_event_text_file=$BAZEL_BUILD_EVENT_TEXT_FILENAME --build_event_publish_all_actions $1 2>&1 | $BAZEL_OUTPUT_PROCESSOR

--- a/tools/xcodeproj_shims/install.sh
+++ b/tools/xcodeproj_shims/install.sh
@@ -9,13 +9,8 @@
 
 set -eux
 
-
-diagnostics_dir="$TARGET_BUILD_DIR/../../../bazel-xcode-diagnostics/"
-mkdir -p $diagnostics_dir
-
 # Delete all logfiles that are older than 7 days
-find $diagnostics_dir -type f -atime +7d -delete
-date_suffix="$(date +%Y%m%d.%H%M%S%L)"
+find $BAZEL_DIAGNOSTICS_DIR -type f -atime +7d -delete
 
 case ${PRODUCT_TYPE} in
     com.apple.product-type.framework)
@@ -45,13 +40,13 @@ fi
 
 rsync \
     --recursive --chmod=u+w --delete \
-    "$input" "$output" > $diagnostics_dir/rsync-stdout-$date_suffix.log 2> $diagnostics_dir/rsync-stderr-$date_suffix.log
+    "$input" "$output" > $BAZEL_DIAGNOSTICS_DIR/rsync-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/rsync-stderr-$DATE_SUFFIX.log
 
 
 # Part of the build intermediary output will be swiftmodule files
 # which XCode will use for indexing. Let's keep those.
-$BAZEL_INSTALLERS_DIR/swiftmodules.sh > $diagnostics_dir/swiftmodules-stdout-$date_suffix.log 2> $diagnostics_dir/swiftmodules-stderr-$date_suffix.log &
-$BAZEL_INSTALLERS_DIR/indexstores.sh > $diagnostics_dir/indexstores-stdout-$date_suffix.log 2> $diagnostics_dir/indexstores-stderr-$date_suffix.log &
-$BAZEL_INSTALLERS_DIR/lldb-settings.sh  > $diagnostics_dir/lldb-stdout-$date_suffix.log 2> $diagnostics_dir/lldb-stderr-$date_suffix.log &
+$BAZEL_INSTALLERS_DIR/swiftmodules.sh > $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stderr-$DATE_SUFFIX.log &
+$BAZEL_INSTALLERS_DIR/indexstores.sh > $BAZEL_DIAGNOSTICS_DIR/indexstores-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/indexstores-stderr-$DATE_SUFFIX.log &
+$BAZEL_INSTALLERS_DIR/lldb-settings.sh  > $BAZEL_DIAGNOSTICS_DIR/lldb-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/lldb-stderr-$DATE_SUFFIX.log &
 
 

--- a/tools/xcodeproj_shims/installers/indexstores.sh
+++ b/tools/xcodeproj_shims/installers/indexstores.sh
@@ -27,3 +27,5 @@ else
 fi
 
 echo "Finish remapping index files at `date`"
+
+ls -ltR $BUILD_DIR/../../Index/DataStore/ > $BAZEL_DIAGNOSTICS_DIR/indexstores-contents-$DATE_SUFFIX.log


### PR DESCRIPTION
I considered using something like this build setting: https://pewpewthespells.com/blog/buildsettings.html#derived_file_dir

But I changed my mind, because I thought it might be easier to find the `bazel-xcode-diagnostics` directory if it was sitting closer to the root. Let me know if there are some other reasons I should consider using a deeper subdirectory of the derived data for the project.