### PR TITLE
Some fixes to the xcodeproj rule

### DIFF
--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -159,7 +159,11 @@ def _xcodeproj_aspect_impl(target, ctx):
             transitive_targets.append(info)
 
         if test_host_target:
-            direct_targets.extend(test_host_target[_TargetInfo].direct_targets)
+            # Add the test_host_target to the targets to be added to the xcode project
+            test_host_direct_targets = test_host_target[_TargetInfo].direct_targets
+            direct_targets.extend(test_host_direct_targets)
+            transitive_targets.extend(test_host_direct_targets)
+
         target_info = _TargetInfo(direct_targets = direct_targets, targets = depset(transitive_targets, transitive = _get_attr_values_for_name(deps, _TargetInfo, "targets")))
         providers.append(target_info)
     else:
@@ -384,7 +388,7 @@ def _xcodeproj_impl(ctx):
     xcodegen_jsonfile = ctx.actions.declare_file(
         "%s-xcodegen.json" % ctx.attr.name,
     )
-    project_name = ctx.attr.project_name if ctx.attr.project_name else ctx.attr.name + ".xcodeproj"
+    project_name = (ctx.attr.project_name or ctx.attr.name) + ".xcodeproj"
     if "/" in project_name:
         fail("No / allowed in project_name")
 

--- a/tests/ios/unit-test/BUILD.bazel
+++ b/tests/ios/unit-test/BUILD.bazel
@@ -29,6 +29,8 @@ ios_unit_test(
     ],
     minimum_os_version = "12.0",
     test_host = "//rules/test_host_app:iOS-9.3-AppHost",
+    # Adding visibility so the xcodeproject tests can depend on this target
+    visibility = ["//visibility:public"],
 )
 
 ios_unit_test(

--- a/tests/ios/xcodeproj/BUILD.bazel
+++ b/tests/ios/xcodeproj/BUILD.bazel
@@ -23,6 +23,18 @@ xcodeproj(
     ],
 )
 
+# Test that the test_host is included when using "include_transitive_targets = True"
+xcodeproj(
+    name = "Test-With-Host-App",
+    testonly = True,
+    bazel_path = "bazelisk",
+    include_transitive_targets = True,
+    project_name = "TestWithHostApp",  # Test that setting a custom project name works as expected
+    deps = [
+        "//tests/ios/unit-test:ExplicitHosted",
+    ],
+)
+
 genrule(
     name = "Test-Project-Regeneration",
     testonly = True,

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/_indexstore.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Import Bazel built indexstores into Xcode. See https://github.com/lyft/index-import
+#
+# This makes use of a number of Xcode's provided environment variables. These
+# file remappings are not specific to this project, the apply to all projects
+# built with Bazel and rules_swift.
+
+# Example: /private/var/tmp/_bazel_<username>/<hash>/execroot/<workspacename>
+readonly bazel_root="^/private/var/tmp/_bazel_.+?/.+?/execroot/[^/]+"
+readonly bazel_bin="^(?:$bazel_root/)?bazel-out/.+?/bin"
+
+# Object file paths are fundamental to how Xcode loads from the indexstore. If
+# the `OutputFile` does not match what Xcode looks for, then those parts of the
+# indexstore will not be found and used.
+readonly bazel_swift_object="$bazel_bin/.*/(.+?)(?:_swift)?_objs/.*/(.+?)[.]swift[.]o$"
+readonly bazel_objc_object="$bazel_bin/.*/_objs/(?:arc/|non_arc/)?(.+?)-(?:objc|cpp)/(.+?)[.]o$"
+readonly xcode_object="$CONFIGURATION_TEMP_DIR/\$1.build/Objects-normal/$ARCHS/\$2.o"
+
+# Bazel built `.swiftmodule` files are copied to `DerivedData`. Since modules
+# are referenced by indexstores, their paths are remapped.
+readonly bazel_module="$bazel_bin/.*/(.+?)[.]swiftmodule$"
+readonly xcode_module="$BUILT_PRODUCTS_DIR/\$1.swiftmodule/$ARCHS.swiftmodule"
+
+# External dependencies are available via the `bazel-<workspacename>` symlink.
+# This remapping, in combination with `xcode-index-preferences.json`, enables
+# index features for external dependencies, such as jump-to-definition.
+readonly bazel_external="$bazel_root/external"
+readonly xcode_external="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$SRCROOT")/external"
+
+
+$BAZEL_INSTALLERS_DIR/index-import \
+    -remap "$bazel_module=$xcode_module" \
+    -remap "$bazel_swift_object=$xcode_object" \
+    -remap "$bazel_objc_object=$xcode_object" \
+    -remap "$bazel_external=$xcode_external" \
+    -remap "$bazel_root=$BAZEL_WORKSPACE_ROOT" \
+    -remap "^([^//])=$BAZEL_WORKSPACE_ROOT/\$1" \
+    "$@" \
+    "$BUILD_DIR"/../../Index/DataStore

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/_swiftmodule.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/_swiftmodule.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+for module in "$@"; do
+    doc="${module%.swiftmodule}.swiftdoc"
+    module_name=$(basename "$module")
+    module_bundle="$BUILT_PRODUCTS_DIR/$module_name"
+    mkdir -p "$module_bundle"
+
+    cp "$module" "$module_bundle/$NATIVE_ARCH_ACTUAL.swiftmodule"
+    cp "$doc" "$module_bundle/$NATIVE_ARCH_ACTUAL.swiftdoc"
+
+    ios_module_name="$NATIVE_ARCH_ACTUAL-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
+    cp "$module" "$module_bundle/$ios_module_name.swiftmodule"
+    cp "$doc" "$module_bundle/$ios_module_name.swiftdoc"
+
+    chmod -R +w "$module_bundle"
+done

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/indexstores.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# See `_indexstore.sh` for full details.
+
+echo "Start remapping index files at `date`"
+
+FOUND_INDEXSTORES=`pcregrep -o1 'command_line: "(.*\.indexstore)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | uniq`
+
+declare -a EXISTING_INDEXSTORES=()
+for i in $FOUND_INDEXSTORES
+do
+  if [ -d $i ]
+  then
+    EXISTING_INDEXSTORES+=($i)
+  fi
+done
+
+echo "Found ${#EXISTING_INDEXSTORES[@]} existing indexstores"
+
+if [ ${#EXISTING_INDEXSTORES[@]} -ne 0 ]
+then
+  "$BAZEL_INSTALLERS_DIR/_indexstore.sh" ${EXISTING_INDEXSTORES[*]}
+else
+  echo "No indexstores found"
+fi
+
+echo "Finish remapping index files at `date`"
+
+ls -ltR $BUILD_DIR/../../Index/DataStore/ > $BAZEL_DIAGNOSTICS_DIR/indexstores-contents-$DATE_SUFFIX.log

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/install.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Install the runnable products so that Xcode can run it. This includes `.app`s,
+# `.xctest`s, and also command line binaries.
+
+set -eux
+
+# Delete all logfiles that are older than 7 days
+find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
+
+case "${PRODUCT_TYPE}" in
+    com.apple.product-type.framework)
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+        ;;
+    com.apple.product-type.framework.static)
+	    # For static library, as the output is not under bazel-bin, we have to get it based on build event
+        # Example of such entry inside build event:
+        # important_output {
+        #   name: ".../SomeFramework.framework/SomeFramework"
+        #   uri: "file:///private/var/tmp/.../.../SomeFramework.framework/SomeFramework"
+        #   path_prefix:... 
+        #   ...
+        #  } 
+        # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
+        QUERY=`grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///"`
+        if [[ -z $QUERY ]]; then 
+            echo "Unable to locate resource for framework of ${TARGET_NAME}"
+            exit 1
+        fi
+        input_options=($(dirname "${QUERY}"))
+        ;;
+    com.apple.product-type.bundle.unit-test)
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}" "bazel-bin/$BAZEL_BIN_SUBDIR/$TARGET_NAME.__internal__.__test_bundle_archive-root/$TARGET_NAME${WRAPPER_SUFFIX:-}")
+        ;;
+    com.apple.product-type.application)
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}" "bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}_archive-root/Payload/$TARGET_NAME${WRAPPER_SUFFIX:-}")
+        ;;
+    *)
+        echo "Error: Installing ${TARGET_NAME} of type ${PRODUCT_TYPE} is unsupported" >&2
+        exit 1
+        ;;
+esac
+output="$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME"
+
+mkdir -p "$(dirname "$output")"
+
+for input in "${input_options[@]}"; do
+    if [[ -z $input ]] || [ $input = "." ] || [ $input = "/" ]; then
+        # rsync can be a dangerous operation when it tries to copy entire root dir into the $output
+        echo "Error: illegal input \"${input}\" for installing ${TARGET_NAME} of type ${PRODUCT_TYPE}" >&2
+        exit 1
+    fi
+    if [[ -d $input ]]; then
+        # Copy bundle contents, into the destination bundle.
+        # This avoids self-nesting, like: Foo.app/Foo.app
+        input+="/"
+    else
+        continue
+    fi
+
+    rsync \
+        --recursive --chmod=u+w --delete \
+        "$input" "$output" > "$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
+    break
+done
+
+if [[ ! -d $output ]]; then
+    echo "error: failed to find $FULL_PRODUCT_NAME in expected locations: ${input_options[*]}"
+    exit 1
+fi
+
+"$BAZEL_INSTALLERS_DIR"/lldb-settings.sh > "$BAZEL_DIAGNOSTICS_DIR"/lldb-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/lldb-stderr-"$DATE_SUFFIX".log
+
+# Part of the build intermediary output will be swiftmodule files
+# which XCode will use for indexing. Let's keep those.
+"$BAZEL_INSTALLERS_DIR"/swiftmodules.sh > "$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/indexstores.sh > "$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/installer
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Install the runnable products so that Xcode can run it. This includes `.app`s,
+# `.xctest`s, and also command line binaries.
+
+set -eux
+
+# Delete all logfiles that are older than 7 days
+find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
+
+case "${PRODUCT_TYPE}" in
+    com.apple.product-type.framework)
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+        ;;
+    com.apple.product-type.framework.static)
+	    # For static library, as the output is not under bazel-bin, we have to get it based on build event
+        # Example of such entry inside build event:
+        # important_output {
+        #   name: ".../SomeFramework.framework/SomeFramework"
+        #   uri: "file:///private/var/tmp/.../.../SomeFramework.framework/SomeFramework"
+        #   path_prefix:... 
+        #   ...
+        #  } 
+        # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
+        QUERY=`grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///"`
+        if [[ -z $QUERY ]]; then 
+            echo "Unable to locate resource for framework of ${TARGET_NAME}"
+            exit 1
+        fi
+        input_options=($(dirname "${QUERY}"))
+        ;;
+    com.apple.product-type.bundle.unit-test)
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}" "bazel-bin/$BAZEL_BIN_SUBDIR/$TARGET_NAME.__internal__.__test_bundle_archive-root/$TARGET_NAME${WRAPPER_SUFFIX:-}")
+        ;;
+    com.apple.product-type.application)
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}" "bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}_archive-root/Payload/$TARGET_NAME${WRAPPER_SUFFIX:-}")
+        ;;
+    *)
+        echo "Error: Installing ${TARGET_NAME} of type ${PRODUCT_TYPE} is unsupported" >&2
+        exit 1
+        ;;
+esac
+output="$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME"
+
+mkdir -p "$(dirname "$output")"
+
+for input in "${input_options[@]}"; do
+    if [[ -z $input ]] || [ $input = "." ] || [ $input = "/" ]; then
+        # rsync can be a dangerous operation when it tries to copy entire root dir into the $output
+        echo "Error: illegal input \"${input}\" for installing ${TARGET_NAME} of type ${PRODUCT_TYPE}" >&2
+        exit 1
+    fi
+    if [[ -d $input ]]; then
+        # Copy bundle contents, into the destination bundle.
+        # This avoids self-nesting, like: Foo.app/Foo.app
+        input+="/"
+    else
+        continue
+    fi
+
+    rsync \
+        --recursive --chmod=u+w --delete \
+        "$input" "$output" > "$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
+    break
+done
+
+if [[ ! -d $output ]]; then
+    echo "error: failed to find $FULL_PRODUCT_NAME in expected locations: ${input_options[*]}"
+    exit 1
+fi
+
+"$BAZEL_INSTALLERS_DIR"/lldb-settings.sh > "$BAZEL_DIAGNOSTICS_DIR"/lldb-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/lldb-stderr-"$DATE_SUFFIX".log
+
+# Part of the build intermediary output will be swiftmodule files
+# which XCode will use for indexing. Let's keep those.
+"$BAZEL_INSTALLERS_DIR"/swiftmodules.sh > "$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/indexstores.sh > "$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2> "$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euo pipefail
+
+
+# Bazel uses `-debug-prefix-map` to strip the bazel build directory from the
+# paths embedded in debug info. This means the debug info contains _project
+# relative_ paths instead of Bazel absolute paths.
+#
+# However, Xcode sets breakpoints via _project absolute_ paths, which are not
+# the paths in the debug info. This lldb setting ensures that _project relative_
+# paths are remapped to _project absolute_ paths.
+#
+# NOTE: In order to use this, add this line to `~/.lldbinit`:
+#
+#     command source ~/.lldbinit-source-map
+cat <<-END > ~/.lldbinit-source-map
+settings set target.source-map ./external/ "$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
+settings append target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
+settings set target.sdk-path $SDKROOT
+settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS
+END

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Copy Bazel build `.swiftmodule` files to `DerivedData`. This is used by Xcode
+# and its indexing.
+echo "Start copying swiftmodules at `date`"
+FOUND_SWIFTMODULES=`pcregrep -o1 'primary_output: "(.*\.swiftmodule)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | uniq`
+declare -a EXISTING_SWIFTMODULES=()
+for i in $FOUND_SWIFTMODULES
+do
+  if [[ -f $i ]]
+  then
+    EXISTING_SWIFTMODULES+=($i)
+  fi
+done
+echo "Found ${#EXISTING_SWIFTMODULES[@]} existing SWIFTMODULES"
+if [ ${#EXISTING_SWIFTMODULES[@]} -ne 0 ]
+then
+  "$BAZEL_INSTALLERS_DIR/_swiftmodule.sh" ${EXISTING_SWIFTMODULES[*]}
+else
+  echo "No SWIFTMODULES found"
+fi
+echo "Finish copying swiftmodules at `date`"

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.pbxproj
@@ -1,0 +1,409 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 51;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		45E7F8EFCCCC1A9DF4D72E93 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = EA28E49F9120D00949E5FAAB /* main.m */; };
+		8172AD24AC6E26E18F4BB8FE /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E5873201DE5FA7E56144FE7 /* empty.swift */; };
+		D6D88A405B801B83965A394E /* empty.m in Sources */ = {isa = PBXBuildFile; fileRef = FFEB9EB1C9B6406A04C9EEDD /* empty.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		F38C65FC54D7CD052E02657E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2E45F5FFD4B2FD1997C70862 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9541626BF2F6C0EE11CA1AD7;
+			remoteInfo = "iOS-9.3-AppHost";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		1A670BBD3E8C25AB89221850 /* iOS-9.3-AppHost.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "iOS-9.3-AppHost.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		252D1E153AD8984665E68A74 /* resource_bundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = resource_bundle.plist; path = ../../../rules/library/resource_bundle.plist; sourceTree = "<group>"; };
+		4C2573089396ADCB63FBB6FE /* AssetCatalogFixture.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = AssetCatalogFixture.xcassets; path = ../../../rules/test_host_app/AssetCatalogFixture.xcassets; sourceTree = "<group>"; };
+		4E5873201DE5FA7E56144FE7 /* empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = empty.swift; path = "../unit-test/empty.swift"; sourceTree = "<group>"; };
+		527A05AD0BFB9B9E5471D17D /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = "../unit-test/BUILD.bazel"; sourceTree = "<group>"; };
+		7623EBE7D0F49CEC82671A64 /* ios.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = ios.entitlements; path = ../../../rules/test_host_app/ios.entitlements; sourceTree = "<group>"; };
+		79E7AD8A4A8CCCE1B4980CEB /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = ../../../rules/test_host_app/BUILD.bazel; sourceTree = "<group>"; };
+		A7A135B2F45AA4AE95B5C366 /* ExplicitHosted.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = ExplicitHosted.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		EA28E49F9120D00949E5FAAB /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = main.m; path = ../../../rules/test_host_app/main.m; sourceTree = "<group>"; };
+		ED29AB1B1F4BCEE96C19748E /* common.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = common.pch; path = ../../../rules/library/common.pch; sourceTree = "<group>"; };
+		FFEB9EB1C9B6406A04C9EEDD /* empty.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = empty.m; path = "../unit-test/empty.m"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		0B5CF4AEC90E36CC75780DCE /* unit-test */ = {
+			isa = PBXGroup;
+			children = (
+				527A05AD0BFB9B9E5471D17D /* BUILD.bazel */,
+				FFEB9EB1C9B6406A04C9EEDD /* empty.m */,
+				4E5873201DE5FA7E56144FE7 /* empty.swift */,
+			);
+			name = "unit-test";
+			sourceTree = "<group>";
+		};
+		332607BCF31A55A4E232E977 /* library */ = {
+			isa = PBXGroup;
+			children = (
+				ED29AB1B1F4BCEE96C19748E /* common.pch */,
+				252D1E153AD8984665E68A74 /* resource_bundle.plist */,
+			);
+			name = library;
+			sourceTree = "<group>";
+		};
+		4458650FCF08ECB7D12D6103 = {
+			isa = PBXGroup;
+			children = (
+				DEF4341AB4D0B0E4410D5310 /* rules */,
+				F00067E7E50682821D2C107F /* tests */,
+				80B743DAD4870A59BE6681A5 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		80B743DAD4870A59BE6681A5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A7A135B2F45AA4AE95B5C366 /* ExplicitHosted.xctest */,
+				1A670BBD3E8C25AB89221850 /* iOS-9.3-AppHost.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		DEF4341AB4D0B0E4410D5310 /* rules */ = {
+			isa = PBXGroup;
+			children = (
+				332607BCF31A55A4E232E977 /* library */,
+				E66A304A2AFBA29E06A2C7F4 /* test_host_app */,
+			);
+			name = rules;
+			sourceTree = "<group>";
+		};
+		E66A304A2AFBA29E06A2C7F4 /* test_host_app */ = {
+			isa = PBXGroup;
+			children = (
+				4C2573089396ADCB63FBB6FE /* AssetCatalogFixture.xcassets */,
+				79E7AD8A4A8CCCE1B4980CEB /* BUILD.bazel */,
+				7623EBE7D0F49CEC82671A64 /* ios.entitlements */,
+				EA28E49F9120D00949E5FAAB /* main.m */,
+			);
+			name = test_host_app;
+			sourceTree = "<group>";
+		};
+		F00067E7E50682821D2C107F /* tests */ = {
+			isa = PBXGroup;
+			children = (
+				FC860E9659513C5FA2ED11FB /* ios */,
+			);
+			name = tests;
+			sourceTree = "<group>";
+		};
+		FC860E9659513C5FA2ED11FB /* ios */ = {
+			isa = PBXGroup;
+			children = (
+				0B5CF4AEC90E36CC75780DCE /* unit-test */,
+			);
+			name = ios;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		5AE0FC080FA6A17C35721D0C /* ExplicitHosted */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B36500A688AD337FE657A850 /* Build configuration list for PBXNativeTarget "ExplicitHosted" */;
+			buildPhases = (
+				14EF484B9911CED9E8CEB705 /* Build with bazel */,
+				E93D8A9BAFBB26189905C129 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				7B117CC3FAAB21A99FD3F683 /* PBXTargetDependency */,
+			);
+			name = ExplicitHosted;
+			productName = ExplicitHosted;
+			productReference = A7A135B2F45AA4AE95B5C366 /* ExplicitHosted.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		9541626BF2F6C0EE11CA1AD7 /* iOS-9.3-AppHost */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 85B0F18E389439629F1AEA96 /* Build configuration list for PBXNativeTarget "iOS-9.3-AppHost" */;
+			buildPhases = (
+				911B498434C94010071D5767 /* Build with bazel */,
+				65484997632584E56344A3A2 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "iOS-9.3-AppHost";
+			productName = "iOS-9.3-AppHost";
+			productReference = 1A670BBD3E8C25AB89221850 /* iOS-9.3-AppHost.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		2E45F5FFD4B2FD1997C70862 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1020;
+				TargetAttributes = {
+				};
+			};
+			buildConfigurationList = 513AB10B3BA24602609F76A5 /* Build configuration list for PBXProject "TestWithHostApp" */;
+			compatibilityVersion = "Xcode 10.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 4458650FCF08ECB7D12D6103;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				5AE0FC080FA6A17C35721D0C /* ExplicitHosted */,
+				9541626BF2F6C0EE11CA1AD7 /* iOS-9.3-AppHost */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		14EF484B9911CED9E8CEB705 /* Build with bazel */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Build with bazel";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\nenv -u RUBYOPT -u RUBY_HOME -u GEM_HOME $BAZEL_BUILD_EXEC tests/ios/unit-test:ExplicitHosted\n$BAZEL_INSTALLER\n";
+		};
+		911B498434C94010071D5767 /* Build with bazel */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Build with bazel";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\nenv -u RUBYOPT -u RUBY_HOME -u GEM_HOME $BAZEL_BUILD_EXEC rules/test_host_app:iOS-9.3-AppHost\n$BAZEL_INSTALLER\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		65484997632584E56344A3A2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				45E7F8EFCCCC1A9DF4D72E93 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E93D8A9BAFBB26189905C129 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D6D88A405B801B83965A394E /* empty.m in Sources */,
+				8172AD24AC6E26E18F4BB8FE /* empty.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		7B117CC3FAAB21A99FD3F683 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9541626BF2F6C0EE11CA1AD7 /* iOS-9.3-AppHost */;
+			targetProxy = F38C65FC54D7CD052E02657E /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		267CDF14370121BE5F884778 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BUILD_EXEC = "$BAZEL_STUBS_DIR/build-wrapper";
+				BAZEL_EXECUTION_LOG_ENABLED = 0;
+				BAZEL_INSTALLER = $BAZEL_INSTALLERS_DIR/installer;
+				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
+				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
+				BAZEL_PATH = bazelisk;
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled --features=-swift.cacheable_swiftmodules --features=-swift.use_global_module_cache";
+				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
+				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
+				CC = "$BAZEL_STUBS_DIR/clang-stub";
+				CLANG_ANALYZER_EXEC = $CC;
+				CODE_SIGNING_ALLOWED = 0;
+				CXX = $CC;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
+				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
+				LD = "$BAZEL_STUBS_DIR/ld-stub";
+				LIBTOOL = /usr/bin/true;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_VERSION = 5;
+			};
+			name = Debug;
+		};
+		5F1F0A8FCB049380CBA75C41 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BIN_SUBDIR = /rules/test_host_app;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
+				INFOPLIST_FILE = "$BAZEL_STUBS_DIR/Info-stub.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MACH_O_TYPE = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.ios-app-host-9.3";
+				PRODUCT_NAME = "iOS-9.3-AppHost";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
+				VALID_ARCHS = "arm64 arm64e";
+			};
+			name = Release;
+		};
+		676421DD17502BB445A7A830 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BIN_SUBDIR = /rules/test_host_app;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
+				INFOPLIST_FILE = "$BAZEL_STUBS_DIR/Info-stub.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MACH_O_TYPE = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.ios-app-host-9.3";
+				PRODUCT_NAME = "iOS-9.3-AppHost";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
+				VALID_ARCHS = "arm64 arm64e";
+			};
+			name = Debug;
+		};
+		79BE8DD7D742DF533736517C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BUILD_EXEC = "$BAZEL_STUBS_DIR/build-wrapper";
+				BAZEL_EXECUTION_LOG_ENABLED = 0;
+				BAZEL_INSTALLER = $BAZEL_INSTALLERS_DIR/installer;
+				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
+				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
+				BAZEL_PATH = bazelisk;
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled --features=-swift.cacheable_swiftmodules --features=-swift.use_global_module_cache";
+				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
+				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
+				CC = "$BAZEL_STUBS_DIR/clang-stub";
+				CLANG_ANALYZER_EXEC = $CC;
+				CODE_SIGNING_ALLOWED = 0;
+				CXX = $CC;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
+				LD = "$BAZEL_STUBS_DIR/ld-stub";
+				LIBTOOL = /usr/bin/true;
+				SDKROOT = iphoneos;
+				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_VERSION = 5;
+			};
+			name = Release;
+		};
+		F3E3860302C8B303E0690262 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MACH_O_TYPE = "$(inherited)";
+				PRODUCT_NAME = ExplicitHosted;
+				SUPPORTS_MACCATALYST = 0;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOS-9.3-AppHost.app/iOS-9.3-AppHost";
+				VALID_ARCHS = "arm64 arm64e";
+			};
+			name = Debug;
+		};
+		FC00DAA2FE113CF025F03701 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MACH_O_TYPE = "$(inherited)";
+				PRODUCT_NAME = ExplicitHosted;
+				SUPPORTS_MACCATALYST = 0;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOS-9.3-AppHost.app/iOS-9.3-AppHost";
+				VALID_ARCHS = "arm64 arm64e";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		513AB10B3BA24602609F76A5 /* Build configuration list for PBXProject "TestWithHostApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				267CDF14370121BE5F884778 /* Debug */,
+				79BE8DD7D742DF533736517C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		85B0F18E389439629F1AEA96 /* Build configuration list for PBXNativeTarget "iOS-9.3-AppHost" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				676421DD17502BB445A7A830 /* Debug */,
+				5F1F0A8FCB049380CBA75C41 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		B36500A688AD337FE657A850 /* Build configuration list for PBXNativeTarget "ExplicitHosted" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F3E3860302C8B303E0690262 /* Debug */,
+				FC00DAA2FE113CF025F03701 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 2E45F5FFD4B2FD1997C70862 /* Project object */;
+}

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:TestWithHostApp.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
+	<false/>
+</dict>
+</plist>

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/xcshareddata/xcschemes/ExplicitHosted.xcscheme
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/xcshareddata/xcschemes/ExplicitHosted.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5AE0FC080FA6A17C35721D0C"
+               BuildableName = "ExplicitHosted.xctest"
+               BlueprintName = "ExplicitHosted"
+               ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5AE0FC080FA6A17C35721D0C"
+               BuildableName = "ExplicitHosted.xctest"
+               BlueprintName = "ExplicitHosted"
+               ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5AE0FC080FA6A17C35721D0C"
+            BuildableName = "ExplicitHosted.xctest"
+            BlueprintName = "ExplicitHosted"
+            ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5AE0FC080FA6A17C35721D0C"
+            BuildableName = "ExplicitHosted.xctest"
+            BlueprintName = "ExplicitHosted"
+            ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5AE0FC080FA6A17C35721D0C"
+            BuildableName = "ExplicitHosted.xctest"
+            BlueprintName = "ExplicitHosted"
+            ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/xcshareddata/xcschemes/iOS-9.3-AppHost.xcscheme
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/xcshareddata/xcschemes/iOS-9.3-AppHost.xcscheme
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9541626BF2F6C0EE11CA1AD7"
+               BuildableName = "iOS-9.3-AppHost.app"
+               BlueprintName = "iOS-9.3-AppHost"
+               ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9541626BF2F6C0EE11CA1AD7"
+            BuildableName = "iOS-9.3-AppHost.app"
+            BlueprintName = "iOS-9.3-AppHost"
+            ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9541626BF2F6C0EE11CA1AD7"
+            BuildableName = "iOS-9.3-AppHost.app"
+            BlueprintName = "iOS-9.3-AppHost"
+            ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9541626BF2F6C0EE11CA1AD7"
+            BuildableName = "iOS-9.3-AppHost.app"
+            BlueprintName = "iOS-9.3-AppHost"
+            ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Fix xcodeproj: 
* Pass a custom name correctly
* Add the host app to the project when adding the transitive dependencies (seems it was forgotten)