### PR TITLE
Hide static framework target from scheme dropdown on xcode

### DIFF
--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -273,7 +273,7 @@ $BAZEL_INSTALLER
 """.format(bazel_build_target_name = target_info.bazel_build_target_name),
             }],
         }
-        if target_info.product_type == "framework":
+        if target_info.product_type == "framework" or target_info.product_type == "framework.static":
             continue
 
         scheme_action_name = "test"


### PR DESCRIPTION
For Chartography (internal sample project) project for example, the scheme for Chartography will disappear after this change, good thing is it is still being built by the test or the actual app. 
Bad news is it is different from the xcodeproject generated by the Cocoapods. In the one by cocoapods, this scheme exists and building it will result in the framework itself being built.

It comes down to the original intention of this `continue` stmt in code, **do we hide frameworks from scheme list?** 

Also in this code: https://github.com/bazel-ios/rules_ios/blob/master/tools/xcodeproj_shims/install.sh#L11 we can see that `framework.static` won't be supported. If we add the scheme for a static framework, it will fail here nonetheless during build stage because it is not supported by bazel script.

