### PR TITLE
Fix bad query from framework causing disk-wasting rsync operation

### DIFF
--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/install.sh
@@ -23,6 +23,10 @@ case "${PRODUCT_TYPE}" in
         #  } 
         # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
         QUERY=`grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///"`
+        if [[ -z $QUERY ]]; then
+            echo "Error: failed to locate resource for static framework of ${TARGET_NAME}" >&2
+            exit 1
+        fi
         input_options=($(dirname "${QUERY}"))
         ;;
     com.apple.product-type.bundle.unit-test)

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/install.sh
@@ -23,8 +23,8 @@ case "${PRODUCT_TYPE}" in
         #  } 
         # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
         QUERY=`grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///"`
-        if [[ -z $QUERY ]]; then
-            echo "Error: failed to locate resource for static framework of ${TARGET_NAME}" >&2
+        if [[ -z $QUERY ]]; then 
+            echo "Unable to locate resource for framework of ${TARGET_NAME}"
             exit 1
         fi
         input_options=($(dirname "${QUERY}"))
@@ -45,6 +45,11 @@ output="$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME"
 mkdir -p "$(dirname "$output")"
 
 for input in "${input_options[@]}"; do
+    if [[ -z $input ]] || [ $input = "." ] || [ $input = "/" ]; then
+        # rsync can be a dangerous operation when it tries to copy entire root dir into the $output
+        echo "Error: illegal input for installing ${TARGET_NAME} of type ${PRODUCT_TYPE}" >&2
+        exit 1
+    fi
     if [[ -d $input ]]; then
         # Copy bundle contents, into the destination bundle.
         # This avoids self-nesting, like: Foo.app/Foo.app

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/installer
@@ -23,6 +23,10 @@ case "${PRODUCT_TYPE}" in
         #  } 
         # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
         QUERY=`grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///"`
+        if [[ -z $QUERY ]]; then
+            echo "Error: failed to locate resource for static framework of ${TARGET_NAME}" >&2
+            exit 1
+        fi
         input_options=($(dirname "${QUERY}"))
         ;;
     com.apple.product-type.bundle.unit-test)

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/installer
@@ -23,8 +23,8 @@ case "${PRODUCT_TYPE}" in
         #  } 
         # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
         QUERY=`grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///"`
-        if [[ -z $QUERY ]]; then
-            echo "Error: failed to locate resource for static framework of ${TARGET_NAME}" >&2
+        if [[ -z $QUERY ]]; then 
+            echo "Unable to locate resource for framework of ${TARGET_NAME}"
             exit 1
         fi
         input_options=($(dirname "${QUERY}"))
@@ -45,6 +45,11 @@ output="$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME"
 mkdir -p "$(dirname "$output")"
 
 for input in "${input_options[@]}"; do
+    if [[ -z $input ]] || [ $input = "." ] || [ $input = "/" ]; then
+        # rsync can be a dangerous operation when it tries to copy entire root dir into the $output
+        echo "Error: illegal input for installing ${TARGET_NAME} of type ${PRODUCT_TYPE}" >&2
+        exit 1
+    fi
     if [[ -d $input ]]; then
         # Copy bundle contents, into the destination bundle.
         # This avoids self-nesting, like: Foo.app/Foo.app

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/install.sh
@@ -23,6 +23,10 @@ case "${PRODUCT_TYPE}" in
         #  } 
         # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
         QUERY=`grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///"`
+        if [[ -z $QUERY ]]; then
+            echo "Error: failed to locate resource for static framework of ${TARGET_NAME}" >&2
+            exit 1
+        fi
         input_options=($(dirname "${QUERY}"))
         ;;
     com.apple.product-type.bundle.unit-test)

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/install.sh
@@ -23,8 +23,8 @@ case "${PRODUCT_TYPE}" in
         #  } 
         # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
         QUERY=`grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///"`
-        if [[ -z $QUERY ]]; then
-            echo "Error: failed to locate resource for static framework of ${TARGET_NAME}" >&2
+        if [[ -z $QUERY ]]; then 
+            echo "Unable to locate resource for framework of ${TARGET_NAME}"
             exit 1
         fi
         input_options=($(dirname "${QUERY}"))
@@ -45,6 +45,11 @@ output="$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME"
 mkdir -p "$(dirname "$output")"
 
 for input in "${input_options[@]}"; do
+    if [[ -z $input ]] || [ $input = "." ] || [ $input = "/" ]; then
+        # rsync can be a dangerous operation when it tries to copy entire root dir into the $output
+        echo "Error: illegal input for installing ${TARGET_NAME} of type ${PRODUCT_TYPE}" >&2
+        exit 1
+    fi
     if [[ -d $input ]]; then
         # Copy bundle contents, into the destination bundle.
         # This avoids self-nesting, like: Foo.app/Foo.app

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/installer
@@ -23,6 +23,10 @@ case "${PRODUCT_TYPE}" in
         #  } 
         # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
         QUERY=`grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///"`
+        if [[ -z $QUERY ]]; then
+            echo "Error: failed to locate resource for static framework of ${TARGET_NAME}" >&2
+            exit 1
+        fi
         input_options=($(dirname "${QUERY}"))
         ;;
     com.apple.product-type.bundle.unit-test)

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/installer
@@ -23,8 +23,8 @@ case "${PRODUCT_TYPE}" in
         #  } 
         # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
         QUERY=`grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///"`
-        if [[ -z $QUERY ]]; then
-            echo "Error: failed to locate resource for static framework of ${TARGET_NAME}" >&2
+        if [[ -z $QUERY ]]; then 
+            echo "Unable to locate resource for framework of ${TARGET_NAME}"
             exit 1
         fi
         input_options=($(dirname "${QUERY}"))
@@ -45,6 +45,11 @@ output="$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME"
 mkdir -p "$(dirname "$output")"
 
 for input in "${input_options[@]}"; do
+    if [[ -z $input ]] || [ $input = "." ] || [ $input = "/" ]; then
+        # rsync can be a dangerous operation when it tries to copy entire root dir into the $output
+        echo "Error: illegal input for installing ${TARGET_NAME} of type ${PRODUCT_TYPE}" >&2
+        exit 1
+    fi
     if [[ -d $input ]]; then
         # Copy bundle contents, into the destination bundle.
         # This avoids self-nesting, like: Foo.app/Foo.app

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/install.sh
@@ -23,6 +23,10 @@ case "${PRODUCT_TYPE}" in
         #  } 
         # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
         QUERY=`grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///"`
+        if [[ -z $QUERY ]]; then
+            echo "Error: failed to locate resource for static framework of ${TARGET_NAME}" >&2
+            exit 1
+        fi
         input_options=($(dirname "${QUERY}"))
         ;;
     com.apple.product-type.bundle.unit-test)

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/install.sh
@@ -23,8 +23,8 @@ case "${PRODUCT_TYPE}" in
         #  } 
         # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
         QUERY=`grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///"`
-        if [[ -z $QUERY ]]; then
-            echo "Error: failed to locate resource for static framework of ${TARGET_NAME}" >&2
+        if [[ -z $QUERY ]]; then 
+            echo "Unable to locate resource for framework of ${TARGET_NAME}"
             exit 1
         fi
         input_options=($(dirname "${QUERY}"))
@@ -45,6 +45,11 @@ output="$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME"
 mkdir -p "$(dirname "$output")"
 
 for input in "${input_options[@]}"; do
+    if [[ -z $input ]] || [ $input = "." ] || [ $input = "/" ]; then
+        # rsync can be a dangerous operation when it tries to copy entire root dir into the $output
+        echo "Error: illegal input for installing ${TARGET_NAME} of type ${PRODUCT_TYPE}" >&2
+        exit 1
+    fi
     if [[ -d $input ]]; then
         # Copy bundle contents, into the destination bundle.
         # This avoids self-nesting, like: Foo.app/Foo.app

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/installer
@@ -23,6 +23,10 @@ case "${PRODUCT_TYPE}" in
         #  } 
         # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
         QUERY=`grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///"`
+        if [[ -z $QUERY ]]; then
+            echo "Error: failed to locate resource for static framework of ${TARGET_NAME}" >&2
+            exit 1
+        fi
         input_options=($(dirname "${QUERY}"))
         ;;
     com.apple.product-type.bundle.unit-test)

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/installer
@@ -23,8 +23,8 @@ case "${PRODUCT_TYPE}" in
         #  } 
         # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
         QUERY=`grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///"`
-        if [[ -z $QUERY ]]; then
-            echo "Error: failed to locate resource for static framework of ${TARGET_NAME}" >&2
+        if [[ -z $QUERY ]]; then 
+            echo "Unable to locate resource for framework of ${TARGET_NAME}"
             exit 1
         fi
         input_options=($(dirname "${QUERY}"))
@@ -45,6 +45,11 @@ output="$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME"
 mkdir -p "$(dirname "$output")"
 
 for input in "${input_options[@]}"; do
+    if [[ -z $input ]] || [ $input = "." ] || [ $input = "/" ]; then
+        # rsync can be a dangerous operation when it tries to copy entire root dir into the $output
+        echo "Error: illegal input for installing ${TARGET_NAME} of type ${PRODUCT_TYPE}" >&2
+        exit 1
+    fi
     if [[ -d $input ]]; then
         # Copy bundle contents, into the destination bundle.
         # This avoids self-nesting, like: Foo.app/Foo.app

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/install.sh
@@ -23,6 +23,10 @@ case "${PRODUCT_TYPE}" in
         #  } 
         # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
         QUERY=`grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///"`
+        if [[ -z $QUERY ]]; then
+            echo "Error: failed to locate resource for static framework of ${TARGET_NAME}" >&2
+            exit 1
+        fi
         input_options=($(dirname "${QUERY}"))
         ;;
     com.apple.product-type.bundle.unit-test)

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/install.sh
@@ -23,8 +23,8 @@ case "${PRODUCT_TYPE}" in
         #  } 
         # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
         QUERY=`grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///"`
-        if [[ -z $QUERY ]]; then
-            echo "Error: failed to locate resource for static framework of ${TARGET_NAME}" >&2
+        if [[ -z $QUERY ]]; then 
+            echo "Unable to locate resource for framework of ${TARGET_NAME}"
             exit 1
         fi
         input_options=($(dirname "${QUERY}"))
@@ -45,6 +45,11 @@ output="$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME"
 mkdir -p "$(dirname "$output")"
 
 for input in "${input_options[@]}"; do
+    if [[ -z $input ]] || [ $input = "." ] || [ $input = "/" ]; then
+        # rsync can be a dangerous operation when it tries to copy entire root dir into the $output
+        echo "Error: illegal input for installing ${TARGET_NAME} of type ${PRODUCT_TYPE}" >&2
+        exit 1
+    fi
     if [[ -d $input ]]; then
         # Copy bundle contents, into the destination bundle.
         # This avoids self-nesting, like: Foo.app/Foo.app

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/installer
@@ -23,6 +23,10 @@ case "${PRODUCT_TYPE}" in
         #  } 
         # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
         QUERY=`grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///"`
+        if [[ -z $QUERY ]]; then
+            echo "Error: failed to locate resource for static framework of ${TARGET_NAME}" >&2
+            exit 1
+        fi
         input_options=($(dirname "${QUERY}"))
         ;;
     com.apple.product-type.bundle.unit-test)

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/installer
@@ -23,8 +23,8 @@ case "${PRODUCT_TYPE}" in
         #  } 
         # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
         QUERY=`grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///"`
-        if [[ -z $QUERY ]]; then
-            echo "Error: failed to locate resource for static framework of ${TARGET_NAME}" >&2
+        if [[ -z $QUERY ]]; then 
+            echo "Unable to locate resource for framework of ${TARGET_NAME}"
             exit 1
         fi
         input_options=($(dirname "${QUERY}"))
@@ -45,6 +45,11 @@ output="$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME"
 mkdir -p "$(dirname "$output")"
 
 for input in "${input_options[@]}"; do
+    if [[ -z $input ]] || [ $input = "." ] || [ $input = "/" ]; then
+        # rsync can be a dangerous operation when it tries to copy entire root dir into the $output
+        echo "Error: illegal input for installing ${TARGET_NAME} of type ${PRODUCT_TYPE}" >&2
+        exit 1
+    fi
     if [[ -d $input ]]; then
         # Copy bundle contents, into the destination bundle.
         # This avoids self-nesting, like: Foo.app/Foo.app

--- a/tools/xcodeproj_shims/install.sh
+++ b/tools/xcodeproj_shims/install.sh
@@ -23,6 +23,10 @@ case "${PRODUCT_TYPE}" in
         #  } 
         # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
         QUERY=`grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///"`
+        if [[ -z $QUERY ]]; then
+            echo "Error: failed to locate resource for static framework of ${TARGET_NAME}" >&2
+            exit 1
+        fi
         input_options=($(dirname "${QUERY}"))
         ;;
     com.apple.product-type.bundle.unit-test)

--- a/tools/xcodeproj_shims/install.sh
+++ b/tools/xcodeproj_shims/install.sh
@@ -23,8 +23,8 @@ case "${PRODUCT_TYPE}" in
         #  } 
         # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
         QUERY=`grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///"`
-        if [[ -z $QUERY ]]; then
-            echo "Error: failed to locate resource for static framework of ${TARGET_NAME}" >&2
+        if [[ -z $QUERY ]]; then 
+            echo "Unable to locate resource for framework of ${TARGET_NAME}"
             exit 1
         fi
         input_options=($(dirname "${QUERY}"))
@@ -45,6 +45,11 @@ output="$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME"
 mkdir -p "$(dirname "$output")"
 
 for input in "${input_options[@]}"; do
+    if [[ -z $input ]] || [ $input = "." ] || [ $input = "/" ]; then
+        # rsync can be a dangerous operation when it tries to copy entire root dir into the $output
+        echo "Error: illegal input for installing ${TARGET_NAME} of type ${PRODUCT_TYPE}" >&2
+        exit 1
+    fi
     if [[ -d $input ]]; then
         # Copy bundle contents, into the destination bundle.
         # This avoids self-nesting, like: Foo.app/Foo.app


### PR DESCRIPTION
### What happened
In this PR (https://github.com/bazel-ios/rules_ios/pull/93/files) a change is added to installer script to obtain path to framework as input and copy it over to another location. However since `rsync` can be a dangerous operation where it might try to copy entire disk or root dir over to another location, it's important to do some basic sanity checks.
This PR introduced such basic checks, please suggest some better ways to validate the input. Also given that current problem arises from framework's `QUERY`, it has a strict check of `not empty` so that in future dev can figure out which target broke this sanity check

###Priority
High