### PR TITLE
Bump rules apple part 1: unpin xctestrunner

### DIFF
--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -47,10 +47,10 @@ def rules_ios_dependencies():
     _maybe(
         github_repo,
         name = "build_bazel_rules_apple",
-        ref = "eadfa72e26dd8b459038dc83fc440759daff65c6",
+        ref = "12ac0738c56f8a15c714a7e09ec87a1bbdbcada9",
         project = "bazelbuild",
         repo = "rules_apple",
-        #sha256 = "3100977922a83c71742ab38cd433e8878e3692d8106a8107126c59e3ca6e50f3",
+        sha256 = "60db0889ce9593ed2e6de513beb59770b9dbc122f6dcb68d5d49379e85c4b374",
     )
 
     _maybe(

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -3,7 +3,6 @@
 load(
     "@bazel_tools//tools/build_defs/repo:http.bzl",
     "http_archive",
-    "http_file",
 )
 
 def _maybe(repo_rule, name, **kwargs):
@@ -51,7 +50,7 @@ def rules_ios_dependencies():
         ref = "eadfa72e26dd8b459038dc83fc440759daff65c6",
         project = "bazelbuild",
         repo = "rules_apple",
-        sha256 = "be2e2e26d85dff61d4f9ae11e74be656a231389629474b39db887baa407a6f7d",
+        #sha256 = "3100977922a83c71742ab38cd433e8878e3692d8106a8107126c59e3ca6e50f3",
     )
 
     _maybe(
@@ -118,14 +117,4 @@ native_binary(
         sha256 = "6c2e212e2dd8000e5cb35aadc772d58d411924d8484f9946f6653aa50e613d31",
         strip_prefix = "xcodegen",
         urls = ["https://github.com/yonaskolb/XcodeGen/releases/download/2.16.0/xcodegen.zip"],
-    )
-
-    # Pinned because 0.2.12 is broken on macOS 10.14
-    # https://github.com/google/xctestrunner/issues/18
-    _maybe(
-        http_file,
-        name = "xctestrunner",
-        executable = 1,
-        sha256 = "9e46d5782a9dc7d40bc93c99377c091886c180b8c4ffb9f79a19a58e234cdb09",
-        urls = ["https://github.com/google/xctestrunner/releases/download/0.2.10/ios_test_runner.par"],
     )


### PR DESCRIPTION
### Why this change
Since the rules_apple we point via the commit has pointed to xctestrunner 0.2.13, which contains fix for pointing to explicit python 2.7 version (instead of just py2), we should be able to go ahead and unpin the xctestrunner version.

This is just part 1 because the rules_apple we point to is not the latest, what is blocking this is a new migration from `whitelist_function_transition` to `allow_list_transition` that is under `bazel_tools`: see this commit: https://github.com/bazelbuild/rules_apple/commit/c283c82941e9f7e58f5176b68850e6a91b68e956

### Tests
Existing tests is enough, also tested against downstream projects

### Next step
try to point to latest commit of rules_apple, this means we need to bump bazel version. This will be coordinated in future ticket.