### PR TITLE
Allow defining apple.experimental.tree_artifact_outputs when building xcodeprojs

### DIFF
--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/install.sh
@@ -3,24 +3,20 @@
 # Install the runnable products so that Xcode can run it. This includes `.app`s,
 # `.xctest`s, and also command line binaries.
 
-# TODO: Lyft uses this script, because Xcode calls `ditto` on the `.swiftmodule`/`.swiftdoc` files of the top-level
-# target.
-# "$SRCROOT"/bazel/installers/xcode-artifacts.sh
-
 set -eux
 
 # Delete all logfiles that are older than 7 days
-find $BAZEL_DIAGNOSTICS_DIR -type f -atime +7d -delete
+find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 
-case ${PRODUCT_TYPE} in
+case "${PRODUCT_TYPE}" in
     com.apple.product-type.framework)
-        input="bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}"
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
         ;;
     com.apple.product-type.bundle.unit-test)
-        input="bazel-bin/$BAZEL_BIN_SUBDIR/$TARGET_NAME.__internal__.__test_bundle_archive-root/$TARGET_NAME${WRAPPER_SUFFIX:-}"
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}" "bazel-bin/$BAZEL_BIN_SUBDIR/$TARGET_NAME.__internal__.__test_bundle_archive-root/$TARGET_NAME${WRAPPER_SUFFIX:-}")
         ;;
     com.apple.product-type.application)
-        input="bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}_archive-root/Payload/$TARGET_NAME${WRAPPER_SUFFIX:-}"
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}" "bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}_archive-root/Payload/$TARGET_NAME${WRAPPER_SUFFIX:-}")
         ;;
     *)
         echo "Error: Installing ${TARGET_NAME} of type ${PRODUCT_TYPE} is unsupported" >&2
@@ -31,22 +27,29 @@ output="$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME"
 
 mkdir -p "$(dirname "$output")"
 
-if [[ -d $input ]]; then
-    # Copy bundle contents, into the destination bundle.
-    # This avoids self-nesting, like: Foo.app/Foo.app
-    input+="/"
+for input in "${input_options[@]}"; do
+    if [[ -d $input ]]; then
+        # Copy bundle contents, into the destination bundle.
+        # This avoids self-nesting, like: Foo.app/Foo.app
+        input+="/"
+    else
+        continue
+    fi
+
+    rsync \
+        --recursive --chmod=u+w --delete \
+        "$input" "$output" > "$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
+    break
+done
+
+if [[ ! -d $output ]]; then
+    echo "error: failed to find $FULL_PRODUCT_NAME in expected locations: ${input_options[*]}"
+    exit 1
 fi
 
-
-rsync \
-    --recursive --chmod=u+w --delete \
-    "$input" "$output" > $BAZEL_DIAGNOSTICS_DIR/rsync-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/rsync-stderr-$DATE_SUFFIX.log
-
-$BAZEL_INSTALLERS_DIR/lldb-settings.sh  > $BAZEL_DIAGNOSTICS_DIR/lldb-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/lldb-stderr-$DATE_SUFFIX.log
+"$BAZEL_INSTALLERS_DIR"/lldb-settings.sh > "$BAZEL_DIAGNOSTICS_DIR"/lldb-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/lldb-stderr-"$DATE_SUFFIX".log
 
 # Part of the build intermediary output will be swiftmodule files
 # which XCode will use for indexing. Let's keep those.
-$BAZEL_INSTALLERS_DIR/swiftmodules.sh > $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stderr-$DATE_SUFFIX.log &
-$BAZEL_INSTALLERS_DIR/indexstores.sh > $BAZEL_DIAGNOSTICS_DIR/indexstores-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/indexstores-stderr-$DATE_SUFFIX.log &
-
-
+"$BAZEL_INSTALLERS_DIR"/swiftmodules.sh > "$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/indexstores.sh > "$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/installer
@@ -3,24 +3,20 @@
 # Install the runnable products so that Xcode can run it. This includes `.app`s,
 # `.xctest`s, and also command line binaries.
 
-# TODO: Lyft uses this script, because Xcode calls `ditto` on the `.swiftmodule`/`.swiftdoc` files of the top-level
-# target.
-# "$SRCROOT"/bazel/installers/xcode-artifacts.sh
-
 set -eux
 
 # Delete all logfiles that are older than 7 days
-find $BAZEL_DIAGNOSTICS_DIR -type f -atime +7d -delete
+find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 
-case ${PRODUCT_TYPE} in
+case "${PRODUCT_TYPE}" in
     com.apple.product-type.framework)
-        input="bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}"
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
         ;;
     com.apple.product-type.bundle.unit-test)
-        input="bazel-bin/$BAZEL_BIN_SUBDIR/$TARGET_NAME.__internal__.__test_bundle_archive-root/$TARGET_NAME${WRAPPER_SUFFIX:-}"
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}" "bazel-bin/$BAZEL_BIN_SUBDIR/$TARGET_NAME.__internal__.__test_bundle_archive-root/$TARGET_NAME${WRAPPER_SUFFIX:-}")
         ;;
     com.apple.product-type.application)
-        input="bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}_archive-root/Payload/$TARGET_NAME${WRAPPER_SUFFIX:-}"
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}" "bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}_archive-root/Payload/$TARGET_NAME${WRAPPER_SUFFIX:-}")
         ;;
     *)
         echo "Error: Installing ${TARGET_NAME} of type ${PRODUCT_TYPE} is unsupported" >&2
@@ -31,22 +27,29 @@ output="$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME"
 
 mkdir -p "$(dirname "$output")"
 
-if [[ -d $input ]]; then
-    # Copy bundle contents, into the destination bundle.
-    # This avoids self-nesting, like: Foo.app/Foo.app
-    input+="/"
+for input in "${input_options[@]}"; do
+    if [[ -d $input ]]; then
+        # Copy bundle contents, into the destination bundle.
+        # This avoids self-nesting, like: Foo.app/Foo.app
+        input+="/"
+    else
+        continue
+    fi
+
+    rsync \
+        --recursive --chmod=u+w --delete \
+        "$input" "$output" > "$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
+    break
+done
+
+if [[ ! -d $output ]]; then
+    echo "error: failed to find $FULL_PRODUCT_NAME in expected locations: ${input_options[*]}"
+    exit 1
 fi
 
-
-rsync \
-    --recursive --chmod=u+w --delete \
-    "$input" "$output" > $BAZEL_DIAGNOSTICS_DIR/rsync-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/rsync-stderr-$DATE_SUFFIX.log
-
-$BAZEL_INSTALLERS_DIR/lldb-settings.sh  > $BAZEL_DIAGNOSTICS_DIR/lldb-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/lldb-stderr-$DATE_SUFFIX.log
+"$BAZEL_INSTALLERS_DIR"/lldb-settings.sh > "$BAZEL_DIAGNOSTICS_DIR"/lldb-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/lldb-stderr-"$DATE_SUFFIX".log
 
 # Part of the build intermediary output will be swiftmodule files
 # which XCode will use for indexing. Let's keep those.
-$BAZEL_INSTALLERS_DIR/swiftmodules.sh > $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stderr-$DATE_SUFFIX.log &
-$BAZEL_INSTALLERS_DIR/indexstores.sh > $BAZEL_DIAGNOSTICS_DIR/indexstores-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/indexstores-stderr-$DATE_SUFFIX.log &
-
-
+"$BAZEL_INSTALLERS_DIR"/swiftmodules.sh > "$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/indexstores.sh > "$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/install.sh
@@ -3,24 +3,20 @@
 # Install the runnable products so that Xcode can run it. This includes `.app`s,
 # `.xctest`s, and also command line binaries.
 
-# TODO: Lyft uses this script, because Xcode calls `ditto` on the `.swiftmodule`/`.swiftdoc` files of the top-level
-# target.
-# "$SRCROOT"/bazel/installers/xcode-artifacts.sh
-
 set -eux
 
 # Delete all logfiles that are older than 7 days
-find $BAZEL_DIAGNOSTICS_DIR -type f -atime +7d -delete
+find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 
-case ${PRODUCT_TYPE} in
+case "${PRODUCT_TYPE}" in
     com.apple.product-type.framework)
-        input="bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}"
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
         ;;
     com.apple.product-type.bundle.unit-test)
-        input="bazel-bin/$BAZEL_BIN_SUBDIR/$TARGET_NAME.__internal__.__test_bundle_archive-root/$TARGET_NAME${WRAPPER_SUFFIX:-}"
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}" "bazel-bin/$BAZEL_BIN_SUBDIR/$TARGET_NAME.__internal__.__test_bundle_archive-root/$TARGET_NAME${WRAPPER_SUFFIX:-}")
         ;;
     com.apple.product-type.application)
-        input="bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}_archive-root/Payload/$TARGET_NAME${WRAPPER_SUFFIX:-}"
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}" "bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}_archive-root/Payload/$TARGET_NAME${WRAPPER_SUFFIX:-}")
         ;;
     *)
         echo "Error: Installing ${TARGET_NAME} of type ${PRODUCT_TYPE} is unsupported" >&2
@@ -31,22 +27,29 @@ output="$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME"
 
 mkdir -p "$(dirname "$output")"
 
-if [[ -d $input ]]; then
-    # Copy bundle contents, into the destination bundle.
-    # This avoids self-nesting, like: Foo.app/Foo.app
-    input+="/"
+for input in "${input_options[@]}"; do
+    if [[ -d $input ]]; then
+        # Copy bundle contents, into the destination bundle.
+        # This avoids self-nesting, like: Foo.app/Foo.app
+        input+="/"
+    else
+        continue
+    fi
+
+    rsync \
+        --recursive --chmod=u+w --delete \
+        "$input" "$output" > "$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
+    break
+done
+
+if [[ ! -d $output ]]; then
+    echo "error: failed to find $FULL_PRODUCT_NAME in expected locations: ${input_options[*]}"
+    exit 1
 fi
 
-
-rsync \
-    --recursive --chmod=u+w --delete \
-    "$input" "$output" > $BAZEL_DIAGNOSTICS_DIR/rsync-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/rsync-stderr-$DATE_SUFFIX.log
-
-$BAZEL_INSTALLERS_DIR/lldb-settings.sh  > $BAZEL_DIAGNOSTICS_DIR/lldb-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/lldb-stderr-$DATE_SUFFIX.log
+"$BAZEL_INSTALLERS_DIR"/lldb-settings.sh > "$BAZEL_DIAGNOSTICS_DIR"/lldb-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/lldb-stderr-"$DATE_SUFFIX".log
 
 # Part of the build intermediary output will be swiftmodule files
 # which XCode will use for indexing. Let's keep those.
-$BAZEL_INSTALLERS_DIR/swiftmodules.sh > $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stderr-$DATE_SUFFIX.log &
-$BAZEL_INSTALLERS_DIR/indexstores.sh > $BAZEL_DIAGNOSTICS_DIR/indexstores-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/indexstores-stderr-$DATE_SUFFIX.log &
-
-
+"$BAZEL_INSTALLERS_DIR"/swiftmodules.sh > "$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/indexstores.sh > "$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/installer
@@ -3,24 +3,20 @@
 # Install the runnable products so that Xcode can run it. This includes `.app`s,
 # `.xctest`s, and also command line binaries.
 
-# TODO: Lyft uses this script, because Xcode calls `ditto` on the `.swiftmodule`/`.swiftdoc` files of the top-level
-# target.
-# "$SRCROOT"/bazel/installers/xcode-artifacts.sh
-
 set -eux
 
 # Delete all logfiles that are older than 7 days
-find $BAZEL_DIAGNOSTICS_DIR -type f -atime +7d -delete
+find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 
-case ${PRODUCT_TYPE} in
+case "${PRODUCT_TYPE}" in
     com.apple.product-type.framework)
-        input="bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}"
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
         ;;
     com.apple.product-type.bundle.unit-test)
-        input="bazel-bin/$BAZEL_BIN_SUBDIR/$TARGET_NAME.__internal__.__test_bundle_archive-root/$TARGET_NAME${WRAPPER_SUFFIX:-}"
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}" "bazel-bin/$BAZEL_BIN_SUBDIR/$TARGET_NAME.__internal__.__test_bundle_archive-root/$TARGET_NAME${WRAPPER_SUFFIX:-}")
         ;;
     com.apple.product-type.application)
-        input="bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}_archive-root/Payload/$TARGET_NAME${WRAPPER_SUFFIX:-}"
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}" "bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}_archive-root/Payload/$TARGET_NAME${WRAPPER_SUFFIX:-}")
         ;;
     *)
         echo "Error: Installing ${TARGET_NAME} of type ${PRODUCT_TYPE} is unsupported" >&2
@@ -31,22 +27,29 @@ output="$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME"
 
 mkdir -p "$(dirname "$output")"
 
-if [[ -d $input ]]; then
-    # Copy bundle contents, into the destination bundle.
-    # This avoids self-nesting, like: Foo.app/Foo.app
-    input+="/"
+for input in "${input_options[@]}"; do
+    if [[ -d $input ]]; then
+        # Copy bundle contents, into the destination bundle.
+        # This avoids self-nesting, like: Foo.app/Foo.app
+        input+="/"
+    else
+        continue
+    fi
+
+    rsync \
+        --recursive --chmod=u+w --delete \
+        "$input" "$output" > "$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
+    break
+done
+
+if [[ ! -d $output ]]; then
+    echo "error: failed to find $FULL_PRODUCT_NAME in expected locations: ${input_options[*]}"
+    exit 1
 fi
 
-
-rsync \
-    --recursive --chmod=u+w --delete \
-    "$input" "$output" > $BAZEL_DIAGNOSTICS_DIR/rsync-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/rsync-stderr-$DATE_SUFFIX.log
-
-$BAZEL_INSTALLERS_DIR/lldb-settings.sh  > $BAZEL_DIAGNOSTICS_DIR/lldb-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/lldb-stderr-$DATE_SUFFIX.log
+"$BAZEL_INSTALLERS_DIR"/lldb-settings.sh > "$BAZEL_DIAGNOSTICS_DIR"/lldb-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/lldb-stderr-"$DATE_SUFFIX".log
 
 # Part of the build intermediary output will be swiftmodule files
 # which XCode will use for indexing. Let's keep those.
-$BAZEL_INSTALLERS_DIR/swiftmodules.sh > $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stderr-$DATE_SUFFIX.log &
-$BAZEL_INSTALLERS_DIR/indexstores.sh > $BAZEL_DIAGNOSTICS_DIR/indexstores-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/indexstores-stderr-$DATE_SUFFIX.log &
-
-
+"$BAZEL_INSTALLERS_DIR"/swiftmodules.sh > "$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/indexstores.sh > "$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/install.sh
@@ -3,24 +3,20 @@
 # Install the runnable products so that Xcode can run it. This includes `.app`s,
 # `.xctest`s, and also command line binaries.
 
-# TODO: Lyft uses this script, because Xcode calls `ditto` on the `.swiftmodule`/`.swiftdoc` files of the top-level
-# target.
-# "$SRCROOT"/bazel/installers/xcode-artifacts.sh
-
 set -eux
 
 # Delete all logfiles that are older than 7 days
-find $BAZEL_DIAGNOSTICS_DIR -type f -atime +7d -delete
+find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 
-case ${PRODUCT_TYPE} in
+case "${PRODUCT_TYPE}" in
     com.apple.product-type.framework)
-        input="bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}"
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
         ;;
     com.apple.product-type.bundle.unit-test)
-        input="bazel-bin/$BAZEL_BIN_SUBDIR/$TARGET_NAME.__internal__.__test_bundle_archive-root/$TARGET_NAME${WRAPPER_SUFFIX:-}"
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}" "bazel-bin/$BAZEL_BIN_SUBDIR/$TARGET_NAME.__internal__.__test_bundle_archive-root/$TARGET_NAME${WRAPPER_SUFFIX:-}")
         ;;
     com.apple.product-type.application)
-        input="bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}_archive-root/Payload/$TARGET_NAME${WRAPPER_SUFFIX:-}"
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}" "bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}_archive-root/Payload/$TARGET_NAME${WRAPPER_SUFFIX:-}")
         ;;
     *)
         echo "Error: Installing ${TARGET_NAME} of type ${PRODUCT_TYPE} is unsupported" >&2
@@ -31,22 +27,29 @@ output="$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME"
 
 mkdir -p "$(dirname "$output")"
 
-if [[ -d $input ]]; then
-    # Copy bundle contents, into the destination bundle.
-    # This avoids self-nesting, like: Foo.app/Foo.app
-    input+="/"
+for input in "${input_options[@]}"; do
+    if [[ -d $input ]]; then
+        # Copy bundle contents, into the destination bundle.
+        # This avoids self-nesting, like: Foo.app/Foo.app
+        input+="/"
+    else
+        continue
+    fi
+
+    rsync \
+        --recursive --chmod=u+w --delete \
+        "$input" "$output" > "$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
+    break
+done
+
+if [[ ! -d $output ]]; then
+    echo "error: failed to find $FULL_PRODUCT_NAME in expected locations: ${input_options[*]}"
+    exit 1
 fi
 
-
-rsync \
-    --recursive --chmod=u+w --delete \
-    "$input" "$output" > $BAZEL_DIAGNOSTICS_DIR/rsync-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/rsync-stderr-$DATE_SUFFIX.log
-
-$BAZEL_INSTALLERS_DIR/lldb-settings.sh  > $BAZEL_DIAGNOSTICS_DIR/lldb-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/lldb-stderr-$DATE_SUFFIX.log
+"$BAZEL_INSTALLERS_DIR"/lldb-settings.sh > "$BAZEL_DIAGNOSTICS_DIR"/lldb-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/lldb-stderr-"$DATE_SUFFIX".log
 
 # Part of the build intermediary output will be swiftmodule files
 # which XCode will use for indexing. Let's keep those.
-$BAZEL_INSTALLERS_DIR/swiftmodules.sh > $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stderr-$DATE_SUFFIX.log &
-$BAZEL_INSTALLERS_DIR/indexstores.sh > $BAZEL_DIAGNOSTICS_DIR/indexstores-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/indexstores-stderr-$DATE_SUFFIX.log &
-
-
+"$BAZEL_INSTALLERS_DIR"/swiftmodules.sh > "$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/indexstores.sh > "$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/installer
@@ -3,24 +3,20 @@
 # Install the runnable products so that Xcode can run it. This includes `.app`s,
 # `.xctest`s, and also command line binaries.
 
-# TODO: Lyft uses this script, because Xcode calls `ditto` on the `.swiftmodule`/`.swiftdoc` files of the top-level
-# target.
-# "$SRCROOT"/bazel/installers/xcode-artifacts.sh
-
 set -eux
 
 # Delete all logfiles that are older than 7 days
-find $BAZEL_DIAGNOSTICS_DIR -type f -atime +7d -delete
+find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 
-case ${PRODUCT_TYPE} in
+case "${PRODUCT_TYPE}" in
     com.apple.product-type.framework)
-        input="bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}"
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
         ;;
     com.apple.product-type.bundle.unit-test)
-        input="bazel-bin/$BAZEL_BIN_SUBDIR/$TARGET_NAME.__internal__.__test_bundle_archive-root/$TARGET_NAME${WRAPPER_SUFFIX:-}"
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}" "bazel-bin/$BAZEL_BIN_SUBDIR/$TARGET_NAME.__internal__.__test_bundle_archive-root/$TARGET_NAME${WRAPPER_SUFFIX:-}")
         ;;
     com.apple.product-type.application)
-        input="bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}_archive-root/Payload/$TARGET_NAME${WRAPPER_SUFFIX:-}"
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}" "bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}_archive-root/Payload/$TARGET_NAME${WRAPPER_SUFFIX:-}")
         ;;
     *)
         echo "Error: Installing ${TARGET_NAME} of type ${PRODUCT_TYPE} is unsupported" >&2
@@ -31,22 +27,29 @@ output="$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME"
 
 mkdir -p "$(dirname "$output")"
 
-if [[ -d $input ]]; then
-    # Copy bundle contents, into the destination bundle.
-    # This avoids self-nesting, like: Foo.app/Foo.app
-    input+="/"
+for input in "${input_options[@]}"; do
+    if [[ -d $input ]]; then
+        # Copy bundle contents, into the destination bundle.
+        # This avoids self-nesting, like: Foo.app/Foo.app
+        input+="/"
+    else
+        continue
+    fi
+
+    rsync \
+        --recursive --chmod=u+w --delete \
+        "$input" "$output" > "$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
+    break
+done
+
+if [[ ! -d $output ]]; then
+    echo "error: failed to find $FULL_PRODUCT_NAME in expected locations: ${input_options[*]}"
+    exit 1
 fi
 
-
-rsync \
-    --recursive --chmod=u+w --delete \
-    "$input" "$output" > $BAZEL_DIAGNOSTICS_DIR/rsync-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/rsync-stderr-$DATE_SUFFIX.log
-
-$BAZEL_INSTALLERS_DIR/lldb-settings.sh  > $BAZEL_DIAGNOSTICS_DIR/lldb-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/lldb-stderr-$DATE_SUFFIX.log
+"$BAZEL_INSTALLERS_DIR"/lldb-settings.sh > "$BAZEL_DIAGNOSTICS_DIR"/lldb-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/lldb-stderr-"$DATE_SUFFIX".log
 
 # Part of the build intermediary output will be swiftmodule files
 # which XCode will use for indexing. Let's keep those.
-$BAZEL_INSTALLERS_DIR/swiftmodules.sh > $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stderr-$DATE_SUFFIX.log &
-$BAZEL_INSTALLERS_DIR/indexstores.sh > $BAZEL_DIAGNOSTICS_DIR/indexstores-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/indexstores-stderr-$DATE_SUFFIX.log &
-
-
+"$BAZEL_INSTALLERS_DIR"/swiftmodules.sh > "$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/indexstores.sh > "$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &

--- a/tools/xcodeproj_shims/install.sh
+++ b/tools/xcodeproj_shims/install.sh
@@ -3,24 +3,20 @@
 # Install the runnable products so that Xcode can run it. This includes `.app`s,
 # `.xctest`s, and also command line binaries.
 
-# TODO: Lyft uses this script, because Xcode calls `ditto` on the `.swiftmodule`/`.swiftdoc` files of the top-level
-# target.
-# "$SRCROOT"/bazel/installers/xcode-artifacts.sh
-
 set -eux
 
 # Delete all logfiles that are older than 7 days
-find $BAZEL_DIAGNOSTICS_DIR -type f -atime +7d -delete
+find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 
-case ${PRODUCT_TYPE} in
+case "${PRODUCT_TYPE}" in
     com.apple.product-type.framework)
-        input="bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}"
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
         ;;
     com.apple.product-type.bundle.unit-test)
-        input="bazel-bin/$BAZEL_BIN_SUBDIR/$TARGET_NAME.__internal__.__test_bundle_archive-root/$TARGET_NAME${WRAPPER_SUFFIX:-}"
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}" "bazel-bin/$BAZEL_BIN_SUBDIR/$TARGET_NAME.__internal__.__test_bundle_archive-root/$TARGET_NAME${WRAPPER_SUFFIX:-}")
         ;;
     com.apple.product-type.application)
-        input="bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}_archive-root/Payload/$TARGET_NAME${WRAPPER_SUFFIX:-}"
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}" "bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}_archive-root/Payload/$TARGET_NAME${WRAPPER_SUFFIX:-}")
         ;;
     *)
         echo "Error: Installing ${TARGET_NAME} of type ${PRODUCT_TYPE} is unsupported" >&2
@@ -31,22 +27,29 @@ output="$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME"
 
 mkdir -p "$(dirname "$output")"
 
-if [[ -d $input ]]; then
-    # Copy bundle contents, into the destination bundle.
-    # This avoids self-nesting, like: Foo.app/Foo.app
-    input+="/"
+for input in "${input_options[@]}"; do
+    if [[ -d $input ]]; then
+        # Copy bundle contents, into the destination bundle.
+        # This avoids self-nesting, like: Foo.app/Foo.app
+        input+="/"
+    else
+        continue
+    fi
+
+    rsync \
+        --recursive --chmod=u+w --delete \
+        "$input" "$output" > "$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
+    break
+done
+
+if [[ ! -d $output ]]; then
+    echo "error: failed to find $FULL_PRODUCT_NAME in expected locations: ${input_options[*]}"
+    exit 1
 fi
 
-
-rsync \
-    --recursive --chmod=u+w --delete \
-    "$input" "$output" > $BAZEL_DIAGNOSTICS_DIR/rsync-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/rsync-stderr-$DATE_SUFFIX.log
-
-$BAZEL_INSTALLERS_DIR/lldb-settings.sh  > $BAZEL_DIAGNOSTICS_DIR/lldb-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/lldb-stderr-$DATE_SUFFIX.log
+"$BAZEL_INSTALLERS_DIR"/lldb-settings.sh > "$BAZEL_DIAGNOSTICS_DIR"/lldb-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/lldb-stderr-"$DATE_SUFFIX".log
 
 # Part of the build intermediary output will be swiftmodule files
 # which XCode will use for indexing. Let's keep those.
-$BAZEL_INSTALLERS_DIR/swiftmodules.sh > $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/swiftmodules-stderr-$DATE_SUFFIX.log &
-$BAZEL_INSTALLERS_DIR/indexstores.sh > $BAZEL_DIAGNOSTICS_DIR/indexstores-stdout-$DATE_SUFFIX.log 2> $BAZEL_DIAGNOSTICS_DIR/indexstores-stderr-$DATE_SUFFIX.log &
-
-
+"$BAZEL_INSTALLERS_DIR"/swiftmodules.sh > "$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/indexstores.sh > "$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &


### PR DESCRIPTION
This experimental setting has been around for 2+ years, and allows rules_apple to skip the zip archive when creating bundles, saving significantly on space used

See https://github.com/bazelbuild/rules_apple/issues/49

Also ran shellcheck over the script, and corrected the warnings (by quoting :all-the-things:)