### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ load(
 )
 
 apple_support_dependencies()
+
+load(
+    "@com_google_protobuf//:protobuf_deps.bzl",
+    "protobuf_deps",
+)
+
+protobuf_deps()
 ```
 
 ## Examples


### PR DESCRIPTION
When trying to integrate rules_ios on some sample libraries I found that bazel would not resolve protobuf:
```
bazel build app/Foo
ERROR: /private/var/tmp/e80d0ca53a27af209c5464cd12ee433a/external/build_bazel_rules_swift/tools/worker/BUILD:19:11: error loading package '@com_google_protobuf//': Unable to find package for @rules_python//python:defs.bzl: The repository '@rules_python' could not be resolved. and referenced by '@build_bazel_rules_swift//tools/worker:compile_with_work
```
I noticed that the actual workspace loads protobuf rules so I was wondering if the readme should call this out.