### PR TITLE
Add example demonstrating the error "this class is not key value coding-compliant for the key" when using XIBs inside resource bundles

### DIFF
--- a/tests/ios/frameworks/target-xib-resource-bundle/BUILD.bazel
+++ b/tests/ios/frameworks/target-xib-resource-bundle/BUILD.bazel
@@ -4,10 +4,10 @@ load("@build_bazel_rules_ios//rules:test.bzl", "ios_unit_test")
 apple_framework(
     name = "TargetXIB",
     srcs = glob(["TargetXIB/**/*.swift"]),
+    platforms = {"ios": "11.0"},
     resource_bundles = {
         "TargetXIB": glob(["TargetXIB/**/*.xib"]),
     },
-    platforms = {"ios": "11.0"},
     visibility = ["//visibility:public"],
 )
 

--- a/tests/ios/frameworks/target-xib-resource-bundle/BUILD.bazel
+++ b/tests/ios/frameworks/target-xib-resource-bundle/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
+load("@build_bazel_rules_ios//rules:test.bzl", "ios_unit_test")
+
+apple_framework(
+    name = "TargetXIB",
+    srcs = glob(["TargetXIB/**/*.swift"]),
+    resource_bundles = {
+        "TargetXIB": glob(["TargetXIB/**/*.xib"]),
+    },
+    platforms = {"ios": "11.0"},
+    visibility = ["//visibility:public"],
+)
+
+apple_framework(
+    name = "TargetXIBTestsLib",
+    srcs = glob(["TargetXIBTests/**/*.swift"]),
+    platforms = {"ios": "11.0"},
+    visibility = ["//visibility:public"],
+    deps = [":TargetXIB"],
+)
+
+ios_unit_test(
+    name = "TargetXIBTests",
+    minimum_os_version = "11.0",
+    deps = [":TargetXIBTestsLib"],
+)

--- a/tests/ios/frameworks/target-xib-resource-bundle/TargetXIB/CustomView.swift
+++ b/tests/ios/frameworks/target-xib-resource-bundle/TargetXIB/CustomView.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+final class CustomView: UIView {
+
+    @IBOutlet private var label: UILabel!
+
+    static func fromNib() -> CustomView? {
+        let bundle = Bundle(for: CustomView.self).url(forResource: "TargetXIB", withExtension: "bundle").flatMap(Bundle.init(url:))
+        return bundle?.loadNibNamed("CustomView", owner: nil, options: nil)?.first as? CustomView
+    }
+}

--- a/tests/ios/frameworks/target-xib-resource-bundle/TargetXIB/CustomView.xib
+++ b/tests/ios/frameworks/target-xib-resource-bundle/TargetXIB/CustomView.xib
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="CustomView" customModule="TestXIB" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="200"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qFq-SM-pDh">
+                    <rect key="frame" x="16" y="60" width="382" height="124"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="qFq-SM-pDh" secondAttribute="bottom" constant="16" id="E3h-Wy-NIO"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="qFq-SM-pDh" secondAttribute="trailing" constant="16" id="UG6-pg-VJt"/>
+                <constraint firstItem="qFq-SM-pDh" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="16" id="bZ3-ip-0zW"/>
+                <constraint firstItem="qFq-SM-pDh" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="16" id="vye-Da-pMq"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <connections>
+                <outlet property="label" destination="qFq-SM-pDh" id="VcW-yF-0ka"/>
+            </connections>
+            <point key="canvasLocation" x="139" y="153"/>
+        </view>
+    </objects>
+</document>

--- a/tests/ios/frameworks/target-xib-resource-bundle/TargetXIBTests/CustomViewTests.swift
+++ b/tests/ios/frameworks/target-xib-resource-bundle/TargetXIBTests/CustomViewTests.swift
@@ -1,0 +1,14 @@
+import UIKit
+import XCTest
+@testable import TargetXIB
+
+final class CustomViewTests: XCTestCase {
+
+    func testCustomView() {
+        let view = CustomView.fromNib()
+
+        assert(view != nil, "CustomView is not instantiated.")
+        // This test result in a crash with the following output:
+        // <unknown>:0: error: -[TargetXIBTestsLib.CustomViewTests testCustomView] : failed: caught "NSUnknownKeyException", "[<UIView 0x7f8d9fc6de50> setValue:forUndefinedKey:]: this class is not key value coding-compliant for the key label."
+    }
+}


### PR DESCRIPTION
This PR contains a failing test that demonstrates the issue https://github.com/bazel-ios/rules_ios/issues/113
This should not be merged