### PR TITLE
Add local debug options as a dependency, but only if local_debug_options_enabled

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,5 +15,5 @@ build --deleted_packages tests/ios/frameworks/sources-with-prebuilt-binaries
 
 # Enable these features to test local and CI builds
 # when swiftmodule caching is enabled.
-build --features=swift.cacheable_swiftmodules
-build --features=swift.use_global_module_cache
+# build --features=swift.cacheable_swiftmodules
+# build --features=swift.use_global_module_cache

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,9 +1,19 @@
 # We can't create a bzl_library for rules-swift because of its visibility,
 # so circumvent by not using the sandbox
 build --strategy=Stardoc=standalone
+
+# Debugging does not work in sandbox mode. Uncomment these lines to turn off sandboxing.
+# build --genrule_strategy=standalone
+# build --spawn_strategy=standalone
+
 build --verbose_failures # Print the full command line for commands that failed
 build --test_output=errors # Prints log file output to the console on failure
 
-# By default do not build the tests for sources-with-prebuilt-binaries, 
+# By default do not build the tests for sources-with-prebuilt-binaries,
 # because it takes quite some time. They will only run on CI
 build --deleted_packages tests/ios/frameworks/sources-with-prebuilt-binaries
+
+# Enable these features to test local and CI builds
+# when swiftmodule caching is enabled.
+build --features=swift.cacheable_swiftmodules
+build --features=swift.use_global_module_cache

--- a/rules/BUILD.bazel
+++ b/rules/BUILD.bazel
@@ -1,4 +1,39 @@
+
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+
 exports_files(
     glob(["*.bzl"]),
     visibility = ["//docs:__pkg__"],
+)
+
+genrule(
+    name = "empty",
+    outs = ["empty.swift"],
+    cmd = "touch $(OUTS)",
+)
+
+# A dummy target that enables serialize-debugging-options but only in local development,
+# so that swiftmodule paths will refer to paths on the local machine and LLDB will work.
+swift_library(
+    name = "_LocalDebugOptions",
+    srcs = [":empty"],
+    copts = [
+            "-Xfrontend",
+            "-serialize-debugging-options",
+    ],
+    module_name = "_LocalDebugOptions",
+    tags = ["no-remote"],
+    visibility = ["//visibility:public"],
+)
+
+
+bool_flag(name = "local_debug_options_enabled", build_setting_default = False)
+
+config_setting(
+    name = "local_debug_options",
+    flag_values = {
+        ":local_debug_options_enabled": "True",
+    }
 )

--- a/rules/BUILD.bazel
+++ b/rules/BUILD.bazel
@@ -16,6 +16,7 @@ genrule(
 
 # A dummy target that enables serialize-debugging-options but only in local development,
 # so that swiftmodule paths will refer to paths on the local machine and LLDB will work.
+# See details here: https://github.com/ios-bazel-users/ios-bazel-users/blob/master/DebuggableRemoteSwift.md
 swift_library(
     name = "_LocalDebugOptions",
     srcs = [":empty"],

--- a/rules/BUILD.bazel
+++ b/rules/BUILD.bazel
@@ -1,7 +1,5 @@
-
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
-
 
 exports_files(
     glob(["*.bzl"]),
@@ -21,20 +19,25 @@ swift_library(
     name = "_LocalDebugOptions",
     srcs = [":empty"],
     copts = [
-            "-Xfrontend",
-            "-serialize-debugging-options",
+        "-Xfrontend",
+        "-serialize-debugging-options",
     ],
     module_name = "_LocalDebugOptions",
-    tags = ["no-remote"],
+    tags = [
+        "manual",
+        "no-remote",
+    ],
     visibility = ["//visibility:public"],
 )
 
-
-bool_flag(name = "local_debug_options_enabled", build_setting_default = False)
+bool_flag(
+    name = "local_debug_options_enabled",
+    build_setting_default = False,
+)
 
 config_setting(
     name = "local_debug_options",
     flag_values = {
         ":local_debug_options_enabled": "True",
-    }
+    },
 )

--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -61,9 +61,16 @@ def ios_application(name, apple_library = apple_library, **kwargs):
     application_kwargs["launch_storyboard"] = application_kwargs.pop("launch_storyboard", library.launch_screen_storyboard_name)
     application_kwargs["families"] = application_kwargs.pop("families", ["iphone", "ipad"])
 
+    local_debug_options_for_swift = []
+    if library.has_swift_sources:
+      local_debug_options_for_swift += ["@build_bazel_rules_ios//rules:_LocalDebugOptions"]
+
     rules_apple_ios_application(
         name = name,
-        deps = library.deps,
+        deps = library.deps + select({
+           "@build_bazel_rules_ios//rules:local_debug_options": local_debug_options_for_swift,
+           "//conditions:default": [],
+        }),
         infoplists = infoplists,
         **application_kwargs
     )

--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -62,14 +62,17 @@ def ios_application(name, apple_library = apple_library, **kwargs):
     application_kwargs["families"] = application_kwargs.pop("families", ["iphone", "ipad"])
 
     local_debug_options_for_swift = []
+
+    # A dummy target that enables serialize-debugging-options but only in local development.
+    # As of Xcode 11.5, LocalDebugOptions is not needed for debugging apps.
     if library.has_swift_sources:
-      local_debug_options_for_swift += ["@build_bazel_rules_ios//rules:_LocalDebugOptions"]
+        local_debug_options_for_swift.append("@build_bazel_rules_ios//rules:_LocalDebugOptions")
 
     rules_apple_ios_application(
         name = name,
         deps = library.deps + select({
-           "@build_bazel_rules_ios//rules:local_debug_options": local_debug_options_for_swift,
-           "//conditions:default": [],
+            "@build_bazel_rules_ios//rules:local_debug_options": local_debug_options_for_swift,
+            "//conditions:default": [],
         }),
         infoplists = infoplists,
         **application_kwargs

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -608,4 +608,5 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
         namespace = namespace,
         linkopts = linkopts,
         platforms = platforms,
+        has_swift_sources = (swift_sources and len(swift_sources) > 0),
     )

--- a/rules/test.bzl
+++ b/rules/test.bzl
@@ -45,7 +45,7 @@ def ios_unit_test(name, apple_library = apple_library, **kwargs):
     library = apple_library(name = name, namespace_is_module_name = False, platforms = {"ios": unit_test_kwargs.get("minimum_os_version")}, **kwargs)
 
     local_debug_options_for_swift = []
-    if library.has_swift_sources and not unit_test_kwargs.get("test_host", None):
+    if library.has_swift_sources and unit_test_kwargs.get("test_host", None) == None:
       local_debug_options_for_swift += ["@build_bazel_rules_ios//rules:_LocalDebugOptions"]
 
     rule(

--- a/rules/test.bzl
+++ b/rules/test.bzl
@@ -46,13 +46,13 @@ def ios_unit_test(name, apple_library = apple_library, **kwargs):
 
     local_debug_options_for_swift = []
     if library.has_swift_sources and unit_test_kwargs.get("test_host", None) == None:
-      local_debug_options_for_swift += ["@build_bazel_rules_ios//rules:_LocalDebugOptions"]
+        local_debug_options_for_swift.append("@build_bazel_rules_ios//rules:_LocalDebugOptions")
 
     rule(
         name = name,
         deps = library.lib_names + select({
-           "@build_bazel_rules_ios//rules:local_debug_options": local_debug_options_for_swift,
-           "//conditions:default": [],
+            "@build_bazel_rules_ios//rules:local_debug_options": local_debug_options_for_swift,
+            "//conditions:default": [],
         }),
         **unit_test_kwargs
     )

--- a/rules/test.bzl
+++ b/rules/test.bzl
@@ -44,8 +44,15 @@ def ios_unit_test(name, apple_library = apple_library, **kwargs):
 
     library = apple_library(name = name, namespace_is_module_name = False, platforms = {"ios": unit_test_kwargs.get("minimum_os_version")}, **kwargs)
 
+    local_debug_options_for_swift = []
+    if library.has_swift_sources and not unit_test_kwargs.get("test_host", None):
+      local_debug_options_for_swift += ["@build_bazel_rules_ios//rules:_LocalDebugOptions"]
+
     rule(
         name = name,
-        deps = library.lib_names,
+        deps = library.lib_names + select({
+           "@build_bazel_rules_ios//rules:local_debug_options": local_debug_options_for_swift,
+           "//conditions:default": [],
+        }),
         **unit_test_kwargs
     )

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -250,6 +250,7 @@ def _xcodeproj_impl(ctx):
     proj_settings_debug = {
         "GCC_PREPROCESSOR_DEFINITIONS": "DEBUG",
         "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+        "BAZEL_DEBUG_SYMBOLS_FLAG": "--compilation_mode=dbg"
     }
     proj_settings = {
         "base": proj_settings_base,
@@ -303,7 +304,9 @@ def _xcodeproj_impl(ctx):
             "CLANG_ENABLE_MODULES": "YES",
             "CLANG_ENABLE_OBJC_ARC": "YES",
         }
-        framework_search_paths = []
+
+        # Ensure Xcode will resolve references to the XCTest framework.
+        framework_search_paths = ["$(PLATFORM_DIR)/Developer/Library/Frameworks"]
         for fi in target_info.framework_includes.to_list():
             if fi[0] != "/":
                 fi = "$BAZEL_WORKSPACE_ROOT/%s" % fi

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -250,7 +250,7 @@ def _xcodeproj_impl(ctx):
     proj_settings_debug = {
         "GCC_PREPROCESSOR_DEFINITIONS": "DEBUG",
         "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
-        "BAZEL_DEBUG_SYMBOLS_FLAG": "--compilation_mode=dbg"
+        "BAZEL_DEBUG_SYMBOLS_FLAG": "--compilation_mode=dbg",
     }
     proj_settings = {
         "base": proj_settings_base,

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
@@ -270,7 +270,7 @@
 				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACH_O_TYPE = "$(inherited)";
@@ -284,6 +284,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BUILD_EXEC = "$BAZEL_STUBS_DIR/build-wrapper";
+				BAZEL_DEBUG_SYMBOLS_FLAG = "--compilation_mode=dbg";
 				BAZEL_INSTALLER = $BAZEL_INSTALLERS_DIR/installer;
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
@@ -313,7 +314,7 @@
 				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-cecbe3cb5ea2880cd67bf87ed1de59490130c0d897af2739d7b0f3dd10b40f24/bin/tests/ios/frameworks/objc/ObjcFramework\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-cecbe3cb5ea2880cd67bf87ed1de59490130c0d897af2739d7b0f3dd10b40f24/bin/tests/ios/frameworks/objc/ObjcFramework\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
 				MACH_O_TYPE = "$(inherited)";
@@ -329,7 +330,7 @@
 				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACH_O_TYPE = "$(inherited)";
@@ -370,7 +371,7 @@
 				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-cecbe3cb5ea2880cd67bf87ed1de59490130c0d897af2739d7b0f3dd10b40f24/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-b6e49002cb7dafa9fcd24b0dd76f1c63efbe73d59588c29fc9a7b41408f04f90/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-cecbe3cb5ea2880cd67bf87ed1de59490130c0d897af2739d7b0f3dd10b40f24/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-b6e49002cb7dafa9fcd24b0dd76f1c63efbe73d59588c29fc9a7b41408f04f90/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACH_O_TYPE = "$(inherited)";
@@ -387,7 +388,7 @@
 				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-cecbe3cb5ea2880cd67bf87ed1de59490130c0d897af2739d7b0f3dd10b40f24/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-b6e49002cb7dafa9fcd24b0dd76f1c63efbe73d59588c29fc9a7b41408f04f90/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-cecbe3cb5ea2880cd67bf87ed1de59490130c0d897af2739d7b0f3dd10b40f24/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-b6e49002cb7dafa9fcd24b0dd76f1c63efbe73d59588c29fc9a7b41408f04f90/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACH_O_TYPE = "$(inherited)";
@@ -404,7 +405,7 @@
 				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-cecbe3cb5ea2880cd67bf87ed1de59490130c0d897af2739d7b0f3dd10b40f24/bin/tests/ios/frameworks/objc/ObjcFramework\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-cecbe3cb5ea2880cd67bf87ed1de59490130c0d897af2739d7b0f3dd10b40f24/bin/tests/ios/frameworks/objc/ObjcFramework\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
 				MACH_O_TYPE = "$(inherited)";

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
@@ -284,7 +284,7 @@
 				BAZEL_BIN_SUBDIR = /tests/macos/xcodeproj;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "\"REQUIRED_DEFINED_FLAG=1\" \"FLAG_WITH_VALUE_ZERO=0\" $(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MACH_O_TYPE = "$(inherited)";
@@ -301,7 +301,7 @@
 				BAZEL_BIN_SUBDIR = /rules/test_host_app;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = "$BAZEL_STUBS_DIR/Info-stub.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -319,7 +319,7 @@
 				BAZEL_BIN_SUBDIR = /rules/test_host_app;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = "$BAZEL_STUBS_DIR/Info-stub.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -335,6 +335,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BUILD_EXEC = "$BAZEL_STUBS_DIR/build-wrapper";
+				BAZEL_DEBUG_SYMBOLS_FLAG = "--compilation_mode=dbg";
 				BAZEL_INSTALLER = $BAZEL_INSTALLERS_DIR/installer;
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
@@ -389,7 +390,7 @@
 				BAZEL_BIN_SUBDIR = /tests/macos/xcodeproj;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "\"REQUIRED_DEFINED_FLAG=1\" \"FLAG_WITH_VALUE_ZERO=0\" $(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MACH_O_TYPE = "$(inherited)";
@@ -406,7 +407,7 @@
 				BAZEL_BIN_SUBDIR = /tests/macos/xcodeproj;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "\"REQUIRED_DEFINED_FLAG=1\" \"FLAG_WITH_VALUE_ZERO=0\" $(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MACH_O_TYPE = "$(inherited)";
@@ -423,7 +424,7 @@
 				BAZEL_BIN_SUBDIR = /tests/macos/xcodeproj;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "\"REQUIRED_DEFINED_FLAG=1\" \"FLAG_WITH_VALUE_ZERO=0\" $(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MACH_O_TYPE = "$(inherited)";

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
@@ -284,7 +284,7 @@
 				BAZEL_BIN_SUBDIR = /tests/macos/xcodeproj;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "\"REQUIRED_DEFINED_FLAG=1\" \"FLAG_WITH_VALUE_ZERO=0\" $(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MACH_O_TYPE = "$(inherited)";
@@ -301,7 +301,7 @@
 				BAZEL_BIN_SUBDIR = /tests/macos/xcodeproj;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "\"REQUIRED_DEFINED_FLAG=1\" \"FLAG_WITH_VALUE_ZERO=0\" $(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MACH_O_TYPE = "$(inherited)";
@@ -343,7 +343,7 @@
 				BAZEL_BIN_SUBDIR = /rules/test_host_app;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = "$BAZEL_STUBS_DIR/Info-stub.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -361,7 +361,7 @@
 				BAZEL_BIN_SUBDIR = /rules/test_host_app;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = "$BAZEL_STUBS_DIR/Info-stub.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -379,7 +379,7 @@
 				BAZEL_BIN_SUBDIR = /tests/macos/xcodeproj;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "\"REQUIRED_DEFINED_FLAG=1\" \"FLAG_WITH_VALUE_ZERO=0\" $(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MACH_O_TYPE = "$(inherited)";
@@ -394,6 +394,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BUILD_EXEC = "$BAZEL_STUBS_DIR/build-wrapper";
+				BAZEL_DEBUG_SYMBOLS_FLAG = "--compilation_mode=dbg";
 				BAZEL_INSTALLER = $BAZEL_INSTALLERS_DIR/installer;
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
@@ -423,7 +424,7 @@
 				BAZEL_BIN_SUBDIR = /tests/macos/xcodeproj;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "\"REQUIRED_DEFINED_FLAG=1\" \"FLAG_WITH_VALUE_ZERO=0\" $(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MACH_O_TYPE = "$(inherited)";

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
@@ -386,7 +386,7 @@
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-f22bcf18950e92551e6bc2e43803228c8d15233d48c88265af0229927f68339f/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-f22bcf18950e92551e6bc2e43803228c8d15233d48c88265af0229927f68339f/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACH_O_TYPE = "$(inherited)";
@@ -404,7 +404,7 @@
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-f22bcf18950e92551e6bc2e43803228c8d15233d48c88265af0229927f68339f/bin/tests/ios/unit-test/test-imports-app/SomeFramework\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-f22bcf18950e92551e6bc2e43803228c8d15233d48c88265af0229927f68339f/bin/tests/ios/unit-test/test-imports-app/SomeFramework\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = "$BAZEL_STUBS_DIR/Info-stub.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -422,7 +422,7 @@
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-f22bcf18950e92551e6bc2e43803228c8d15233d48c88265af0229927f68339f/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-f22bcf18950e92551e6bc2e43803228c8d15233d48c88265af0229927f68339f/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACH_O_TYPE = "$(inherited)";
@@ -440,7 +440,7 @@
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACH_O_TYPE = "$(inherited)";
@@ -458,7 +458,7 @@
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-f22bcf18950e92551e6bc2e43803228c8d15233d48c88265af0229927f68339f/bin/tests/ios/unit-test/test-imports-app/SomeFramework\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-f22bcf18950e92551e6bc2e43803228c8d15233d48c88265af0229927f68339f/bin/tests/ios/unit-test/test-imports-app/SomeFramework\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = "$BAZEL_STUBS_DIR/Info-stub.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -501,7 +501,7 @@
 				BAZEL_BIN_SUBDIR = /rules/test_host_app;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = "$BAZEL_STUBS_DIR/Info-stub.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
@@ -519,7 +519,7 @@
 				BAZEL_BIN_SUBDIR = /rules/test_host_app;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = "$BAZEL_STUBS_DIR/Info-stub.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
@@ -535,6 +535,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BUILD_EXEC = "$BAZEL_STUBS_DIR/build-wrapper";
+				BAZEL_DEBUG_SYMBOLS_FLAG = "--compilation_mode=dbg";
 				BAZEL_INSTALLER = $BAZEL_INSTALLERS_DIR/installer;
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
@@ -564,7 +565,7 @@
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACH_O_TYPE = "$(inherited)";

--- a/tests/macos/xcodeproj/build.sh
+++ b/tests/macos/xcodeproj/build.sh
@@ -5,3 +5,4 @@ cd $(dirname $0)
 xcodebuild -project Single-Application-Project-DirectTargetsOnly.xcodeproj -quiet
 xcodebuild -project Single-Application-Project-AllTargets.xcodeproj -quiet
 xcodebuild -project Test-Target-With-Test-Host-Project.xcodeproj -quiet
+# TODO: use strings to test that absolute paths and debug-prefix-map are present in the LocalDebug.swiftmodule. Not sure if this is the right palce to do it. We could also grep out the build event text file maybe.

--- a/tests/macos/xcodeproj/build.sh
+++ b/tests/macos/xcodeproj/build.sh
@@ -5,4 +5,3 @@ cd $(dirname $0)
 xcodebuild -project Single-Application-Project-DirectTargetsOnly.xcodeproj -quiet
 xcodebuild -project Single-Application-Project-AllTargets.xcodeproj -quiet
 xcodebuild -project Test-Target-With-Test-Host-Project.xcodeproj -quiet
-# TODO: use strings to test that absolute paths and debug-prefix-map are present in the LocalDebug.swiftmodule. Not sure if this is the right palce to do it. We could also grep out the build event text file maybe.

--- a/tools/xcodeproj_shims/build-wrapper.sh
+++ b/tools/xcodeproj_shims/build-wrapper.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 set -euxo pipefail
 
-$BAZEL_PATH build --experimental_execution_log_file=$BAZEL_BUILD_EXECUTION_LOG_FILENAME --build_event_text_file=$BAZEL_BUILD_EVENT_TEXT_FILENAME --build_event_publish_all_actions $1 --@build_bazel_rules_ios//rules:local_debug_options_enabled 2>&1 | $BAZEL_OUTPUT_PROCESSOR
+# TODO: If the target is being built from the rules_ios repo, then remove the `@build_bazel_rules_ios`
+# prefix to the `local_debug_options_enabled` build flag
+$BAZEL_PATH build --experimental_execution_log_file=$BAZEL_BUILD_EXECUTION_LOG_FILENAME --build_event_text_file=$BAZEL_BUILD_EVENT_TEXT_FILENAME --build_event_publish_all_actions $1 --@build_bazel_rules_ios//rules:local_debug_options_enabled $BAZEL_DEBUG_SYMBOLS_FLAG 2>&1 | $BAZEL_OUTPUT_PROCESSOR

--- a/tools/xcodeproj_shims/build-wrapper.sh
+++ b/tools/xcodeproj_shims/build-wrapper.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euxo pipefail
 
-$BAZEL_PATH build --experimental_execution_log_file=$BAZEL_BUILD_EXECUTION_LOG_FILENAME --build_event_text_file=$BAZEL_BUILD_EVENT_TEXT_FILENAME --build_event_publish_all_actions $1 2>&1 | $BAZEL_OUTPUT_PROCESSOR
+$BAZEL_PATH build --experimental_execution_log_file=$BAZEL_BUILD_EXECUTION_LOG_FILENAME --build_event_text_file=$BAZEL_BUILD_EVENT_TEXT_FILENAME --build_event_publish_all_actions $1 --@build_bazel_rules_ios//rules:local_debug_options_enabled 2>&1 | $BAZEL_OUTPUT_PROCESSOR


### PR DESCRIPTION
Only do this if local_debug_options_enabled is specified at command line. Make xcode specify this config.

The changes in this PR are taken from the suggested changes in https://github.com/ios-bazel-users/ios-bazel-users/blob/master/DebuggableRemoteSwift.md to get debugging working.

Note that in order for the example applications and tests in the rules_ios repo to be debuggable from Xcode, you must:
1. Disable sandboxing in .bazelrc.
2. Update the flag in the tools/xcodeproj_shims/build-wrapper.sh to refer to `--//rules:local_debug_options_enabled` rather than `--@build_bazel_rules_ios//rules:local_debug_options_enabled`

There are still known issues with evaluating variables from the debugger for swift tests.