### PR TITLE
Stop copying xcasset directories into compiled resource bundles

### DIFF
--- a/rules/library/resources.bzl
+++ b/rules/library/resources.bzl
@@ -56,7 +56,7 @@ or `resources` in an `apple_resource_bundle`.
 
 def wrap_resources_in_filegroup(name, srcs, extensions_to_filter = [], **kwargs):
     extensions_to_filter = list(extensions_to_filter)
-    for x in ("xcdatamodeld", "xcmappingmodel"):
+    for x in ("xcdatamodeld", "xcmappingmodel", "xcassets"):
         if x not in extensions_to_filter:
             extensions_to_filter.append(x)
     resources_filegroup(


### PR DESCRIPTION
They bloat the size of the bundles and serve no purpose, since the compiled Assets.car is already in the bundle