### PR TITLE
Force swift local debug option to be turned on so that framework search path has correct payload after project is built

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,3 +17,6 @@ build --deleted_packages tests/ios/frameworks/sources-with-prebuilt-binaries
 # when swiftmodule caching is enabled.
 # build --features=swift.cacheable_swiftmodules
 # build --features=swift.use_global_module_cache
+
+# Match this with the flag used in build-wrapper.sh
+build --compilation_mode=dbg

--- a/.bazelrc
+++ b/.bazelrc
@@ -18,6 +18,3 @@ build --deleted_packages tests/ios/frameworks/sources-with-prebuilt-binaries
 # build --features=swift.cacheable_swiftmodules
 # build --features=swift.use_global_module_cache
 
-# Match this with the flag used in build-wrapper.sh
-build --compilation_mode=dbg
-

--- a/.bazelrc
+++ b/.bazelrc
@@ -20,3 +20,4 @@ build --deleted_packages tests/ios/frameworks/sources-with-prebuilt-binaries
 
 # Match this with the flag used in build-wrapper.sh
 build --compilation_mode=dbg
+

--- a/.bazelrc
+++ b/.bazelrc
@@ -17,4 +17,3 @@ build --deleted_packages tests/ios/frameworks/sources-with-prebuilt-binaries
 # when swiftmodule caching is enabled.
 # build --features=swift.cacheable_swiftmodules
 # build --features=swift.use_global_module_cache
-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Generate Xcode projects and compare against existing record
         run: |
           set -euo pipefail
+          bazelisk clean
           bazelisk query 'kind(xcodeproj, tests/macos/xcodeproj/...)' | xargs -n 1 bazelisk run
           bazelisk query 'attr(executable, 1, kind(genrule, tests/macos/xcodeproj/...))' | xargs -n 1 bazelisk run
           git diff --exit-code tests/macos/xcodeproj
@@ -64,10 +65,15 @@ jobs:
       - name: Generate Xcode projects and compare against existing record
         run: |
           set -euo pipefail
+          bazelisk clean
           bazelisk query 'kind(xcodeproj, tests/ios/xcodeproj/...)' | xargs -n 1 bazelisk run
           bazelisk query 'attr(executable, 1, kind(genrule, tests/ios/xcodeproj/...))' | xargs -n 1 bazelisk run
           git diff --exit-code tests/ios/xcodeproj
+      - name: Run pre build checks
+        run: ./tests/ios/xcodeproj/pre_build_check.sh
       - name: Run Xcode builds
         run: ./tests/ios/xcodeproj/build.sh
+      - name: Run post build checks
+        run: ./tests/ios/xcodeproj/post_build_check.sh
       - name: Run Unit tests
         run: ./tests/ios/xcodeproj/tests.sh

--- a/rules/transition_support.bzl
+++ b/rules/transition_support.bzl
@@ -118,7 +118,23 @@ _apple_rule_transition = transition(
     ],
 )
 
+def _xcodeproj_rule_transition_impl(settings, attr):
+    _ignore = (settings, attr)
+    return [
+        {"@build_bazel_rules_ios//rules:local_debug_options_enabled": True},
+    ]
+
+
+_xcodeproj_rule_transition = transition(
+    implementation=_xcodeproj_rule_transition_impl,
+    inputs=[],
+    outputs=[
+        "@build_bazel_rules_ios//rules:local_debug_options_enabled"
+    ]
+)
+
 transition_support = struct(
-    apple_rule_transition = _apple_rule_transition,
-    current_apple_platform = _current_apple_platform,
+    apple_rule_transition=_apple_rule_transition,
+    current_apple_platform=_current_apple_platform,
+    xcodeproj_rule_transition=_xcodeproj_rule_transition,
 )

--- a/rules/transition_support.bzl
+++ b/rules/transition_support.bzl
@@ -118,14 +118,14 @@ _apple_rule_transition = transition(
     ],
 )
 
-def _xcodeproj_rule_transition_impl(settings, attr):
+def _force_swift_local_debug_options_transition_impl(settings, attr):
     _ignore = (settings, attr)
     return [
         {"@build_bazel_rules_ios//rules:local_debug_options_enabled": True},
     ]
 
-_xcodeproj_rule_transition = transition(
-    implementation = _xcodeproj_rule_transition_impl,
+_force_swift_local_debug_options_transition = transition(
+    implementation = _force_swift_local_debug_options_transition_impl,
     inputs = [],
     outputs = [
         "@build_bazel_rules_ios//rules:local_debug_options_enabled",
@@ -135,5 +135,5 @@ _xcodeproj_rule_transition = transition(
 transition_support = struct(
     apple_rule_transition = _apple_rule_transition,
     current_apple_platform = _current_apple_platform,
-    xcodeproj_rule_transition = _xcodeproj_rule_transition,
+    force_swift_local_debug_options_transition = _force_swift_local_debug_options_transition,
 )

--- a/rules/transition_support.bzl
+++ b/rules/transition_support.bzl
@@ -124,17 +124,16 @@ def _xcodeproj_rule_transition_impl(settings, attr):
         {"@build_bazel_rules_ios//rules:local_debug_options_enabled": True},
     ]
 
-
 _xcodeproj_rule_transition = transition(
-    implementation=_xcodeproj_rule_transition_impl,
-    inputs=[],
-    outputs=[
-        "@build_bazel_rules_ios//rules:local_debug_options_enabled"
-    ]
+    implementation = _xcodeproj_rule_transition_impl,
+    inputs = [],
+    outputs = [
+        "@build_bazel_rules_ios//rules:local_debug_options_enabled",
+    ],
 )
 
 transition_support = struct(
-    apple_rule_transition=_apple_rule_transition,
-    current_apple_platform=_current_apple_platform,
-    xcodeproj_rule_transition=_xcodeproj_rule_transition,
+    apple_rule_transition = _apple_rule_transition,
+    current_apple_platform = _current_apple_platform,
+    xcodeproj_rule_transition = _xcodeproj_rule_transition,
 )

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -282,6 +282,7 @@ def _xcodeproj_impl(ctx):
         "BAZEL_BUILD_EXEC": "$BAZEL_STUBS_DIR/build-wrapper",
         "BAZEL_OUTPUT_PROCESSOR": "$BAZEL_STUBS_DIR/output-processor.rb",
         "BAZEL_PATH": ctx.attr.bazel_path,
+        "BAZEL_RULES_IOS_OPTIONS": "--@build_bazel_rules_ios//rules:local_debug_options_enabled",
         "BAZEL_WORKSPACE_ROOT": "$SRCROOT/%s" % script_dot_dots,
         "BAZEL_STUBS_DIR": "$PROJECT_FILE_PATH/bazelstubs",
         "BAZEL_INSTALLERS_DIR": "$PROJECT_FILE_PATH/bazelinstallers",

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -302,7 +302,6 @@ def _xcodeproj_impl(ctx):
     proj_settings_debug = {
         "GCC_PREPROCESSOR_DEFINITIONS": "DEBUG",
         "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
-        "BAZEL_DEBUG_SYMBOLS_FLAG": "--compilation_mode=dbg",
     }
     proj_settings = {
         "base": proj_settings_base,

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -2,6 +2,7 @@ load("@build_bazel_rules_apple//apple:providers.bzl", "AppleBundleInfo")
 load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//rules:hmap.bzl", "HeaderMapInfo")
+load("//rules:transition_support.bzl", "transition_support")
 
 def _get_attr_values_for_name(deps, provider, field):
     return [
@@ -526,6 +527,7 @@ $BAZEL_INSTALLER
 
 xcodeproj = rule(
     implementation = _xcodeproj_impl,
+    cfg = transition_support.xcodeproj_rule_transition,
     attrs = {
         "deps": attr.label_list(mandatory = True, allow_empty = False, providers = [], aspects = [_xcodeproj_aspect]),
         "include_transitive_targets": attr.bool(default = False, mandatory = False),
@@ -546,6 +548,10 @@ xcodeproj = rule(
         "installer": attr.label(executable = True, default = Label("//tools/xcodeproj_shims:installer"), cfg = "host"),
         "build_wrapper": attr.label(executable = True, default = Label("//tools/xcodeproj_shims:build-wrapper"), cfg = "host"),
         "additional_files": attr.label_list(allow_files = True, allow_empty = True, default = [], mandatory = False),
+        "_whitelist_function_transition": attr.label(
+            default = "@build_bazel_rules_apple//tools/whitelists/function_transition_whitelist",
+            doc = "Needed to allow this rule to have an incoming edge configuration transition.",
+        ),
     },
     executable = True,
 )

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -527,7 +527,7 @@ $BAZEL_INSTALLER
 
 xcodeproj = rule(
     implementation = _xcodeproj_impl,
-    cfg = transition_support.xcodeproj_rule_transition,
+    cfg = transition_support.force_swift_local_debug_options_transition,
     attrs = {
         "deps": attr.label_list(mandatory = True, allow_empty = False, providers = [], aspects = [_xcodeproj_aspect]),
         "include_transitive_targets": attr.bool(default = False, mandatory = False),

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
@@ -272,7 +272,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACH_O_TYPE = "$(inherited)";
 				PRODUCT_NAME = ObjcFramework;
@@ -285,7 +285,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BUILD_EXEC = "$BAZEL_STUBS_DIR/build-wrapper";
-				BAZEL_DEBUG_SYMBOLS_FLAG = "--compilation_mode=dbg";
 				BAZEL_INSTALLER = $BAZEL_INSTALLERS_DIR/installer;
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
@@ -316,9 +315,9 @@
 				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
 				MACH_O_TYPE = "$(inherited)";
 				PRODUCT_NAME = ObjcFrameworkTestLib;
@@ -335,7 +334,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACH_O_TYPE = "$(inherited)";
 				PRODUCT_NAME = ObjcFramework;
@@ -376,7 +375,7 @@
 				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
@@ -394,7 +393,7 @@
 				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
@@ -412,9 +411,9 @@
 				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
 				MACH_O_TYPE = "$(inherited)";
 				PRODUCT_NAME = ObjcFrameworkTestLib;

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
@@ -272,7 +272,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-cecbe3cb5ea2880cd67bf87ed1de59490130c0d897af2739d7b0f3dd10b40f24/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-cecbe3cb5ea2880cd67bf87ed1de59490130c0d897af2739d7b0f3dd10b40f24/bin/tests/ios/frameworks/objc/ObjcFramework_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-cecbe3cb5ea2880cd67bf87ed1de59490130c0d897af2739d7b0f3dd10b40f24/bin/tests/ios/frameworks/objc/ObjcFramework_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACH_O_TYPE = "$(inherited)";
 				PRODUCT_NAME = ObjcFramework;
@@ -290,6 +290,7 @@
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 				CC = "$BAZEL_STUBS_DIR/clang-stub";
@@ -315,9 +316,9 @@
 				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-cecbe3cb5ea2880cd67bf87ed1de59490130c0d897af2739d7b0f3dd10b40f24/bin/tests/ios/frameworks/objc/ObjcFramework\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-b6e49002cb7dafa9fcd24b0dd76f1c63efbe73d59588c29fc9a7b41408f04f90/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-b6e49002cb7dafa9fcd24b0dd76f1c63efbe73d59588c29fc9a7b41408f04f90/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-b6e49002cb7dafa9fcd24b0dd76f1c63efbe73d59588c29fc9a7b41408f04f90/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
 				MACH_O_TYPE = "$(inherited)";
 				PRODUCT_NAME = ObjcFrameworkTestLib;
@@ -334,7 +335,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-cecbe3cb5ea2880cd67bf87ed1de59490130c0d897af2739d7b0f3dd10b40f24/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-cecbe3cb5ea2880cd67bf87ed1de59490130c0d897af2739d7b0f3dd10b40f24/bin/tests/ios/frameworks/objc/ObjcFramework_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-cecbe3cb5ea2880cd67bf87ed1de59490130c0d897af2739d7b0f3dd10b40f24/bin/tests/ios/frameworks/objc/ObjcFramework_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACH_O_TYPE = "$(inherited)";
 				PRODUCT_NAME = ObjcFramework;
@@ -351,6 +352,7 @@
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 				CC = "$BAZEL_STUBS_DIR/clang-stub";
@@ -374,7 +376,7 @@
 				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-cecbe3cb5ea2880cd67bf87ed1de59490130c0d897af2739d7b0f3dd10b40f24/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-b6e49002cb7dafa9fcd24b0dd76f1c63efbe73d59588c29fc9a7b41408f04f90/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
@@ -392,7 +394,7 @@
 				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-cecbe3cb5ea2880cd67bf87ed1de59490130c0d897af2739d7b0f3dd10b40f24/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-b6e49002cb7dafa9fcd24b0dd76f1c63efbe73d59588c29fc9a7b41408f04f90/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
@@ -410,9 +412,9 @@
 				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-cecbe3cb5ea2880cd67bf87ed1de59490130c0d897af2739d7b0f3dd10b40f24/bin/tests/ios/frameworks/objc/ObjcFramework\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5d7c870816a1308920f53f7c45f65d480b6cd2451ad80050b3b8463330f8102d/bin/tests/ios/frameworks/objc/ObjcFramework\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-b6e49002cb7dafa9fcd24b0dd76f1c63efbe73d59588c29fc9a7b41408f04f90/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-b6e49002cb7dafa9fcd24b0dd76f1c63efbe73d59588c29fc9a7b41408f04f90/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-b6e49002cb7dafa9fcd24b0dd76f1c63efbe73d59588c29fc9a7b41408f04f90/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-006753303a9ce8dc092bd0aaee4e68b70ebc0961995143f84a46be022751c3c0/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
 				MACH_O_TYPE = "$(inherited)";
 				PRODUCT_NAME = ObjcFrameworkTestLib;

--- a/tests/ios/xcodeproj/build.sh
+++ b/tests/ios/xcodeproj/build.sh
@@ -2,17 +2,6 @@ set -eux
 
 cd $(dirname $0)
 
-export HEADER_SERACH_PATHS=`grep "HEADER_SEARCH_PATHS" *.xcodeproj/project.pbxproj | grep -o  "bazel-out\S*\.hmap"`
-
-echo "Ensure hmap files do not exist (or remove if they do)"
-for path in ${HEADER_SERACH_PATHS}; do
-    FULL_PATH="../../../$path"
-    if [ -f $FULL_PATH ]; then
-        rm $FULL_PATH;
-        echo "Removed file at $FULL_PATH"; 
-    fi
-done
-
 # Make sure there are simulators avilable as destinations
 xcrun simctl list
 
@@ -20,12 +9,3 @@ export PROJECT_AND_SCHEME="-project Single-Static-Framework-Project.xcodeproj -s
 export SIM_DEVICE_ID=`xcodebuild $PROJECT_AND_SCHEME -showdestinations | grep "platform:iOS Sim" | head -1 | ruby -e "puts STDIN.read.split(',')[1].split(':').last"`
 
 xcodebuild $PROJECT_AND_SCHEME -destination "id=$SIM_DEVICE_ID" -quiet 
-
-echo "Make sure hmap files exist after build"
-for path in ${HEADER_SERACH_PATHS}; do
-    FULL_PATH="../../../$path"
-    if [ ! -f $FULL_PATH ]; then
-        echo "File at $FULL_PATH not found!";
-        exit 1; 
-    fi
-done

--- a/tests/ios/xcodeproj/build.sh
+++ b/tests/ios/xcodeproj/build.sh
@@ -2,6 +2,17 @@ set -eux
 
 cd $(dirname $0)
 
+export HEADER_SERACH_PATHS=`grep "HEADER_SEARCH_PATHS" *.xcodeproj/project.pbxproj | grep -o  "bazel-out\S*\.hmap"`
+
+echo "Ensure hmap files do not exist (or remove if they do)"
+for path in ${HEADER_SERACH_PATHS}; do
+    FULL_PATH="../../../$path"
+    if [ -f $FULL_PATH ]; then
+        rm $FULL_PATH;
+        echo "Removed file at $FULL_PATH"; 
+    fi
+done
+
 # Make sure there are simulators avilable as destinations
 xcrun simctl list
 
@@ -9,3 +20,12 @@ export PROJECT_AND_SCHEME="-project Single-Static-Framework-Project.xcodeproj -s
 export SIM_DEVICE_ID=`xcodebuild $PROJECT_AND_SCHEME -showdestinations | grep "platform:iOS Sim" | head -1 | ruby -e "puts STDIN.read.split(',')[1].split(':').last"`
 
 xcodebuild $PROJECT_AND_SCHEME -destination "id=$SIM_DEVICE_ID" -quiet 
+
+echo "Make sure hmap files exist after build"
+for path in ${HEADER_SERACH_PATHS}; do
+    FULL_PATH="../../../$path"
+    if [ ! -f $FULL_PATH ]; then
+        echo "File at $FULL_PATH not found!";
+        exit 1; 
+    fi
+done

--- a/tests/ios/xcodeproj/post_build_check.sh
+++ b/tests/ios/xcodeproj/post_build_check.sh
@@ -1,0 +1,13 @@
+set -eux
+
+cd $(dirname $0)
+
+export HEADER_SERACH_PATHS=`grep "HEADER_SEARCH_PATHS" *.xcodeproj/project.pbxproj | grep -o  "bazel-out\S*\.hmap"`
+echo "Make sure hmap files exist after build"
+for path in ${HEADER_SERACH_PATHS}; do
+    FULL_PATH="../../../$path"
+    if [ ! -f $FULL_PATH ]; then
+        echo "File at $FULL_PATH not found!";
+        exit 1; 
+    fi
+done

--- a/tests/ios/xcodeproj/pre_build_check.sh
+++ b/tests/ios/xcodeproj/pre_build_check.sh
@@ -1,0 +1,15 @@
+set -eux
+
+cd $(dirname $0)
+
+export HEADER_SERACH_PATHS=`grep "HEADER_SEARCH_PATHS" *.xcodeproj/project.pbxproj | grep -o  "bazel-out\S*\.hmap"`
+
+echo "Ensure hmap files do not exist (remove if they do)"
+for path in ${HEADER_SERACH_PATHS}; do
+    FULL_PATH="../../../$path"
+    if [ -f $FULL_PATH ]; then
+        rm $FULL_PATH;
+        echo "Removed file at $FULL_PATH"; 
+    fi
+done
+

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
@@ -338,7 +338,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BUILD_EXEC = "$BAZEL_STUBS_DIR/build-wrapper";
-				BAZEL_DEBUG_SYMBOLS_FLAG = "--compilation_mode=dbg";
 				BAZEL_INSTALLER = $BAZEL_INSTALLERS_DIR/installer;
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
@@ -343,6 +343,7 @@
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 				CC = "$BAZEL_STUBS_DIR/clang-stub";
@@ -370,6 +371,7 @@
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 				CC = "$BAZEL_STUBS_DIR/clang-stub";

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
@@ -322,6 +322,7 @@
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 				CC = "$BAZEL_STUBS_DIR/clang-stub";
@@ -404,6 +405,7 @@
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 				CC = "$BAZEL_STUBS_DIR/clang-stub";

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
@@ -400,7 +400,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BUILD_EXEC = "$BAZEL_STUBS_DIR/build-wrapper";
-				BAZEL_DEBUG_SYMBOLS_FLAG = "--compilation_mode=dbg";
 				BAZEL_INSTALLER = $BAZEL_INSTALLERS_DIR/installer;
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
@@ -386,7 +386,7 @@
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-f22bcf18950e92551e6bc2e43803228c8d15233d48c88265af0229927f68339f/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-b8411baab8ff49a269ea6eecbae660d0d7e666287b9fda7540f6697eee077121/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -405,7 +405,7 @@
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-f22bcf18950e92551e6bc2e43803228c8d15233d48c88265af0229927f68339f/bin/tests/ios/unit-test/test-imports-app/SomeFramework\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-b8411baab8ff49a269ea6eecbae660d0d7e666287b9fda7540f6697eee077121/bin/tests/ios/unit-test/test-imports-app/SomeFramework\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				INFOPLIST_FILE = "$BAZEL_STUBS_DIR/Info-stub.plist";
@@ -424,7 +424,7 @@
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-f22bcf18950e92551e6bc2e43803228c8d15233d48c88265af0229927f68339f/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-b8411baab8ff49a269ea6eecbae660d0d7e666287b9fda7540f6697eee077121/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -462,7 +462,7 @@
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-f22bcf18950e92551e6bc2e43803228c8d15233d48c88265af0229927f68339f/bin/tests/ios/unit-test/test-imports-app/SomeFramework\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-b8411baab8ff49a269ea6eecbae660d0d7e666287b9fda7540f6697eee077121/bin/tests/ios/unit-test/test-imports-app/SomeFramework\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				INFOPLIST_FILE = "$BAZEL_STUBS_DIR/Info-stub.plist";
@@ -483,6 +483,7 @@
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 				CC = "$BAZEL_STUBS_DIR/clang-stub";
@@ -547,6 +548,7 @@
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 				CC = "$BAZEL_STUBS_DIR/clang-stub";

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
@@ -386,7 +386,7 @@
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-b8411baab8ff49a269ea6eecbae660d0d7e666287b9fda7540f6697eee077121/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-b8411baab8ff49a269ea6eecbae660d0d7e666287b9fda7540f6697eee077121/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -405,7 +405,7 @@
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-b8411baab8ff49a269ea6eecbae660d0d7e666287b9fda7540f6697eee077121/bin/tests/ios/unit-test/test-imports-app/SomeFramework\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-b8411baab8ff49a269ea6eecbae660d0d7e666287b9fda7540f6697eee077121/bin/tests/ios/unit-test/test-imports-app/SomeFramework\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				INFOPLIST_FILE = "$BAZEL_STUBS_DIR/Info-stub.plist";
@@ -424,7 +424,7 @@
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-b8411baab8ff49a269ea6eecbae660d0d7e666287b9fda7540f6697eee077121/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-b8411baab8ff49a269ea6eecbae660d0d7e666287b9fda7540f6697eee077121/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -462,7 +462,7 @@
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-b8411baab8ff49a269ea6eecbae660d0d7e666287b9fda7540f6697eee077121/bin/tests/ios/unit-test/test-imports-app/SomeFramework\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-b8411baab8ff49a269ea6eecbae660d0d7e666287b9fda7540f6697eee077121/bin/tests/ios/unit-test/test-imports-app/SomeFramework\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				INFOPLIST_FILE = "$BAZEL_STUBS_DIR/Info-stub.plist";
@@ -543,7 +543,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BUILD_EXEC = "$BAZEL_STUBS_DIR/build-wrapper";
-				BAZEL_DEBUG_SYMBOLS_FLAG = "--compilation_mode=dbg";
 				BAZEL_INSTALLER = $BAZEL_INSTALLERS_DIR/installer;
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";

--- a/tools/xcodeproj_shims/build-wrapper.sh
+++ b/tools/xcodeproj_shims/build-wrapper.sh
@@ -6,5 +6,5 @@ $BAZEL_PATH build \
 --build_event_text_file=$BAZEL_BUILD_EVENT_TEXT_FILENAME \
 --build_event_publish_all_actions $1 \
 $BAZEL_RULES_IOS_OPTIONS \
-$BAZEL_DEBUG_SYMBOLS_FLAG 2>&1 \
+2>&1 \
 | $BAZEL_OUTPUT_PROCESSOR

--- a/tools/xcodeproj_shims/build-wrapper.sh
+++ b/tools/xcodeproj_shims/build-wrapper.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euxo pipefail
 
-# TODO: If the target is being built from the rules_ios repo, then remove the `@build_bazel_rules_ios`
-# prefix to the `local_debug_options_enabled` build flag
-$BAZEL_PATH build --experimental_execution_log_file=$BAZEL_BUILD_EXECUTION_LOG_FILENAME --build_event_text_file=$BAZEL_BUILD_EVENT_TEXT_FILENAME --build_event_publish_all_actions $1 --@build_bazel_rules_ios//rules:local_debug_options_enabled $BAZEL_DEBUG_SYMBOLS_FLAG 2>&1 | $BAZEL_OUTPUT_PROCESSOR
+$BAZEL_PATH build \
+--experimental_execution_log_file=$BAZEL_BUILD_EXECUTION_LOG_FILENAME \
+--build_event_text_file=$BAZEL_BUILD_EVENT_TEXT_FILENAME \
+--build_event_publish_all_actions $1 \
+$BAZEL_RULES_IOS_OPTIONS \
+$BAZEL_DEBUG_SYMBOLS_FLAG 2>&1 \
+| $BAZEL_OUTPUT_PROCESSOR

--- a/tools/xcodeproj_shims/build-wrapper.sh
+++ b/tools/xcodeproj_shims/build-wrapper.sh
@@ -2,9 +2,9 @@
 set -euxo pipefail
 
 $BAZEL_PATH build \
---experimental_execution_log_file=$BAZEL_BUILD_EXECUTION_LOG_FILENAME \
---build_event_text_file=$BAZEL_BUILD_EVENT_TEXT_FILENAME \
---build_event_publish_all_actions $1 \
-$BAZEL_RULES_IOS_OPTIONS \
-2>&1 \
-| $BAZEL_OUTPUT_PROCESSOR
+    --experimental_execution_log_file=$BAZEL_BUILD_EXECUTION_LOG_FILENAME \
+    --build_event_text_file=$BAZEL_BUILD_EVENT_TEXT_FILENAME \
+    --build_event_publish_all_actions $1 \
+    $BAZEL_RULES_IOS_OPTIONS \
+    2>&1 \
+    | $BAZEL_OUTPUT_PROCESSOR


### PR DESCRIPTION
### Why this change
With the change introduced in https://github.com/bazel-ios/rules_ios/pull/98, when bazel builds behind the scene (inside 1build-wrapper1), it will generates one that enables swift to be debuggable. However the framework search paths generated during the xcodeproj generation stage (`bazel run some_xcodeprojec_rule`) will generate a different configuration cache than the one generated by bazel build (since inside build wrapper there are additional flags: 1. compilation mode and 2. local_debug_option)
As evidenced by the test fixture changes, the search paths are changed in this PR because 
1. 1compilation_mode1 is set to debug to match with when xcode builds under debug config (not release config, so under release this is still broken)
2. `local_debug_option` is set to True for both xcode proj rule (through transition) and inside build-wrapper

The direct effect is that the framework search path is now pointing at the correct location.

### Known issue:
Release config won't work with this change because compilation mode for debug is only set for Debug config, wondering if we should just have Release config pointing to `compilation_mode = dbg` too since the expectation is that ppl use release config under xcode is because they want to test the behaviors of the MACROS? 

### Tests
1. Existing fixtures
2. TODO: add a step after xcodebuild to verify that each framework specified under framework search path and header search path can be all found