### PR TITLE
Unique the list of indexstores and move all of them, not just the first

### DIFF
--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $BAZEL_BUILD_EVENT_TEXT_FILENAME || true`
+FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | uniq`
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
@@ -21,7 +21,7 @@ echo "Found ${#EXISTING_INDEXSTORES[@]} existing indexstores"
 
 if [ ${#EXISTING_INDEXSTORES[@]} -ne 0 ]
 then
-  "$BAZEL_INSTALLERS_DIR/_indexstore.sh" $EXISTING_INDEXSTORES
+  "$BAZEL_INSTALLERS_DIR/_indexstore.sh" ${EXISTING_INDEXSTORES[*]}
 else
   echo "No indexstores found"
 fi

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $BAZEL_BUILD_EVENT_TEXT_FILENAME || true`
+FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | uniq`
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
@@ -21,7 +21,7 @@ echo "Found ${#EXISTING_INDEXSTORES[@]} existing indexstores"
 
 if [ ${#EXISTING_INDEXSTORES[@]} -ne 0 ]
 then
-  "$BAZEL_INSTALLERS_DIR/_indexstore.sh" $EXISTING_INDEXSTORES
+  "$BAZEL_INSTALLERS_DIR/_indexstore.sh" ${EXISTING_INDEXSTORES[*]}
 else
   echo "No indexstores found"
 fi

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $BAZEL_BUILD_EVENT_TEXT_FILENAME || true`
+FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | uniq`
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
@@ -21,7 +21,7 @@ echo "Found ${#EXISTING_INDEXSTORES[@]} existing indexstores"
 
 if [ ${#EXISTING_INDEXSTORES[@]} -ne 0 ]
 then
-  "$BAZEL_INSTALLERS_DIR/_indexstore.sh" $EXISTING_INDEXSTORES
+  "$BAZEL_INSTALLERS_DIR/_indexstore.sh" ${EXISTING_INDEXSTORES[*]}
 else
   echo "No indexstores found"
 fi

--- a/tools/xcodeproj_shims/installers/indexstores.sh
+++ b/tools/xcodeproj_shims/installers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $BAZEL_BUILD_EVENT_TEXT_FILENAME || true`
+FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | uniq`
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
@@ -21,7 +21,7 @@ echo "Found ${#EXISTING_INDEXSTORES[@]} existing indexstores"
 
 if [ ${#EXISTING_INDEXSTORES[@]} -ne 0 ]
 then
-  "$BAZEL_INSTALLERS_DIR/_indexstore.sh" $EXISTING_INDEXSTORES
+  "$BAZEL_INSTALLERS_DIR/_indexstore.sh" ${EXISTING_INDEXSTORES[*]}
 else
   echo "No indexstores found"
 fi


### PR DESCRIPTION
The bazel build process generates indexstores, if the necessary index-store-path options are enabled.

The xcodeproject invokes bazel build. Then it moves the generated indexstores to the derived data directory. This fixes a bug where only the FIRST indexstore was getting moved and not the others!!!!