### PR TITLE
Handle bourne shell tokenization in objc_copts and linkopts when expanding xcconfigs

### DIFF
--- a/tests/ios/frameworks/target-xib/BUILD.bazel
+++ b/tests/ios/frameworks/target-xib/BUILD.bazel
@@ -5,12 +5,14 @@ apple_framework(
     name = "TargetXIB",
     srcs = glob(["TargetXIB/**/*.swift"]),
     data = glob(["TargetXIB/**/*.xib"]),
+    platforms = {"ios": "11.0"},
     visibility = ["//visibility:public"],
 )
 
 apple_framework(
     name = "TargetXIBTestsLib",
     srcs = glob(["TargetXIBTests/**/*.swift"]),
+    platforms = {"ios": "11.0"},
     visibility = ["//visibility:public"],
     deps = [":TargetXIB"],
 )

--- a/tests/macos/xcconfig/BUILD.bazel
+++ b/tests/macos/xcconfig/BUILD.bazel
@@ -35,6 +35,7 @@ apple_framework(
         "GCC_PREPROCESSOR_DEFINITIONS": [
             "FOO",
             "BAR=1",
+            "ABCD=HAS SO MANY SPACES",
         ],
     },
 )

--- a/tests/macos/xcconfig/tests.bzl
+++ b/tests/macos/xcconfig/tests.bzl
@@ -135,7 +135,7 @@ def xcconfig_unit_test_suite():
             assert_xcconfig(
                 name = "otherwise_supported",
                 xcconfig = {"ALTERNATE_LINKER": "foo"},
-                expected = {"linkopts": ["-fuse-ld=foo"]},
+                expected = {"linkopts": ["-fuse-ld='foo'"]},
             ),
             assert_xcconfig(
                 name = "empty_string_match",
@@ -145,12 +145,12 @@ def xcconfig_unit_test_suite():
             assert_xcconfig(
                 name = "command_line_flag",
                 xcconfig = {"SYSTEM_FRAMEWORK_SEARCH_PATHS": ["foo", "/bar"]},
-                expected = {"linkopts": ["-iframework", "foo", "-iframework", "/bar"]},
+                expected = {"linkopts": ["-iframework", "'foo'", "-iframework", "'/bar'"]},
             ),
             assert_xcconfig(
                 name = "command_line_prefix",
                 xcconfig = {"CLANG_MACRO_BACKTRACE_LIMIT": "12"},
-                expected = {"objc_copts": ["-fmacro-backtrace-limit=12"]},
+                expected = {"objc_copts": ["-fmacro-backtrace-limit='12'"]},
             ),
             assert_xcconfig(
                 name = "command_line_flag_default_bool",
@@ -170,7 +170,12 @@ def xcconfig_unit_test_suite():
             assert_xcconfig(
                 name = "option_with_inherited",
                 xcconfig = {"GCC_PREPROCESSOR_DEFINITIONS": ["$(inherited)", "ABC=1"]},
-                expected = {"objc_copts": ["-D$(inherited)", "-DABC=1"]},
+                expected = {"objc_copts": ["-D'$(inherited)'", "-D'ABC=1'"]},
+            ),
+            assert_xcconfig(
+                name = "option_with_shell_metacharacters",
+                xcconfig = {"GCC_PREPROCESSOR_DEFINITIONS": ["DISPLAY_VERSION=1.0.0-beta.1", "SDK_NAME=WHY WOULD YOU ADD SPACES"]},
+                expected = {"objc_copts": ["-D'DISPLAY_VERSION=1.0.0-beta.1'", "-D'SDK_NAME=WHY WOULD YOU ADD SPACES'"]},
             ),
             # TODO: we should eventually support conditioned vars somehow
             assert_xcconfig(


### PR DESCRIPTION
obj_library and cc_library shell-expand their copts & linkopts, swift_library does not
