### PR TITLE
Fix how xcdatamodel is represented under generated xcodeproj 

### DIFF
--- a/rules/library/resources.bzl
+++ b/rules/library/resources.bzl
@@ -56,7 +56,7 @@ or `resources` in an `apple_resource_bundle`.
 
 def wrap_resources_in_filegroup(name, srcs, extensions_to_filter = [], **kwargs):
     extensions_to_filter = list(extensions_to_filter)
-    for x in ("xcdatamodeld", "xcmappingmodel", "xcassets"):
+    for x in ("xcdatamodeld", "xcdatamodel", "xcmappingmodel", "xcassets"):
         if x not in extensions_to_filter:
             extensions_to_filter.append(x)
     resources_filegroup(

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -113,8 +113,8 @@ native_binary(
     visibility = ["//visibility:public"],
 )
 """,
-        canonical_id = "xcodegen-2.16.0",
-        sha256 = "6c2e212e2dd8000e5cb35aadc772d58d411924d8484f9946f6653aa50e613d31",
+        canonical_id = "xcodegen-2.17.0",
+        sha256 = "6d1e4a8617e7d13910366c25d1e3ab475158e91e3071cb17f44e3ea29c9a1a41",
         strip_prefix = "xcodegen",
-        urls = ["https://github.com/yonaskolb/XcodeGen/releases/download/2.16.0/xcodegen.zip"],
+        urls = ["https://github.com/yonaskolb/XcodeGen/releases/download/2.17.0/xcodegen.zip"],
     )

--- a/tests/ios/unit-test/test-imports-app/BUILD.bazel
+++ b/tests/ios/unit-test/test-imports-app/BUILD.bazel
@@ -22,6 +22,10 @@ ios_application(
     bundle_id = "com.example.TestImports-App",
     minimum_os_version = "12.0",
     module_name = "TestImports_App",
+    resource_bundles = {"ResourceBundle": glob(
+        ["Resources/**/*"],
+        exclude_directories = 0,
+    )},
     sdk_frameworks = ["UIKit"],
     visibility = ["//visibility:public"],
     deps = [

--- a/tests/ios/unit-test/test-imports-app/Resources/TestModel.xcdatamodel/contents
+++ b/tests/ios/unit-test/test-imports-app/Resources/TestModel.xcdatamodel/contents
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="15508" systemVersion="19G2021" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Entity" representedClassName="Entity" syncable="YES" codeGenerationType="class">
+        <attribute name="test1" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="test2" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+    </entity>
+    <elements>
+        <element name="Entity" positionX="-45" positionY="0" width="128" height="73"/>
+    </elements>
+</model>

--- a/tests/ios/unit-test/test-imports-app/Resources/TestModel2.xcdatamodel/contents
+++ b/tests/ios/unit-test/test-imports-app/Resources/TestModel2.xcdatamodel/contents
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="15508" systemVersion="19G2021" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Entity" representedClassName="Entity" syncable="YES" codeGenerationType="class">
+        <attribute name="bar2" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="foo2" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <elements>
+        <element name="Entity" positionX="-36" positionY="9" width="128" height="73"/>
+    </elements>
+</model>

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.pbxproj
@@ -26,10 +26,13 @@
 /* Begin PBXFileReference section */
 		034C629FFD4FA9DFBC427161 /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = "../unit-test/test-imports-app/BUILD.bazel"; sourceTree = "<group>"; };
 		2C080011EC2F624D38C590D3 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = main.m; path = "../unit-test/test-imports-app/main.m"; sourceTree = "<group>"; };
+		4B218D3B14EACFE8F6D1A7D9 /* TestModel2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; name = TestModel2.xcdatamodel; path = "../unit-test/test-imports-app/Resources/TestModel2.xcdatamodel"; sourceTree = "<group>"; };
 		4C00C28DA12F127AC0AE1387 /* test.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = test.m; path = "../unit-test/test-imports-app/test.m"; sourceTree = "<group>"; };
 		58E87329BAD4527D85639045 /* common.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = common.pch; path = ../../../rules/library/common.pch; sourceTree = "<group>"; };
+		7658664DBA198AB4F6A9633C /* resource_bundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = resource_bundle.plist; path = ../../../rules/library/resource_bundle.plist; sourceTree = "<group>"; };
 		C5EE49718CB8070C38416B64 /* empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = empty.swift; path = "../unit-test/test-imports-app/empty.swift"; sourceTree = "<group>"; };
 		C73857A1D91F761A1128A896 /* Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Header.h; path = "../unit-test/test-imports-app/Header.h"; sourceTree = "<group>"; };
+		DF561348FD5E569AB21F7F3D /* TestModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; name = TestModel.xcdatamodel; path = "../unit-test/test-imports-app/Resources/TestModel.xcdatamodel"; sourceTree = "<group>"; };
 		E6411D3FC8114DF5DE33DABC /* Header2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Header2.h; path = "../unit-test/test-imports-app/Header2.h"; sourceTree = "<group>"; };
 		EC730E57A94AE56443A8D68E /* TestImports-App.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "TestImports-App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EFFCD75973B790B8428EF9E7 /* test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = test.swift; path = "../unit-test/test-imports-app/test.swift"; sourceTree = "<group>"; };
@@ -74,6 +77,7 @@
 			isa = PBXGroup;
 			children = (
 				58E87329BAD4527D85639045 /* common.pch */,
+				7658664DBA198AB4F6A9633C /* resource_bundle.plist */,
 			);
 			name = library;
 			sourceTree = "<group>";
@@ -103,10 +107,20 @@
 				C73857A1D91F761A1128A896 /* Header.h */,
 				E6411D3FC8114DF5DE33DABC /* Header2.h */,
 				2C080011EC2F624D38C590D3 /* main.m */,
+				EB86E0720942E17186A84231 /* Resources */,
 				4C00C28DA12F127AC0AE1387 /* test.m */,
 				EFFCD75973B790B8428EF9E7 /* test.swift */,
 			);
 			name = "test-imports-app";
+			sourceTree = "<group>";
+		};
+		EB86E0720942E17186A84231 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				DF561348FD5E569AB21F7F3D /* TestModel.xcdatamodel */,
+				4B218D3B14EACFE8F6D1A7D9 /* TestModel2.xcdatamodel */,
+			);
+			name = Resources;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
@@ -43,12 +43,14 @@
 		2238C255CB7ED2E848A7FC51 /* common.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = common.pch; path = ../../../rules/library/common.pch; sourceTree = "<group>"; };
 		2263A980666D293D7413BE92 /* test.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = test.m; path = "../../ios/unit-test/test-imports-app/test.m"; sourceTree = "<group>"; };
 		246AA4985E50044D3CD8228A /* test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = test.swift; path = "../../ios/unit-test/test-imports-app/test.swift"; sourceTree = "<group>"; };
+		29A682D26AECECF5058D991B /* TestModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; name = TestModel.xcdatamodel; path = "../../ios/unit-test/test-imports-app/Resources/TestModel.xcdatamodel"; sourceTree = "<group>"; };
 		300321A84FA667D38500A4EE /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = ../../../rules/test_host_app/BUILD.bazel; sourceTree = "<group>"; };
 		31B65EED0A5FCC9038424593 /* empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = empty.swift; path = "../../ios/unit-test/empty.swift"; sourceTree = "<group>"; };
 		36C5066BFCF7F5E1A169E184 /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = "../../ios/unit-test/BUILD.bazel"; sourceTree = "<group>"; };
 		61CE3CBBAD0BFAFC0953377B /* TestImports-App.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "TestImports-App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6725F1A1E5A5BAFC1EE01F00 /* Header2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Header2.h; path = "../../ios/unit-test/test-imports-app/Header2.h"; sourceTree = "<group>"; };
 		9E7E8177A9991D407C446EF6 /* TestImports-Unit-Tests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = "TestImports-Unit-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B07BC976C01F7FFC817868EC /* TestModel2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; name = TestModel2.xcdatamodel; path = "../../ios/unit-test/test-imports-app/Resources/TestModel2.xcdatamodel"; sourceTree = "<group>"; };
 		BC8493575E7FDD7052346981 /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = "../../ios/unit-test/test-imports-app/BUILD.bazel"; sourceTree = "<group>"; };
 		BCDD3D2387B5DA5045A0D600 /* Contents.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = Contents.json; path = ../../../rules/test_host_app/AssetCatalogFixture.xcassets/Contents.json; sourceTree = "<group>"; };
 		CD38E215541F1766D3CAFBEE /* ios.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = ios.entitlements; path = ../../../rules/test_host_app/ios.entitlements; sourceTree = "<group>"; };
@@ -64,6 +66,15 @@
 				0E1A2D407EDFADA150631F26 /* resource_bundle.plist */,
 			);
 			name = library;
+			sourceTree = "<group>";
+		};
+		04C2FDC1FEE0E4D66A74C119 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				29A682D26AECECF5058D991B /* TestModel.xcdatamodel */,
+				B07BC976C01F7FFC817868EC /* TestModel2.xcdatamodel */,
+			);
+			name = Resources;
 			sourceTree = "<group>";
 		};
 		41BE2FF5579DA46E599A01EC /* Products */ = {
@@ -85,6 +96,7 @@
 				08D20BAAC5B1A41903E13B27 /* Header.h */,
 				6725F1A1E5A5BAFC1EE01F00 /* Header2.h */,
 				0C55810C4D90EF86058DB06A /* main.m */,
+				04C2FDC1FEE0E4D66A74C119 /* Resources */,
 				2263A980666D293D7413BE92 /* test.m */,
 				246AA4985E50044D3CD8228A /* test.swift */,
 			);


### PR DESCRIPTION
### Why this change
If one revert just the changes in xcodeproj.bzl and regenerate the newly added "Simple-iOS-App-Project" target under bazel and open the `Simple-iOS-App-Project.xcodeproj`, you will see that the .xcdatamodel or .xcdatamodeld is not presented correctly under the project:

This change simply detect such special directory and choose to only add the directory itself (nothing underneath) so that XCode will present the, correctly (see screenshots). The current version feature for data model is also tested in this PR.

Also updated to latest version of xcodegen to pick up latest improvements

### What's not in this PR
Not concrete test on whether the project will compile and read datamodel. Also we for sure knows that just adding the xcdatamodel to xcode directly won't work as bazel side does not pick that up.

### Screenshots
Before:
<img width="252" alt="Screen Shot 2020-08-27 at 2 38 23 PM" src="https://user-images.githubusercontent.com/493722/91481819-08846980-e873-11ea-9a44-1c80690409a8.png">
After: 
<img width="291" alt="Screen Shot 2020-08-27 at 2 38 03 PM" src="https://user-images.githubusercontent.com/493722/91481836-0cb08700-e873-11ea-9a36-561ab5abb967.png">
