### PR TITLE
Disable generation of debug info (dSYM) file by default for all xcode projects

### DIFF
--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -209,6 +209,7 @@ def _xcodeproj_impl(ctx):
         "CXX": "$CC",
         "CLANG_ANALYZER_EXEC": "$CC",
         "CODE_SIGNING_ALLOWED": False,
+        "DEBUG_INFORMATION_FORMAT": "dwarf",
         "DONT_RUN_SWIFT_STDLIB_TOOL": True,
         "LD": "$BAZEL_STUBS_DIR/ld-stub",
         "LIBTOOL": "/usr/bin/true",

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
@@ -293,6 +293,7 @@
 				CLANG_ANALYZER_EXEC = $CC;
 				CODE_SIGNING_ALLOWED = 0;
 				CXX = $CC;
+				DEBUG_INFORMATION_FORMAT = dwarf;
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
@@ -347,6 +348,7 @@
 				CLANG_ANALYZER_EXEC = $CC;
 				CODE_SIGNING_ALLOWED = 0;
 				CXX = $CC;
+				DEBUG_INFORMATION_FORMAT = dwarf;
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;

--- a/tests/macos/xcodeproj/NonArcObject.h
+++ b/tests/macos/xcodeproj/NonArcObject.h
@@ -1,2 +1,2 @@
-@interface NonArcObject
+@interface NonArcObject : NSObject
 @end

--- a/tests/macos/xcodeproj/NonArcObject.h
+++ b/tests/macos/xcodeproj/NonArcObject.h
@@ -1,2 +1,2 @@
-@interface NonArcObject : NSObject
+@interface NonArcObject
 @end

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
@@ -342,6 +342,7 @@
 				CLANG_ANALYZER_EXEC = $CC;
 				CODE_SIGNING_ALLOWED = 0;
 				CXX = $CC;
+				DEBUG_INFORMATION_FORMAT = dwarf;
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
@@ -366,6 +367,7 @@
 				CLANG_ANALYZER_EXEC = $CC;
 				CODE_SIGNING_ALLOWED = 0;
 				CXX = $CC;
+				DEBUG_INFORMATION_FORMAT = dwarf;
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
@@ -324,6 +324,7 @@
 				CLANG_ANALYZER_EXEC = $CC;
 				CODE_SIGNING_ALLOWED = 0;
 				CXX = $CC;
+				DEBUG_INFORMATION_FORMAT = dwarf;
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
@@ -398,6 +399,7 @@
 				CLANG_ANALYZER_EXEC = $CC;
 				CODE_SIGNING_ALLOWED = 0;
 				CXX = $CC;
+				DEBUG_INFORMATION_FORMAT = dwarf;
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
@@ -479,6 +479,7 @@
 				CLANG_ANALYZER_EXEC = $CC;
 				CODE_SIGNING_ALLOWED = 0;
 				CXX = $CC;
+				DEBUG_INFORMATION_FORMAT = dwarf;
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
@@ -537,6 +538,7 @@
 				CLANG_ANALYZER_EXEC = $CC;
 				CODE_SIGNING_ALLOWED = 0;
 				CXX = $CC;
+				DEBUG_INFORMATION_FORMAT = dwarf;
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;


### PR DESCRIPTION
### Why this change
For some reason instead of generating dwarf only for debug config, by default xcodeGen is specifying to generate dwarf+dSYM for all configs. Generating dsym file can take a long time for big targets, so it's time saving to disable it for now

Also we are seeing lots of warnings from `dsymutil` regarding `swiftmodule` files not found. This will turn off this warnings as well

### Additional changes
1. Fix an error during testing regarding NonArcObj not having NSObject as super class