### PR TITLE
Fix the precompiled_apple_resource_bundle to use a correct swift module

### DIFF
--- a/docs/precompiled_apple_resource_bundle_doc.md
+++ b/docs/precompiled_apple_resource_bundle_doc.md
@@ -6,7 +6,7 @@
 
 <pre>
 precompiled_apple_resource_bundle(<a href="#precompiled_apple_resource_bundle-name">name</a>, <a href="#precompiled_apple_resource_bundle-bundle_extension">bundle_extension</a>, <a href="#precompiled_apple_resource_bundle-bundle_id">bundle_id</a>, <a href="#precompiled_apple_resource_bundle-bundle_name">bundle_name</a>, <a href="#precompiled_apple_resource_bundle-infoplists">infoplists</a>,
-                                  <a href="#precompiled_apple_resource_bundle-ipa_post_processor">ipa_post_processor</a>, <a href="#precompiled_apple_resource_bundle-platforms">platforms</a>, <a href="#precompiled_apple_resource_bundle-resources">resources</a>)
+                                  <a href="#precompiled_apple_resource_bundle-ipa_post_processor">ipa_post_processor</a>, <a href="#precompiled_apple_resource_bundle-platforms">platforms</a>, <a href="#precompiled_apple_resource_bundle-resources">resources</a>, <a href="#precompiled_apple_resource_bundle-swift_module">swift_module</a>)
 </pre>
 
 
@@ -24,5 +24,6 @@ precompiled_apple_resource_bundle(<a href="#precompiled_apple_resource_bundle-na
 | ipa_post_processor |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | platforms |  A dictionary of platform names to minimum deployment targets. If not given, the resource bundle will be built for the platform it inherits from the target that uses the bundle as a dependency.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | resources |  The list of resources to be included in the resource bundle.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| swift_module |  The swift module to use when compiling storyboards, nibs and xibs that contain a customModuleProvider   | String | optional | "" |
 
 

--- a/tests/ios/frameworks/core-data-resource-bundle/BUILD.bazel
+++ b/tests/ios/frameworks/core-data-resource-bundle/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
+load("@build_bazel_rules_ios//rules:test.bzl", "ios_unit_test")
+
+# This example tests that a core data model that sets `Model = "Current Product Module"`
+# works well when using a resource bundle
+
+apple_framework(
+    name = "CoreDataExample",
+    srcs = glob(["CoreDataExample/**/*.swift"]),
+    platforms = {"ios": "11.0"},
+    resource_bundles = {
+        "CoreDataExample": glob(["CoreDataExample/**/*.xcdatamodeld"]),
+    },
+    visibility = ["//visibility:public"],
+)
+
+apple_framework(
+    name = "CoreDataExampleTestsLib",
+    srcs = glob(["TargetXIBTests/**/*.swift"]),
+    platforms = {"ios": "11.0"},
+    visibility = ["//visibility:public"],
+    deps = [":CoreDataExample"],
+)
+
+ios_unit_test(
+    name = "CoreDataExampleTests",
+    minimum_os_version = "11.0",
+    deps = [":CoreDataExampleTestsLib"],
+)

--- a/tests/ios/frameworks/core-data-resource-bundle/CoreDataExample/CoreDataManager.swift
+++ b/tests/ios/frameworks/core-data-resource-bundle/CoreDataExample/CoreDataManager.swift
@@ -1,0 +1,77 @@
+import CoreData
+
+public final class CoreDataManager {
+
+    // MARK: - Properties
+    private let modelName: String
+
+    // MARK: - Initialization
+    init(modelName: String = "Model") {
+        self.modelName = modelName
+    }
+
+    // MARK: - Core Data Stack
+    private(set) lazy var managedObjectContext: NSManagedObjectContext = {
+        let managedObjectContext = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+
+        managedObjectContext.persistentStoreCoordinator = self.persistentStoreCoordinator
+
+        return managedObjectContext
+    }()
+
+    private lazy var managedObjectModel: NSManagedObjectModel = {
+        guard let modelURL = Bundle(for: Self.self).url(forResource: self.modelName, withExtension: "momd") else {
+            fatalError("Unable to Find Data Model")
+        }
+
+        guard let managedObjectModel = NSManagedObjectModel(contentsOf: modelURL) else {
+            fatalError("Unable to Load Data Model")
+        }
+
+        return managedObjectModel
+    }()
+
+    private lazy var persistentStoreCoordinatorUrl: URL = {
+        let fileManager = FileManager.default
+        let storeName = "\(self.modelName).sqlite"
+
+        let documentsDirectoryURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+
+        let persistentStoreURL = documentsDirectoryURL.appendingPathComponent(storeName)
+        return persistentStoreURL
+    }()
+
+    private lazy var persistentStoreCoordinator: NSPersistentStoreCoordinator = {
+        let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: self.managedObjectModel)
+
+
+        do {
+            try persistentStoreCoordinator.addPersistentStore(ofType: NSSQLiteStoreType,
+                                                              configurationName: nil,
+                                                              at: persistentStoreCoordinatorUrl,
+                                                              options: nil)
+        } catch {
+            fatalError("Unable to Load Persistent Store")
+        }
+
+        return persistentStoreCoordinator
+    }()
+
+    public func savePerson(name: String) {
+        let person = NSEntityDescription.insertNewObject(
+            forEntityName: "Person",
+            into: managedObjectContext
+        ) as? Person
+        person?.name = name
+        try? managedObjectContext.save()
+    }
+
+    public func fetchPeople() -> [Person] {
+        let result: [Person] = (try? managedObjectContext.fetch(Person.fetchRequest())) ?? []
+        return result
+    }
+
+    public func nuke() {
+        try? FileManager.default.removeItem(at: persistentStoreCoordinatorUrl)
+    }
+}

--- a/tests/ios/frameworks/core-data-resource-bundle/CoreDataExample/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/tests/ios/frameworks/core-data-resource-bundle/CoreDataExample/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="16119" systemVersion="19G2021" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Person" representedClassName=".Person" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String"/>
+    </entity>
+    <elements>
+        <element name="Person" positionX="-63" positionY="-18" width="128" height="58"/>
+    </elements>
+</model>

--- a/tests/ios/frameworks/core-data-resource-bundle/CoreDataExample/Person.swift
+++ b/tests/ios/frameworks/core-data-resource-bundle/CoreDataExample/Person.swift
@@ -1,0 +1,11 @@
+import UIKit
+import CoreData
+import Foundation
+
+public class Person: NSManagedObject {
+    @nonobjc public static func fetchRequest() -> NSFetchRequest<Person> {
+        return NSFetchRequest<Person>(entityName: "Person")
+    }
+
+    @NSManaged var name: String?
+}

--- a/tests/ios/frameworks/core-data-resource-bundle/CoreDataExampleTests/CoreDataExampleTests.swift
+++ b/tests/ios/frameworks/core-data-resource-bundle/CoreDataExampleTests/CoreDataExampleTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import CoreDataExample
+
+class CoreDataExampleTests: XCTestCase {
+    func test() {
+        let coreData = CoreDataManager()
+        coreData.nuke()
+
+        coreData.savePerson(name: "Peter")
+        let people = coreData.fetchPeople()
+
+        XCTAssertEqual(people.count, 1)
+        XCTAssertEqual(people.first?.name, "Peter")
+    }
+}

--- a/tests/ios/frameworks/target-xib-resource-bundle/BUILD.bazel
+++ b/tests/ios/frameworks/target-xib-resource-bundle/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
+load("@build_bazel_rules_ios//rules:test.bzl", "ios_unit_test")
+
+apple_framework(
+    name = "TargetXIB",
+    srcs = glob(["TargetXIB/**/*.swift"]),
+    platforms = {"ios": "11.0"},
+    resource_bundles = {
+        "TargetXIB": glob(["TargetXIB/**/*.xib"]),
+    },
+    visibility = ["//visibility:public"],
+)
+
+apple_framework(
+    name = "TargetXIBTestsLib",
+    srcs = glob(["TargetXIBTests/**/*.swift"]),
+    platforms = {"ios": "11.0"},
+    visibility = ["//visibility:public"],
+    deps = [":TargetXIB"],
+)
+
+ios_unit_test(
+    name = "TargetXIBTests",
+    minimum_os_version = "11.0",
+    deps = [":TargetXIBTestsLib"],
+)

--- a/tests/ios/frameworks/target-xib-resource-bundle/TargetXIB/CustomView.swift
+++ b/tests/ios/frameworks/target-xib-resource-bundle/TargetXIB/CustomView.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+final class CustomView: UIView {
+
+    @IBOutlet private var label: UILabel!
+
+    static func fromNib() -> CustomView? {
+        let bundle = Bundle(for: CustomView.self).url(forResource: "TargetXIB", withExtension: "bundle").flatMap(Bundle.init(url:))
+        return bundle?.loadNibNamed("CustomView", owner: nil, options: nil)?.first as? CustomView
+    }
+}

--- a/tests/ios/frameworks/target-xib-resource-bundle/TargetXIB/CustomView.xib
+++ b/tests/ios/frameworks/target-xib-resource-bundle/TargetXIB/CustomView.xib
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="CustomView" customModule="TestXIB" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="200"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qFq-SM-pDh">
+                    <rect key="frame" x="16" y="60" width="382" height="124"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="qFq-SM-pDh" secondAttribute="bottom" constant="16" id="E3h-Wy-NIO"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="qFq-SM-pDh" secondAttribute="trailing" constant="16" id="UG6-pg-VJt"/>
+                <constraint firstItem="qFq-SM-pDh" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="16" id="bZ3-ip-0zW"/>
+                <constraint firstItem="qFq-SM-pDh" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="16" id="vye-Da-pMq"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <connections>
+                <outlet property="label" destination="qFq-SM-pDh" id="VcW-yF-0ka"/>
+            </connections>
+            <point key="canvasLocation" x="139" y="153"/>
+        </view>
+    </objects>
+</document>

--- a/tests/ios/frameworks/target-xib-resource-bundle/TargetXIBTests/CustomViewTests.swift
+++ b/tests/ios/frameworks/target-xib-resource-bundle/TargetXIBTests/CustomViewTests.swift
@@ -1,0 +1,12 @@
+import UIKit
+import XCTest
+@testable import TargetXIB
+
+final class CustomViewTests: XCTestCase {
+
+    func testCustomView() {
+        let view = CustomView.fromNib()
+
+        assert(view != nil, "CustomView is not instantiated.")
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/bazel-ios/rules_ios/issues/113

I couldnt find a way to properly pass the `swift_module` parameter to the `xibCompile` step, so instead I changed the label for the `fake_ctx` (which seems to be non important) to match the required `swift_module`: in the end, such label is used as a fallback value when `swift_module` is not specified.

You can see the fallback here: https://github.com/bazelbuild/rules_apple/blob/master/apple/internal/partials/support/resources_support.bzl#L446