### PR TITLE
New tag to help ignore targets, also checks to make sure no target overwrite with different type

### DIFF
--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -73,6 +73,8 @@ def _xcodeproj_aspect_impl(target, ctx):
     deps = []
     deps += getattr(ctx.rule.attr, "deps", [])
     deps += getattr(ctx.rule.attr, "infoplists", [])
+    tags = getattr(ctx.rule.attr, "tags", [])
+
     entitlements = getattr(ctx.rule.attr, "entitlements", None)
     if entitlements:
         deps.append(entitlements)
@@ -132,6 +134,7 @@ def _xcodeproj_aspect_impl(target, ctx):
             env_vars = env_vars,
             hmap_paths = depset([], transitive = _get_attr_values_for_name(deps, _SrcsInfo, "hmap_paths")),
             commandline_args = commandline_args,
+            tags = tags,
         )
         if ctx.rule.kind != "apple_framework_packaging":
             providers.append(
@@ -323,6 +326,8 @@ def _xcodeproj_impl(ctx):
     xcodeproj_schemes_by_name = {}
 
     for target_info in targets:
+        if "xcodeproj-ignore-as-target" in target_info.tags:
+            continue
         target_macho_type = "staticlib" if target_info.product_type == "framework" else "$(inherited)"
         compiled_sources = [{
             "path": paths.join(src_dot_dots, s.short_path),

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -340,9 +340,10 @@ def _xcodeproj_impl(ctx):
             if target_info.product_type != existing_type:
                 fail("""\
 Failed to generate xcodeproj for "{}" due to conflicting targets:
-Target "{}" is defined with type "{}", but a same-name target of type "{}" wants to override.
+Target "{}" is already defined with type "{}". 
+A same-name target with label "{}" of type "{}" wants to override.
 Double check your rule declaration for naming or add `xcodeproj-ignore-as-target` as a tag to choose which target to ignore.
-""".format(ctx.label, target_name, existing_type, target_info.product_type))
+""".format(ctx.label, target_name, existing_type, target_info.bazel_build_target_name, target_info.product_type))
 
         target_macho_type = "staticlib" if target_info.product_type == "framework" else "$(inherited)"
         compiled_sources = [{
@@ -549,7 +550,7 @@ $BAZEL_INSTALLER
 xcodeproj = rule(
     implementation = _xcodeproj_impl,
     doc = """\
-Generates a XCode project file (.xcodeproj) with a reasonable set of defaults
+Generates a Xcode project file (.xcodeproj) with a reasonable set of defaults
 Tags for configuration:
     xcodeproj-ignore-as-target: Add this to a rule declaration so that this rule will not generates a scheme for this target
 """,

--- a/tests/ios/unit-test/test-imports-app/BUILD.bazel
+++ b/tests/ios/unit-test/test-imports-app/BUILD.bazel
@@ -23,6 +23,7 @@ ios_application(
     minimum_os_version = "12.0",
     module_name = "TestImports_App",
     sdk_frameworks = ["UIKit"],
+    visibility = ["//visibility:public"],
     deps = [
         ":SomeFramework",
     ],
@@ -37,7 +38,12 @@ apple_framework_packaging(
         "ios": "12.0",
     },
     skip_packaging = ["binary"],
+    tags = [
+        "manual",
+        "xcodeproj-ignore-as-target",
+    ],
     transitive_deps = [],
+    visibility = ["//visibility:public"],
     deps = [
         ":TestImports-App_objc",
         ":TestImports-App_swift",

--- a/tests/ios/xcodeproj/BUILD.bazel
+++ b/tests/ios/xcodeproj/BUILD.bazel
@@ -11,6 +11,18 @@ xcodeproj(
     ],
 )
 
+xcodeproj(
+    name = "Test-Imports-App-Project",
+    testonly = True,
+    bazel_path = "bazelisk",
+    include_transitive_targets = False,
+    deps = [
+        "//tests/ios/unit-test/test-imports-app:TestImports-App",
+        "//tests/ios/unit-test/test-imports-app:TestImports-App_framework_unlinked",
+        "//tests/ios/unit-test/test-imports-app:TestImports-Unit-Tests",
+    ],
+)
+
 genrule(
     name = "Test-Project-Regeneration",
     testonly = True,

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Import Bazel built indexstores into Xcode. See https://github.com/lyft/index-import
+#
+# This makes use of a number of Xcode's provided environment variables. These
+# file remappings are not specific to this project, the apply to all projects
+# built with Bazel and rules_swift.
+
+# Example: /private/var/tmp/_bazel_<username>/<hash>/execroot/<workspacename>
+readonly bazel_root="^/private/var/tmp/_bazel_.+?/.+?/execroot/[^/]+"
+readonly bazel_bin="^(?:$bazel_root/)?bazel-out/.+?/bin"
+
+# Object file paths are fundamental to how Xcode loads from the indexstore. If
+# the `OutputFile` does not match what Xcode looks for, then those parts of the
+# indexstore will not be found and used.
+readonly bazel_swift_object="$bazel_bin/.*/(.+?)(?:_swift)?_objs/.*/(.+?)[.]swift[.]o$"
+readonly bazel_objc_object="$bazel_bin/.*/_objs/(?:arc/|non_arc/)?(.+?)-(?:objc|cpp)/(.+?)[.]o$"
+readonly xcode_object="$CONFIGURATION_TEMP_DIR/\$1.build/Objects-normal/$ARCHS/\$2.o"
+
+# Bazel built `.swiftmodule` files are copied to `DerivedData`. Since modules
+# are referenced by indexstores, their paths are remapped.
+readonly bazel_module="$bazel_bin/.*/(.+?)[.]swiftmodule$"
+readonly xcode_module="$BUILT_PRODUCTS_DIR/\$1.swiftmodule/$ARCHS.swiftmodule"
+
+# External dependencies are available via the `bazel-<workspacename>` symlink.
+# This remapping, in combination with `xcode-index-preferences.json`, enables
+# index features for external dependencies, such as jump-to-definition.
+readonly bazel_external="$bazel_root/external"
+readonly xcode_external="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$SRCROOT")/external"
+
+
+$BAZEL_INSTALLERS_DIR/index-import \
+    -remap "$bazel_module=$xcode_module" \
+    -remap "$bazel_swift_object=$xcode_object" \
+    -remap "$bazel_objc_object=$xcode_object" \
+    -remap "$bazel_external=$xcode_external" \
+    -remap "$bazel_root=$BAZEL_WORKSPACE_ROOT" \
+    -remap "^([^//])=$BAZEL_WORKSPACE_ROOT/\$1" \
+    "$@" \
+    "$BUILD_DIR"/../../Index/DataStore

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/_swiftmodule.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/_swiftmodule.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+for module in "$@"; do
+    doc="${module%.swiftmodule}.swiftdoc"
+    module_name=$(basename "$module")
+    module_bundle="$BUILT_PRODUCTS_DIR/$module_name"
+    mkdir -p "$module_bundle"
+
+    cp "$module" "$module_bundle/$NATIVE_ARCH_ACTUAL.swiftmodule"
+    cp "$doc" "$module_bundle/$NATIVE_ARCH_ACTUAL.swiftdoc"
+
+    ios_module_name="$NATIVE_ARCH_ACTUAL-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
+    cp "$module" "$module_bundle/$ios_module_name.swiftmodule"
+    cp "$doc" "$module_bundle/$ios_module_name.swiftdoc"
+
+    chmod -R +w "$module_bundle"
+done

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# See `_indexstore.sh` for full details.
+
+echo "Start remapping index files at `date`"
+
+FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | uniq`
+
+declare -a EXISTING_INDEXSTORES=()
+for i in $FOUND_INDEXSTORES
+do
+  if [ -d $i ]
+  then
+    EXISTING_INDEXSTORES+=($i)
+  fi
+done
+
+echo "Found ${#EXISTING_INDEXSTORES[@]} existing indexstores"
+
+if [ ${#EXISTING_INDEXSTORES[@]} -ne 0 ]
+then
+  "$BAZEL_INSTALLERS_DIR/_indexstore.sh" ${EXISTING_INDEXSTORES[*]}
+else
+  echo "No indexstores found"
+fi
+
+echo "Finish remapping index files at `date`"
+
+ls -ltR $BUILD_DIR/../../Index/DataStore/ > $BAZEL_DIAGNOSTICS_DIR/indexstores-contents-$DATE_SUFFIX.log

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/install.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Install the runnable products so that Xcode can run it. This includes `.app`s,
+# `.xctest`s, and also command line binaries.
+
+set -eux
+
+# Delete all logfiles that are older than 7 days
+find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
+
+case "${PRODUCT_TYPE}" in
+    com.apple.product-type.framework)
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+        ;;
+    com.apple.product-type.framework.static)
+	    # For static library, as the output is not under bazel-bin, we have to get it based on build event
+        # Example of such entry inside build event:
+        # important_output {
+        #   name: ".../SomeFramework.framework/SomeFramework"
+        #   uri: "file:///private/var/tmp/.../.../SomeFramework.framework/SomeFramework"
+        #   path_prefix:... 
+        #   ...
+        #  } 
+        # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
+        QUERY=`grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///"`
+        if [[ -z $QUERY ]]; then 
+            echo "Unable to locate resource for framework of ${TARGET_NAME}"
+            exit 1
+        fi
+        input_options=($(dirname "${QUERY}"))
+        ;;
+    com.apple.product-type.bundle.unit-test)
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}" "bazel-bin/$BAZEL_BIN_SUBDIR/$TARGET_NAME.__internal__.__test_bundle_archive-root/$TARGET_NAME${WRAPPER_SUFFIX:-}")
+        ;;
+    com.apple.product-type.application)
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}" "bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}_archive-root/Payload/$TARGET_NAME${WRAPPER_SUFFIX:-}")
+        ;;
+    *)
+        echo "Error: Installing ${TARGET_NAME} of type ${PRODUCT_TYPE} is unsupported" >&2
+        exit 1
+        ;;
+esac
+output="$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME"
+
+mkdir -p "$(dirname "$output")"
+
+for input in "${input_options[@]}"; do
+    if [[ -z $input ]] || [ $input = "." ] || [ $input = "/" ]; then
+        # rsync can be a dangerous operation when it tries to copy entire root dir into the $output
+        echo "Error: illegal input for installing ${TARGET_NAME} of type ${PRODUCT_TYPE}" >&2
+        exit 1
+    fi
+    if [[ -d $input ]]; then
+        # Copy bundle contents, into the destination bundle.
+        # This avoids self-nesting, like: Foo.app/Foo.app
+        input+="/"
+    else
+        continue
+    fi
+
+    rsync \
+        --recursive --chmod=u+w --delete \
+        "$input" "$output" > "$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
+    break
+done
+
+if [[ ! -d $output ]]; then
+    echo "error: failed to find $FULL_PRODUCT_NAME in expected locations: ${input_options[*]}"
+    exit 1
+fi
+
+"$BAZEL_INSTALLERS_DIR"/lldb-settings.sh > "$BAZEL_DIAGNOSTICS_DIR"/lldb-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/lldb-stderr-"$DATE_SUFFIX".log
+
+# Part of the build intermediary output will be swiftmodule files
+# which XCode will use for indexing. Let's keep those.
+"$BAZEL_INSTALLERS_DIR"/swiftmodules.sh > "$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/indexstores.sh > "$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/install.sh
@@ -47,7 +47,7 @@ mkdir -p "$(dirname "$output")"
 for input in "${input_options[@]}"; do
     if [[ -z $input ]] || [ $input = "." ] || [ $input = "/" ]; then
         # rsync can be a dangerous operation when it tries to copy entire root dir into the $output
-        echo "Error: illegal input for installing ${TARGET_NAME} of type ${PRODUCT_TYPE}" >&2
+        echo "Error: illegal input \"${input}\" for installing ${TARGET_NAME} of type ${PRODUCT_TYPE}" >&2
         exit 1
     fi
     if [[ -d $input ]]; then

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/installer
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Install the runnable products so that Xcode can run it. This includes `.app`s,
+# `.xctest`s, and also command line binaries.
+
+set -eux
+
+# Delete all logfiles that are older than 7 days
+find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
+
+case "${PRODUCT_TYPE}" in
+    com.apple.product-type.framework)
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+        ;;
+    com.apple.product-type.framework.static)
+	    # For static library, as the output is not under bazel-bin, we have to get it based on build event
+        # Example of such entry inside build event:
+        # important_output {
+        #   name: ".../SomeFramework.framework/SomeFramework"
+        #   uri: "file:///private/var/tmp/.../.../SomeFramework.framework/SomeFramework"
+        #   path_prefix:... 
+        #   ...
+        #  } 
+        # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
+        QUERY=`grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///"`
+        if [[ -z $QUERY ]]; then 
+            echo "Unable to locate resource for framework of ${TARGET_NAME}"
+            exit 1
+        fi
+        input_options=($(dirname "${QUERY}"))
+        ;;
+    com.apple.product-type.bundle.unit-test)
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}" "bazel-bin/$BAZEL_BIN_SUBDIR/$TARGET_NAME.__internal__.__test_bundle_archive-root/$TARGET_NAME${WRAPPER_SUFFIX:-}")
+        ;;
+    com.apple.product-type.application)
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}" "bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}_archive-root/Payload/$TARGET_NAME${WRAPPER_SUFFIX:-}")
+        ;;
+    *)
+        echo "Error: Installing ${TARGET_NAME} of type ${PRODUCT_TYPE} is unsupported" >&2
+        exit 1
+        ;;
+esac
+output="$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME"
+
+mkdir -p "$(dirname "$output")"
+
+for input in "${input_options[@]}"; do
+    if [[ -z $input ]] || [ $input = "." ] || [ $input = "/" ]; then
+        # rsync can be a dangerous operation when it tries to copy entire root dir into the $output
+        echo "Error: illegal input for installing ${TARGET_NAME} of type ${PRODUCT_TYPE}" >&2
+        exit 1
+    fi
+    if [[ -d $input ]]; then
+        # Copy bundle contents, into the destination bundle.
+        # This avoids self-nesting, like: Foo.app/Foo.app
+        input+="/"
+    else
+        continue
+    fi
+
+    rsync \
+        --recursive --chmod=u+w --delete \
+        "$input" "$output" > "$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
+    break
+done
+
+if [[ ! -d $output ]]; then
+    echo "error: failed to find $FULL_PRODUCT_NAME in expected locations: ${input_options[*]}"
+    exit 1
+fi
+
+"$BAZEL_INSTALLERS_DIR"/lldb-settings.sh > "$BAZEL_DIAGNOSTICS_DIR"/lldb-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/lldb-stderr-"$DATE_SUFFIX".log
+
+# Part of the build intermediary output will be swiftmodule files
+# which XCode will use for indexing. Let's keep those.
+"$BAZEL_INSTALLERS_DIR"/swiftmodules.sh > "$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/indexstores.sh > "$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/installer
@@ -47,7 +47,7 @@ mkdir -p "$(dirname "$output")"
 for input in "${input_options[@]}"; do
     if [[ -z $input ]] || [ $input = "." ] || [ $input = "/" ]; then
         # rsync can be a dangerous operation when it tries to copy entire root dir into the $output
-        echo "Error: illegal input for installing ${TARGET_NAME} of type ${PRODUCT_TYPE}" >&2
+        echo "Error: illegal input \"${input}\" for installing ${TARGET_NAME} of type ${PRODUCT_TYPE}" >&2
         exit 1
     fi
     if [[ -d $input ]]; then

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euo pipefail
+
+
+# Bazel uses `-debug-prefix-map` to strip the bazel build directory from the
+# paths embedded in debug info. This means the debug info contains _project
+# relative_ paths instead of Bazel absolute paths.
+#
+# However, Xcode sets breakpoints via _project absolute_ paths, which are not
+# the paths in the debug info. This lldb setting ensures that _project relative_
+# paths are remapped to _project absolute_ paths.
+#
+# NOTE: In order to use this, add this line to `~/.lldbinit`:
+#
+#     command source ~/.lldbinit-source-map
+cat <<-END > ~/.lldbinit-source-map
+settings set target.source-map ./external/ "$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
+settings append target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
+settings set target.sdk-path $SDKROOT
+settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS
+END

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Copy Bazel build `.swiftmodule` files to `DerivedData`. This is used by Xcode
+# and its indexing.
+echo "Start copying swiftmodules at `date`"
+FOUND_SWIFTMODULES=`pcregrep -o1 'primary_output: "(.*\.swiftmodule)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | uniq`
+declare -a EXISTING_SWIFTMODULES=()
+for i in $FOUND_SWIFTMODULES
+do
+  if [[ -f $i ]]
+  then
+    EXISTING_SWIFTMODULES+=($i)
+  fi
+done
+echo "Found ${#EXISTING_SWIFTMODULES[@]} existing SWIFTMODULES"
+if [ ${#EXISTING_SWIFTMODULES[@]} -ne 0 ]
+then
+  "$BAZEL_INSTALLERS_DIR/_swiftmodule.sh" ${EXISTING_SWIFTMODULES[*]}
+else
+  echo "No SWIFTMODULES found"
+fi
+echo "Finish copying swiftmodules at `date`"

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.pbxproj
@@ -249,7 +249,7 @@
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
-				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled --features=-swift.cacheable_swiftmodules --features=-swift.use_global_module_cache";
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 				CC = "$BAZEL_STUBS_DIR/clang-stub";
@@ -277,7 +277,7 @@
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
-				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled --features=-swift.cacheable_swiftmodules --features=-swift.use_global_module_cache";
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 				CC = "$BAZEL_STUBS_DIR/clang-stub";

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.pbxproj
@@ -1,0 +1,407 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 51;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		21B461EAB7C0599E6E439C2A /* test.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFFCD75973B790B8428EF9E7 /* test.swift */; };
+		B9A7450627748CC2D7F58245 /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5EE49718CB8070C38416B64 /* empty.swift */; };
+		D22E20A62C92D4512E0FB68E /* test.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C00C28DA12F127AC0AE1387 /* test.m */; };
+		DD54889640478286F3D7EE39 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C080011EC2F624D38C590D3 /* main.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		4A725FD7CA6B196D01987D53 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36C95CC23D076CD1E4D6F262 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BAE883963A69FF9CDA89E73E;
+			remoteInfo = "TestImports-App";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		034C629FFD4FA9DFBC427161 /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = "../unit-test/test-imports-app/BUILD.bazel"; sourceTree = "<group>"; };
+		2C080011EC2F624D38C590D3 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = main.m; path = "../unit-test/test-imports-app/main.m"; sourceTree = "<group>"; };
+		4C00C28DA12F127AC0AE1387 /* test.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = test.m; path = "../unit-test/test-imports-app/test.m"; sourceTree = "<group>"; };
+		58E87329BAD4527D85639045 /* common.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = common.pch; path = ../../../rules/library/common.pch; sourceTree = "<group>"; };
+		C5EE49718CB8070C38416B64 /* empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = empty.swift; path = "../unit-test/test-imports-app/empty.swift"; sourceTree = "<group>"; };
+		C73857A1D91F761A1128A896 /* Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Header.h; path = "../unit-test/test-imports-app/Header.h"; sourceTree = "<group>"; };
+		E6411D3FC8114DF5DE33DABC /* Header2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Header2.h; path = "../unit-test/test-imports-app/Header2.h"; sourceTree = "<group>"; };
+		EC730E57A94AE56443A8D68E /* TestImports-App.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "TestImports-App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		EFFCD75973B790B8428EF9E7 /* test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = test.swift; path = "../unit-test/test-imports-app/test.swift"; sourceTree = "<group>"; };
+		FFC67BEE5C0F371E96445C00 /* TestImports-Unit-Tests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = "TestImports-Unit-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		0FE10EE3091635571895E70D /* rules */ = {
+			isa = PBXGroup;
+			children = (
+				5C497A439614A741544A6E1D /* library */,
+			);
+			name = rules;
+			sourceTree = "<group>";
+		};
+		26F69A463591D5BF4E58071F = {
+			isa = PBXGroup;
+			children = (
+				0FE10EE3091635571895E70D /* rules */,
+				4EE9EE45D0BA3C4F3C9940DC /* tests */,
+				8910DAC3B74F70E3EAF715F8 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		3569A79348A02D3B2304900C /* unit-test */ = {
+			isa = PBXGroup;
+			children = (
+				B85CBF061C0EE7D29E6325E4 /* test-imports-app */,
+			);
+			name = "unit-test";
+			sourceTree = "<group>";
+		};
+		4EE9EE45D0BA3C4F3C9940DC /* tests */ = {
+			isa = PBXGroup;
+			children = (
+				A8CE1638F1E0F10970A23913 /* ios */,
+			);
+			name = tests;
+			sourceTree = "<group>";
+		};
+		5C497A439614A741544A6E1D /* library */ = {
+			isa = PBXGroup;
+			children = (
+				58E87329BAD4527D85639045 /* common.pch */,
+			);
+			name = library;
+			sourceTree = "<group>";
+		};
+		8910DAC3B74F70E3EAF715F8 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				EC730E57A94AE56443A8D68E /* TestImports-App.app */,
+				FFC67BEE5C0F371E96445C00 /* TestImports-Unit-Tests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		A8CE1638F1E0F10970A23913 /* ios */ = {
+			isa = PBXGroup;
+			children = (
+				3569A79348A02D3B2304900C /* unit-test */,
+			);
+			name = ios;
+			sourceTree = "<group>";
+		};
+		B85CBF061C0EE7D29E6325E4 /* test-imports-app */ = {
+			isa = PBXGroup;
+			children = (
+				034C629FFD4FA9DFBC427161 /* BUILD.bazel */,
+				C5EE49718CB8070C38416B64 /* empty.swift */,
+				C73857A1D91F761A1128A896 /* Header.h */,
+				E6411D3FC8114DF5DE33DABC /* Header2.h */,
+				2C080011EC2F624D38C590D3 /* main.m */,
+				4C00C28DA12F127AC0AE1387 /* test.m */,
+				EFFCD75973B790B8428EF9E7 /* test.swift */,
+			);
+			name = "test-imports-app";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		BAE883963A69FF9CDA89E73E /* TestImports-App */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DD122DE14C36AF0A16AA3CC5 /* Build configuration list for PBXNativeTarget "TestImports-App" */;
+			buildPhases = (
+				B5E34299AB3251A857755C8C /* Build with bazel */,
+				B95DD5720FEEB9865A9EFB5D /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "TestImports-App";
+			productName = "TestImports-App";
+			productReference = EC730E57A94AE56443A8D68E /* TestImports-App.app */;
+			productType = "com.apple.product-type.application";
+		};
+		E2BD7425648456079213996C /* TestImports-Unit-Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E8E89DA74F84D1FCB4167D9A /* Build configuration list for PBXNativeTarget "TestImports-Unit-Tests" */;
+			buildPhases = (
+				04239F1A5092A1EE207BE0F0 /* Build with bazel */,
+				028AA87F36243A3B1EEB14EB /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E4FD0C9DEB55E99C27707C5E /* PBXTargetDependency */,
+			);
+			name = "TestImports-Unit-Tests";
+			productName = "TestImports-Unit-Tests";
+			productReference = FFC67BEE5C0F371E96445C00 /* TestImports-Unit-Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		36C95CC23D076CD1E4D6F262 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1020;
+				TargetAttributes = {
+				};
+			};
+			buildConfigurationList = 76DF430C8942076293D1F36C /* Build configuration list for PBXProject "Test-Imports-App-Project" */;
+			compatibilityVersion = "Xcode 10.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 26F69A463591D5BF4E58071F;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				BAE883963A69FF9CDA89E73E /* TestImports-App */,
+				E2BD7425648456079213996C /* TestImports-Unit-Tests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		04239F1A5092A1EE207BE0F0 /* Build with bazel */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Build with bazel";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\nenv -u RUBYOPT -u RUBY_HOME -u GEM_HOME $BAZEL_BUILD_EXEC tests/ios/unit-test/test-imports-app:TestImports-Unit-Tests\n$BAZEL_INSTALLER\n";
+		};
+		B5E34299AB3251A857755C8C /* Build with bazel */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Build with bazel";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\nenv -u RUBYOPT -u RUBY_HOME -u GEM_HOME $BAZEL_BUILD_EXEC tests/ios/unit-test/test-imports-app:TestImports-App\n$BAZEL_INSTALLER\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		028AA87F36243A3B1EEB14EB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D22E20A62C92D4512E0FB68E /* test.m in Sources */,
+				21B461EAB7C0599E6E439C2A /* test.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B95DD5720FEEB9865A9EFB5D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B9A7450627748CC2D7F58245 /* empty.swift in Sources */,
+				DD54889640478286F3D7EE39 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		E4FD0C9DEB55E99C27707C5E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BAE883963A69FF9CDA89E73E /* TestImports-App */;
+			targetProxy = 4A725FD7CA6B196D01987D53 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		1103801B675CC6E6499B42D3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BUILD_EXEC = "$BAZEL_STUBS_DIR/build-wrapper";
+				BAZEL_INSTALLER = $BAZEL_INSTALLERS_DIR/installer;
+				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
+				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
+				BAZEL_PATH = bazelisk;
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
+				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
+				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
+				CC = "$BAZEL_STUBS_DIR/clang-stub";
+				CLANG_ANALYZER_EXEC = $CC;
+				CODE_SIGNING_ALLOWED = 0;
+				CXX = $CC;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
+				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
+				LD = "$BAZEL_STUBS_DIR/ld-stub";
+				LIBTOOL = /usr/bin/true;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_VERSION = 5;
+			};
+			name = Debug;
+		};
+		22C450DE4D602A10E6301EFB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BUILD_EXEC = "$BAZEL_STUBS_DIR/build-wrapper";
+				BAZEL_INSTALLER = $BAZEL_INSTALLERS_DIR/installer;
+				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
+				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
+				BAZEL_PATH = bazelisk;
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
+				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
+				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
+				CC = "$BAZEL_STUBS_DIR/clang-stub";
+				CLANG_ANALYZER_EXEC = $CC;
+				CODE_SIGNING_ALLOWED = 0;
+				CXX = $CC;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
+				LD = "$BAZEL_STUBS_DIR/ld-stub";
+				LIBTOOL = /usr/bin/true;
+				SDKROOT = iphoneos;
+				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_VERSION = 5;
+			};
+			name = Release;
+		};
+		BA7468A2B07548EAF4412A87 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-b8411baab8ff49a269ea6eecbae660d0d7e666287b9fda7540f6697eee077121/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MACH_O_TYPE = "$(inherited)";
+				PRODUCT_NAME = "TestImports-Unit-Tests";
+				SUPPORTS_MACCATALYST = 0;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestImports-App.app/TestImports-App";
+				VALID_ARCHS = "arm64 arm64e";
+			};
+			name = Release;
+		};
+		D0AC9E94935B33DB2ADE8BC5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-b8411baab8ff49a269ea6eecbae660d0d7e666287b9fda7540f6697eee077121/bin/tests/ios/unit-test/test-imports-app/SomeFramework\"";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
+				INFOPLIST_FILE = "$BAZEL_STUBS_DIR/Info-stub.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MACH_O_TYPE = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.TestImports-App";
+				PRODUCT_NAME = "TestImports-App";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
+				VALID_ARCHS = "arm64 arm64e";
+			};
+			name = Release;
+		};
+		E8223A82EB3FE575199C7DAB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-b8411baab8ff49a269ea6eecbae660d0d7e666287b9fda7540f6697eee077121/bin/tests/ios/unit-test/test-imports-app/SomeFramework\"";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
+				INFOPLIST_FILE = "$BAZEL_STUBS_DIR/Info-stub.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MACH_O_TYPE = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.TestImports-App";
+				PRODUCT_NAME = "TestImports-App";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
+				VALID_ARCHS = "arm64 arm64e";
+			};
+			name = Debug;
+		};
+		F2CE3146A179F4568B225E22 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-b8411baab8ff49a269ea6eecbae660d0d7e666287b9fda7540f6697eee077121/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MACH_O_TYPE = "$(inherited)";
+				PRODUCT_NAME = "TestImports-Unit-Tests";
+				SUPPORTS_MACCATALYST = 0;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestImports-App.app/TestImports-App";
+				VALID_ARCHS = "arm64 arm64e";
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		76DF430C8942076293D1F36C /* Build configuration list for PBXProject "Test-Imports-App-Project" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1103801B675CC6E6499B42D3 /* Debug */,
+				22C450DE4D602A10E6301EFB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		DD122DE14C36AF0A16AA3CC5 /* Build configuration list for PBXNativeTarget "TestImports-App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E8223A82EB3FE575199C7DAB /* Debug */,
+				D0AC9E94935B33DB2ADE8BC5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		E8E89DA74F84D1FCB4167D9A /* Build configuration list for PBXNativeTarget "TestImports-Unit-Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F2CE3146A179F4568B225E22 /* Debug */,
+				BA7468A2B07548EAF4412A87 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 36C95CC23D076CD1E4D6F262 /* Project object */;
+}

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Test-Imports-App-Project.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
+	<false/>
+</dict>
+</plist>

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/xcshareddata/xcschemes/SomeFramework.xcscheme
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/xcshareddata/xcschemes/SomeFramework.xcscheme
@@ -14,10 +14,10 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1ECB59A3C8C905569C62BCE7"
-               BuildableName = "TestImports-App.app"
-               BlueprintName = "TestImports-App"
-               ReferencedContainer = "container:Test-Target-With-Test-Host-Project.xcodeproj">
+               BlueprintIdentifier = "23DA0DD8AF1DB9CAF252282C"
+               BuildableName = "SomeFramework.framework"
+               BlueprintName = "SomeFramework"
+               ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -26,18 +26,19 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1ECB59A3C8C905569C62BCE7"
-            BuildableName = "TestImports-App.app"
-            BlueprintName = "TestImports-App"
-            ReferencedContainer = "container:Test-Target-With-Test-Host-Project.xcodeproj">
+            BlueprintIdentifier = "23DA0DD8AF1DB9CAF252282C"
+            BuildableName = "SomeFramework.framework"
+            BlueprintName = "SomeFramework"
+            ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <Testables>
-      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -49,16 +50,17 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1ECB59A3C8C905569C62BCE7"
-            BuildableName = "TestImports-App.app"
-            BlueprintName = "TestImports-App"
-            ReferencedContainer = "container:Test-Target-With-Test-Host-Project.xcodeproj">
+            BlueprintIdentifier = "23DA0DD8AF1DB9CAF252282C"
+            BuildableName = "SomeFramework.framework"
+            BlueprintName = "SomeFramework"
+            ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -70,10 +72,10 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1ECB59A3C8C905569C62BCE7"
-            BuildableName = "TestImports-App.app"
-            BlueprintName = "TestImports-App"
-            ReferencedContainer = "container:Test-Target-With-Test-Host-Project.xcodeproj">
+            BlueprintIdentifier = "23DA0DD8AF1DB9CAF252282C"
+            BuildableName = "SomeFramework.framework"
+            BlueprintName = "SomeFramework"
+            ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/xcshareddata/xcschemes/TestImports-App.xcscheme
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/xcshareddata/xcschemes/TestImports-App.xcscheme
@@ -14,10 +14,10 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1ECB59A3C8C905569C62BCE7"
+               BlueprintIdentifier = "BAE883963A69FF9CDA89E73E"
                BuildableName = "TestImports-App.app"
                BlueprintName = "TestImports-App"
-               ReferencedContainer = "container:Test-Target-With-Test-Host-Project.xcodeproj">
+               ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -26,18 +26,19 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1ECB59A3C8C905569C62BCE7"
+            BlueprintIdentifier = "BAE883963A69FF9CDA89E73E"
             BuildableName = "TestImports-App.app"
             BlueprintName = "TestImports-App"
-            ReferencedContainer = "container:Test-Target-With-Test-Host-Project.xcodeproj">
+            ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <Testables>
-      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -53,12 +54,14 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1ECB59A3C8C905569C62BCE7"
+            BlueprintIdentifier = "BAE883963A69FF9CDA89E73E"
             BuildableName = "TestImports-App.app"
             BlueprintName = "TestImports-App"
-            ReferencedContainer = "container:Test-Target-With-Test-Host-Project.xcodeproj">
+            ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -70,10 +73,10 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1ECB59A3C8C905569C62BCE7"
+            BlueprintIdentifier = "BAE883963A69FF9CDA89E73E"
             BuildableName = "TestImports-App.app"
             BlueprintName = "TestImports-App"
-            ReferencedContainer = "container:Test-Target-With-Test-Host-Project.xcodeproj">
+            ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/xcshareddata/xcschemes/TestImports-Unit-Tests.xcscheme
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/xcshareddata/xcschemes/TestImports-Unit-Tests.xcscheme
@@ -14,10 +14,10 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1ECB59A3C8C905569C62BCE7"
-               BuildableName = "TestImports-App.app"
-               BlueprintName = "TestImports-App"
-               ReferencedContainer = "container:Test-Target-With-Test-Host-Project.xcodeproj">
+               BlueprintIdentifier = "E2BD7425648456079213996C"
+               BuildableName = "TestImports-Unit-Tests.xctest"
+               BlueprintName = "TestImports-Unit-Tests"
+               ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -26,18 +26,31 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E2BD7425648456079213996C"
+               BuildableName = "TestImports-Unit-Tests.xctest"
+               BlueprintName = "TestImports-Unit-Tests"
+               ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1ECB59A3C8C905569C62BCE7"
-            BuildableName = "TestImports-App.app"
-            BlueprintName = "TestImports-App"
-            ReferencedContainer = "container:Test-Target-With-Test-Host-Project.xcodeproj">
+            BlueprintIdentifier = "E2BD7425648456079213996C"
+            BuildableName = "TestImports-Unit-Tests.xctest"
+            BlueprintName = "TestImports-Unit-Tests"
+            ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <Testables>
-      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -49,16 +62,17 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1ECB59A3C8C905569C62BCE7"
-            BuildableName = "TestImports-App.app"
-            BlueprintName = "TestImports-App"
-            ReferencedContainer = "container:Test-Target-With-Test-Host-Project.xcodeproj">
+            BlueprintIdentifier = "E2BD7425648456079213996C"
+            BuildableName = "TestImports-Unit-Tests.xctest"
+            BlueprintName = "TestImports-Unit-Tests"
+            ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -70,10 +84,10 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1ECB59A3C8C905569C62BCE7"
-            BuildableName = "TestImports-App.app"
-            BlueprintName = "TestImports-App"
-            ReferencedContainer = "container:Test-Target-With-Test-Host-Project.xcodeproj">
+            BlueprintIdentifier = "E2BD7425648456079213996C"
+            BuildableName = "TestImports-Unit-Tests.xctest"
+            BlueprintName = "TestImports-Unit-Tests"
+            ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>

--- a/tests/ios/xcodeproj/build.sh
+++ b/tests/ios/xcodeproj/build.sh
@@ -8,6 +8,6 @@ xcrun simctl list
 export SAMPLE_PROJECT_AND_SCHEME="-project Single-Static-Framework-Project.xcodeproj -scheme ObjcFrameworkTests"
 export SIM_DEVICE_ID=`xcodebuild $SAMPLE_PROJECT_AND_SCHEME -showdestinations | grep "platform:iOS Sim" | head -1 | ruby -e "puts STDIN.read.split(',')[1].split(':').last"`
 
-for i in ` find *.xcodeproj -maxdepth 0 -type d`; do
+for i in `find *.xcodeproj -maxdepth 0 -type d`; do
     xcodebuild -project $i -alltargets -destination "id=$SIM_DEVICE_ID" -quiet
 done

--- a/tests/ios/xcodeproj/build.sh
+++ b/tests/ios/xcodeproj/build.sh
@@ -9,3 +9,4 @@ export PROJECT_AND_SCHEME="-project Single-Static-Framework-Project.xcodeproj -s
 export SIM_DEVICE_ID=`xcodebuild $PROJECT_AND_SCHEME -showdestinations | grep "platform:iOS Sim" | head -1 | ruby -e "puts STDIN.read.split(',')[1].split(':').last"`
 
 xcodebuild $PROJECT_AND_SCHEME -destination "id=$SIM_DEVICE_ID" -quiet 
+xcodebuild -project Test-Imports-App-Project.xcodeproj -scheme TestImports-App -destination "id=$SIM_DEVICE_ID" -quiet

--- a/tests/ios/xcodeproj/build.sh
+++ b/tests/ios/xcodeproj/build.sh
@@ -5,8 +5,9 @@ cd $(dirname $0)
 # Make sure there are simulators avilable as destinations
 xcrun simctl list
 
-export PROJECT_AND_SCHEME="-project Single-Static-Framework-Project.xcodeproj -scheme ObjcFrameworkTests"
-export SIM_DEVICE_ID=`xcodebuild $PROJECT_AND_SCHEME -showdestinations | grep "platform:iOS Sim" | head -1 | ruby -e "puts STDIN.read.split(',')[1].split(':').last"`
+export SAMPLE_PROJECT_AND_SCHEME="-project Single-Static-Framework-Project.xcodeproj -scheme ObjcFrameworkTests"
+export SIM_DEVICE_ID=`xcodebuild $SAMPLE_PROJECT_AND_SCHEME -showdestinations | grep "platform:iOS Sim" | head -1 | ruby -e "puts STDIN.read.split(',')[1].split(':').last"`
 
-xcodebuild $PROJECT_AND_SCHEME -destination "id=$SIM_DEVICE_ID" -quiet 
-xcodebuild -project Test-Imports-App-Project.xcodeproj -scheme TestImports-App -destination "id=$SIM_DEVICE_ID" -quiet
+for i in ` find *.xcodeproj -maxdepth 0 -type d`; do
+    xcodebuild -project $i -alltargets -destination "id=$SIM_DEVICE_ID" -quiet
+done

--- a/tests/ios/xcodeproj/post_build_check.sh
+++ b/tests/ios/xcodeproj/post_build_check.sh
@@ -1,4 +1,4 @@
-set -e
+set -eu
 
 cd $(dirname $0)
 

--- a/tests/ios/xcodeproj/post_build_check.sh
+++ b/tests/ios/xcodeproj/post_build_check.sh
@@ -1,4 +1,4 @@
-set -eux
+set -e
 
 cd $(dirname $0)
 

--- a/tests/ios/xcodeproj/pre_build_check.sh
+++ b/tests/ios/xcodeproj/pre_build_check.sh
@@ -1,4 +1,4 @@
-set -eux
+set -eu
 
 cd $(dirname $0)
 

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/xcshareddata/xcschemes/TestImports-App.xcscheme
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/xcshareddata/xcschemes/TestImports-App.xcscheme
@@ -26,7 +26,10 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -36,8 +39,6 @@
             ReferencedContainer = "container:Test-Target-With-Test-Host-Project.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <Testables>
-      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -59,6 +60,8 @@
             ReferencedContainer = "container:Test-Target-With-Test-Host-Project.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
### Why this change
Due to the need to have a "framework_unlinked" version of a app so that tests can run, we end up having a framework target with name `Foo` while there is an app target also with name `Foo`. If we don't ignore one of them, during `xcodeproj` generation phase one will overwrite the other.

This PR is therefore putting efforts to prevent this from happening:
1. a new tag so dev can specify to ignore one of them
2. a check to prevent such thing from happening

### Tests done
The new xcodeproj rule is testing against above situation so without the tag, new test cases will fail during `bazel run <some_xcodeproj_rule>` stage

### Outstanding question
1. Where to document this new tag?