### PR TITLE
Set clang flags in lldb, propagate linker options

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,9 +6,6 @@ build --incompatible_objc_compile_info_migration
 # so circumvent by not using the sandbox
 build --strategy=Stardoc=standalone
 
-# Debugging does not work in sandbox mode. Uncomment these lines to turn off sandboxing.
-# build --genrule_strategy=standalone
-# build --spawn_strategy=standalone
 
 build --verbose_failures # Print the full command line for commands that failed
 build --test_output=errors # Prints log file output to the console on failure
@@ -19,5 +16,10 @@ build --deleted_packages tests/ios/frameworks/sources-with-prebuilt-binaries
 
 # Enable these features to test local and CI builds
 # when swiftmodule caching is enabled.
-# build --features=swift.cacheable_swiftmodules
-# build --features=swift.use_global_module_cache
+build --features=swift.cacheable_swiftmodules
+build --features=swift.use_global_module_cache
+build --compilation_mode=dbg
+
+# Debugging does not work in sandbox mode
+build --genrule_strategy=standalone
+build --spawn_strategy=standalone

--- a/.bazelrc
+++ b/.bazelrc
@@ -6,6 +6,9 @@ build --incompatible_objc_compile_info_migration
 # so circumvent by not using the sandbox
 build --strategy=Stardoc=standalone
 
+# Debugging does not work in sandbox mode. Uncomment these lines to turn off sandboxing.
+# build --genrule_strategy=standalone
+# build --spawn_strategy=standalone
 
 build --verbose_failures # Print the full command line for commands that failed
 build --test_output=errors # Prints log file output to the console on failure
@@ -14,12 +17,6 @@ build --test_output=errors # Prints log file output to the console on failure
 # because it takes quite some time. They will only run on CI
 build --deleted_packages tests/ios/frameworks/sources-with-prebuilt-binaries
 
-# Enable these features to test local and CI builds
-# when swiftmodule caching is enabled.
-build --features=swift.cacheable_swiftmodules
-build --features=swift.use_global_module_cache
+# Enable dbg compilation mode in this repo, so we can test xcodeproj-built
+# binaries contain debug symbol tables.
 build --compilation_mode=dbg
-
-# Debugging does not work in sandbox mode
-build --genrule_strategy=standalone
-build --spawn_strategy=standalone

--- a/README.md
+++ b/README.md
@@ -92,3 +92,6 @@ ios_application(
 
 See the [tests](https://github.com/bazel-ios/rules_ios/tree/master/tests)
 directory for sample applications.
+
+## Special note about debugging
+Debugging does not work in sandbox mode, due to issue #108. The workaround for now is to disable sandboxing in the .bazelrc file.

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -250,9 +250,13 @@ def _apple_framework_packaging_impl(ctx):
         "imported_library",
         "force_load_library",
         "multi_arch_linked_archives",
+        "multi_arch_linked_binaries",
+        "multi_arch_dynamic_libraries",
         "source",
         "define",
         "include",
+        "link_inputs",
+        "linkopt",
     ]:
         set = depset(
             direct = [],

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -407,7 +407,7 @@ def _xcodeproj_impl(ctx):
         "BAZEL_BUILD_EXEC": "$BAZEL_STUBS_DIR/build-wrapper",
         "BAZEL_OUTPUT_PROCESSOR": "$BAZEL_STUBS_DIR/output-processor.rb",
         "BAZEL_PATH": ctx.attr.bazel_path,
-        "BAZEL_RULES_IOS_OPTIONS": "--@build_bazel_rules_ios//rules:local_debug_options_enabled --features=-swift.cacheable_swiftmodules --features=-swift.use_global_module_cache",
+        "BAZEL_RULES_IOS_OPTIONS": "--@build_bazel_rules_ios//rules:local_debug_options_enabled",
         "BAZEL_WORKSPACE_ROOT": "$SRCROOT/%s" % script_dot_dots,
         "BAZEL_STUBS_DIR": "$PROJECT_FILE_PATH/bazelstubs",
         "BAZEL_INSTALLERS_DIR": "$PROJECT_FILE_PATH/bazelinstallers",
@@ -456,7 +456,7 @@ def _xcodeproj_impl(ctx):
             if target_info.product_type != existing_type:
                 fail("""\
 Failed to generate xcodeproj for "{}" due to conflicting targets:
-Target "{}" is already defined with type "{}". 
+Target "{}" is already defined with type "{}".
 A same-name target with label "{}" of type "{}" wants to override.
 Double check your rule declaration for naming or add `xcodeproj-ignore-as-target` as a tag to choose which target to ignore.
 """.format(ctx.label, target_name, existing_type, target_info.bazel_build_target_name, target_info.product_type))
@@ -510,6 +510,10 @@ Double check your rule declaration for naming or add `xcodeproj-ignore-as-target
         target_settings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] = " ".join(
             ["\"%s\"" % d for d in defines_without_equal_sign],
         )
+        target_settings["BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS"] = " ".join(
+            ["-D%s" % d for d in target_info.cc_defines.to_list()],
+        )
+
 
         if target_info.product_type == "application":
             target_settings["INFOPLIST_FILE"] = "$BAZEL_STUBS_DIR/Info-stub.plist"

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -514,7 +514,6 @@ Double check your rule declaration for naming or add `xcodeproj-ignore-as-target
             ["-D%s" % d for d in target_info.cc_defines.to_list()],
         )
 
-
         if target_info.product_type == "application":
             target_settings["INFOPLIST_FILE"] = "$BAZEL_STUBS_DIR/Info-stub.plist"
             target_settings["PRODUCT_BUNDLE_IDENTIFIER"] = target_info.bundle_id

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -20,21 +20,17 @@ settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS
 END
 
-set +u
-if [[ -n $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]]
+if [[ -n ${BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS:-} ]]
 then
-set -u
-cat <<-END >> ~/.lldbinit-source-map
+  cat <<-END >> ~/.lldbinit-source-map
 settings set -- target.swift-extra-clang-flags $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS
 END
 fi
-set -u
 
 BAZEL_EXTERNAL_DIRNAME="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
-if [ -d $BAZEL_EXTERNAL_DIRNAME ]
+if [ -d "$BAZEL_EXTERNAL_DIRNAME" ]
 then
-cat <<-END >> ~/.lldbinit-source-map
-settings append target.source-map ./external/ $BAZEL_EXTERNAL_DIRNAME
+  cat <<-END >> ~/.lldbinit-source-map
+settings append target.source-map ./external/ "$BAZEL_EXTERNAL_DIRNAME"
 END
 fi
-

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -20,3 +20,10 @@ settings append target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
 settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS
 END
+
+if [ -v BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]
+then
+cat <<-END > ~/.lldbinit-source-map
+settings set -- target.swift-extra-clang-flags $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS
+END
+fi

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -15,15 +15,26 @@ set -euo pipefail
 #
 #     command source ~/.lldbinit-source-map
 cat <<-END > ~/.lldbinit-source-map
-settings set target.source-map ./external/ "$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
-settings append target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
+settings set target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
 settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS
 END
 
-if [ -v BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]
+set +u
+if [[ -n $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]]
 then
-cat <<-END > ~/.lldbinit-source-map
+set -u
+cat <<-END >> ~/.lldbinit-source-map
 settings set -- target.swift-extra-clang-flags $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS
 END
 fi
+set -u
+
+BAZEL_EXTERNAL_DIRNAME="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
+if [ -d $BAZEL_EXTERNAL_DIRNAME ]
+then
+cat <<-END >> ~/.lldbinit-source-map
+settings append target.source-map ./external/ $BAZEL_EXTERNAL_DIRNAME
+END
+fi
+

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
@@ -268,11 +268,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-f75cadb68314/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-f75cadb68314/bin/tests/ios/frameworks/objc/ObjcFramework_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-f75cadb68314/bin/tests/ios/frameworks/objc/ObjcFramework_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-f75cadb68314/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-f75cadb68314/bin/tests/ios/frameworks/objc/ObjcFramework_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-f75cadb68314/bin/tests/ios/frameworks/objc/ObjcFramework_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACH_O_TYPE = "$(inherited)";
 				PRODUCT_NAME = ObjcFramework;
@@ -290,7 +291,7 @@
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
-				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled --features=-swift.cacheable_swiftmodules --features=-swift.use_global_module_cache";
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 				CC = "$BAZEL_STUBS_DIR/clang-stub";
@@ -314,11 +315,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-f75cadb68314/bin/tests/ios/frameworks/objc/ObjcFramework\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-f75cadb68314/bin/tests/ios/frameworks/objc/ObjcFramework\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-0010df40fd2e/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-0010df40fd2e/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-0010df40fd2e/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-0010df40fd2e/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-0010df40fd2e/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-0010df40fd2e/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
 				MACH_O_TYPE = "$(inherited)";
 				PRODUCT_NAME = ObjcFrameworkTestLib;
@@ -331,11 +333,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-f75cadb68314/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-f75cadb68314/bin/tests/ios/frameworks/objc/ObjcFramework_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-f75cadb68314/bin/tests/ios/frameworks/objc/ObjcFramework_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-f75cadb68314/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-f75cadb68314/bin/tests/ios/frameworks/objc/ObjcFramework_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-f75cadb68314/bin/tests/ios/frameworks/objc/ObjcFramework_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACH_O_TYPE = "$(inherited)";
 				PRODUCT_NAME = ObjcFramework;
@@ -353,7 +356,7 @@
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
-				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled --features=-swift.cacheable_swiftmodules --features=-swift.use_global_module_cache";
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 				CC = "$BAZEL_STUBS_DIR/clang-stub";
@@ -375,9 +378,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-f75cadb68314/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-0010df40fd2e/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-f75cadb68314/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-0010df40fd2e/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
@@ -393,9 +397,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-f75cadb68314/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-0010df40fd2e/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-f75cadb68314/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-0010df40fd2e/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
@@ -411,11 +416,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-f75cadb68314/bin/tests/ios/frameworks/objc/ObjcFramework\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-f75cadb68314/bin/tests/ios/frameworks/objc/ObjcFramework\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-0010df40fd2e/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-0010df40fd2e/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-0010df40fd2e/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-0010df40fd2e/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-0010df40fd2e/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-0010df40fd2e/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_angled_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
 				MACH_O_TYPE = "$(inherited)";
 				PRODUCT_NAME = ObjcFrameworkTestLib;

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -20,21 +20,17 @@ settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS
 END
 
-set +u
-if [[ -n $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]]
+if [[ -n ${BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS:-} ]]
 then
-set -u
-cat <<-END >> ~/.lldbinit-source-map
+  cat <<-END >> ~/.lldbinit-source-map
 settings set -- target.swift-extra-clang-flags $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS
 END
 fi
-set -u
 
 BAZEL_EXTERNAL_DIRNAME="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
-if [ -d $BAZEL_EXTERNAL_DIRNAME ]
+if [ -d "$BAZEL_EXTERNAL_DIRNAME" ]
 then
-cat <<-END >> ~/.lldbinit-source-map
-settings append target.source-map ./external/ $BAZEL_EXTERNAL_DIRNAME
+  cat <<-END >> ~/.lldbinit-source-map
+settings append target.source-map ./external/ "$BAZEL_EXTERNAL_DIRNAME"
 END
 fi
-

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -20,3 +20,10 @@ settings append target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
 settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS
 END
+
+if [ -v BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]
+then
+cat <<-END > ~/.lldbinit-source-map
+settings set -- target.swift-extra-clang-flags $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS
+END
+fi

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -15,15 +15,26 @@ set -euo pipefail
 #
 #     command source ~/.lldbinit-source-map
 cat <<-END > ~/.lldbinit-source-map
-settings set target.source-map ./external/ "$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
-settings append target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
+settings set target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
 settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS
 END
 
-if [ -v BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]
+set +u
+if [[ -n $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]]
 then
-cat <<-END > ~/.lldbinit-source-map
+set -u
+cat <<-END >> ~/.lldbinit-source-map
 settings set -- target.swift-extra-clang-flags $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS
 END
 fi
+set -u
+
+BAZEL_EXTERNAL_DIRNAME="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
+if [ -d $BAZEL_EXTERNAL_DIRNAME ]
+then
+cat <<-END >> ~/.lldbinit-source-map
+settings append target.source-map ./external/ $BAZEL_EXTERNAL_DIRNAME
+END
+fi
+

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.pbxproj
@@ -280,7 +280,7 @@
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
-				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled --features=-swift.cacheable_swiftmodules --features=-swift.use_global_module_cache";
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 				CC = "$BAZEL_STUBS_DIR/clang-stub";
@@ -309,7 +309,7 @@
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
-				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled --features=-swift.cacheable_swiftmodules --features=-swift.use_global_module_cache";
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 				CC = "$BAZEL_STUBS_DIR/clang-stub";
@@ -331,9 +331,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-e11e4ada49a5/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-e11e4ada49a5/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -350,9 +351,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-e11e4ada49a5/bin/tests/ios/unit-test/test-imports-app/SomeFramework\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-e11e4ada49a5/bin/tests/ios/unit-test/test-imports-app/SomeFramework\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				INFOPLIST_FILE = "$BAZEL_STUBS_DIR/Info-stub.plist";
@@ -369,9 +371,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-e11e4ada49a5/bin/tests/ios/unit-test/test-imports-app/SomeFramework\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-e11e4ada49a5/bin/tests/ios/unit-test/test-imports-app/SomeFramework\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				INFOPLIST_FILE = "$BAZEL_STUBS_DIR/Info-stub.plist";
@@ -388,9 +391,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-e11e4ada49a5/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-e11e4ada49a5/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -15,8 +15,22 @@ set -euo pipefail
 #
 #     command source ~/.lldbinit-source-map
 cat <<-END > ~/.lldbinit-source-map
-settings set target.source-map ./external/ "$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
-settings append target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
+settings set target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
 settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS
 END
+
+if [[ -n ${BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS:-} ]]
+then
+  cat <<-END >> ~/.lldbinit-source-map
+settings set -- target.swift-extra-clang-flags $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS
+END
+fi
+
+BAZEL_EXTERNAL_DIRNAME="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
+if [ -d "$BAZEL_EXTERNAL_DIRNAME" ]
+then
+  cat <<-END >> ~/.lldbinit-source-map
+settings append target.source-map ./external/ "$BAZEL_EXTERNAL_DIRNAME"
+END
+fi

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.pbxproj
@@ -250,7 +250,7 @@
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
-				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled --features=-swift.cacheable_swiftmodules --features=-swift.use_global_module_cache";
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 				CC = "$BAZEL_STUBS_DIR/clang-stub";
@@ -274,6 +274,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = /rules/test_host_app;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
@@ -293,6 +294,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = /rules/test_host_app;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
@@ -317,7 +319,7 @@
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
-				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled --features=-swift.cacheable_swiftmodules --features=-swift.use_global_module_cache";
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 				CC = "$BAZEL_STUBS_DIR/clang-stub";
@@ -339,6 +341,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test";
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
@@ -358,6 +361,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test";
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";

--- a/tests/ios/xcodeproj/build.sh
+++ b/tests/ios/xcodeproj/build.sh
@@ -12,6 +12,3 @@ for i in `find *.xcodeproj -maxdepth 0 -type d`; do
     xcodebuild -project $i -alltargets -destination "id=$SIM_DEVICE_ID" -quiet
 done
 
-# The linked binary should include ASTs for the transitive dependency as well
-export NUM_LINKED_ASTS=`dsymutil -s bazel-bin/tests/ios/unit-test/test-imports-app/TestImports-App_archive-root/Payload/TestImports-App.app/TestImports-App  | grep -c N_AST`
-[[ $NUM_LINKED_ASTS == 2 ]]

--- a/tests/ios/xcodeproj/build.sh
+++ b/tests/ios/xcodeproj/build.sh
@@ -11,3 +11,7 @@ export SIM_DEVICE_ID=`xcodebuild $SAMPLE_PROJECT_AND_SCHEME -showdestinations | 
 for i in `find *.xcodeproj -maxdepth 0 -type d`; do
     xcodebuild -project $i -alltargets -destination "id=$SIM_DEVICE_ID" -quiet
 done
+
+# The linked binary should include ASTs for the transitive dependency as well
+export NUM_LINKED_ASTS=`dsymutil -s bazel-bin/tests/ios/unit-test/test-imports-app/TestImports-App_archive-root/Payload/TestImports-App.app/TestImports-App  | grep -c N_AST`
+[[ $NUM_LINKED_ASTS == 2 ]]

--- a/tests/ios/xcodeproj/post_build_check.sh
+++ b/tests/ios/xcodeproj/post_build_check.sh
@@ -2,6 +2,10 @@ set -eu
 
 cd $(dirname $0)
 
+# The linked binary should include ASTs for the transitive dependency as well
+export NUM_LINKED_ASTS=`dsymutil -s ../../../bazel-bin/tests/ios/unit-test/test-imports-app/TestImports-App_archive-root/Payload/TestImports-App.app/TestImports-App  | grep -c N_AST`
+[[ $NUM_LINKED_ASTS == 2 ]]
+
 export HSP=`grep "HEADER_SEARCH_PATHS" *.xcodeproj/project.pbxproj | grep -o  "bazel-out\S*\.hmap"`
 echo "Make sure hmap files exist after build"
 for path in ${HSP}; do

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -20,21 +20,17 @@ settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS
 END
 
-set +u
-if [[ -n $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]]
+if [[ -n ${BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS:-} ]]
 then
-set -u
-cat <<-END >> ~/.lldbinit-source-map
+  cat <<-END >> ~/.lldbinit-source-map
 settings set -- target.swift-extra-clang-flags $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS
 END
 fi
-set -u
 
 BAZEL_EXTERNAL_DIRNAME="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
-if [ -d $BAZEL_EXTERNAL_DIRNAME ]
+if [ -d "$BAZEL_EXTERNAL_DIRNAME" ]
 then
-cat <<-END >> ~/.lldbinit-source-map
-settings append target.source-map ./external/ $BAZEL_EXTERNAL_DIRNAME
+  cat <<-END >> ~/.lldbinit-source-map
+settings append target.source-map ./external/ "$BAZEL_EXTERNAL_DIRNAME"
 END
 fi
-

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -20,3 +20,10 @@ settings append target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
 settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS
 END
+
+if [ -v BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]
+then
+cat <<-END > ~/.lldbinit-source-map
+settings set -- target.swift-extra-clang-flags $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS
+END
+fi

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -15,15 +15,26 @@ set -euo pipefail
 #
 #     command source ~/.lldbinit-source-map
 cat <<-END > ~/.lldbinit-source-map
-settings set target.source-map ./external/ "$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
-settings append target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
+settings set target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
 settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS
 END
 
-if [ -v BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]
+set +u
+if [[ -n $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]]
 then
-cat <<-END > ~/.lldbinit-source-map
+set -u
+cat <<-END >> ~/.lldbinit-source-map
 settings set -- target.swift-extra-clang-flags $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS
 END
 fi
+set -u
+
+BAZEL_EXTERNAL_DIRNAME="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
+if [ -d $BAZEL_EXTERNAL_DIRNAME ]
+then
+cat <<-END >> ~/.lldbinit-source-map
+settings append target.source-map ./external/ $BAZEL_EXTERNAL_DIRNAME
+END
+fi
+

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
@@ -274,6 +274,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = /tests/macos/xcodeproj;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "-DREQUIRED_DEFINED_FLAG=1 -DFLAG_WITH_VALUE_ZERO=0";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
@@ -292,6 +293,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = /rules/test_host_app;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
@@ -311,6 +313,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = /rules/test_host_app;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
@@ -335,7 +338,7 @@
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
-				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled --features=-swift.cacheable_swiftmodules --features=-swift.use_global_module_cache";
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 				CC = "$BAZEL_STUBS_DIR/clang-stub";
@@ -364,7 +367,7 @@
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
-				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled --features=-swift.cacheable_swiftmodules --features=-swift.use_global_module_cache";
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 				CC = "$BAZEL_STUBS_DIR/clang-stub";
@@ -386,6 +389,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = /tests/macos/xcodeproj;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "-DREQUIRED_DEFINED_FLAG=1 -DFLAG_WITH_VALUE_ZERO=0";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
@@ -404,6 +408,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = /tests/macos/xcodeproj;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "-DREQUIRED_DEFINED_FLAG=1 -DFLAG_WITH_VALUE_ZERO=0";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
@@ -422,6 +427,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = /tests/macos/xcodeproj;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "-DREQUIRED_DEFINED_FLAG=1 -DFLAG_WITH_VALUE_ZERO=0";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -20,21 +20,17 @@ settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS
 END
 
-set +u
-if [[ -n $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]]
+if [[ -n ${BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS:-} ]]
 then
-set -u
-cat <<-END >> ~/.lldbinit-source-map
+  cat <<-END >> ~/.lldbinit-source-map
 settings set -- target.swift-extra-clang-flags $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS
 END
 fi
-set -u
 
 BAZEL_EXTERNAL_DIRNAME="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
-if [ -d $BAZEL_EXTERNAL_DIRNAME ]
+if [ -d "$BAZEL_EXTERNAL_DIRNAME" ]
 then
-cat <<-END >> ~/.lldbinit-source-map
-settings append target.source-map ./external/ $BAZEL_EXTERNAL_DIRNAME
+  cat <<-END >> ~/.lldbinit-source-map
+settings append target.source-map ./external/ "$BAZEL_EXTERNAL_DIRNAME"
 END
 fi
-

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -20,3 +20,10 @@ settings append target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
 settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS
 END
+
+if [ -v BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]
+then
+cat <<-END > ~/.lldbinit-source-map
+settings set -- target.swift-extra-clang-flags $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS
+END
+fi

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -15,15 +15,26 @@ set -euo pipefail
 #
 #     command source ~/.lldbinit-source-map
 cat <<-END > ~/.lldbinit-source-map
-settings set target.source-map ./external/ "$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
-settings append target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
+settings set target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
 settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS
 END
 
-if [ -v BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]
+set +u
+if [[ -n $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]]
 then
-cat <<-END > ~/.lldbinit-source-map
+set -u
+cat <<-END >> ~/.lldbinit-source-map
 settings set -- target.swift-extra-clang-flags $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS
 END
 fi
+set -u
+
+BAZEL_EXTERNAL_DIRNAME="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
+if [ -d $BAZEL_EXTERNAL_DIRNAME ]
+then
+cat <<-END >> ~/.lldbinit-source-map
+settings append target.source-map ./external/ $BAZEL_EXTERNAL_DIRNAME
+END
+fi
+

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
@@ -274,6 +274,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = /tests/macos/xcodeproj;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "-DREQUIRED_DEFINED_FLAG=1 -DFLAG_WITH_VALUE_ZERO=0";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
@@ -292,6 +293,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = /tests/macos/xcodeproj;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "-DREQUIRED_DEFINED_FLAG=1 -DFLAG_WITH_VALUE_ZERO=0";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
@@ -315,7 +317,7 @@
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
-				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled --features=-swift.cacheable_swiftmodules --features=-swift.use_global_module_cache";
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 				CC = "$BAZEL_STUBS_DIR/clang-stub";
@@ -337,6 +339,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = /rules/test_host_app;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
@@ -356,6 +359,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = /rules/test_host_app;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
@@ -375,6 +379,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = /tests/macos/xcodeproj;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "-DREQUIRED_DEFINED_FLAG=1 -DFLAG_WITH_VALUE_ZERO=0";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
@@ -398,7 +403,7 @@
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
-				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled --features=-swift.cacheable_swiftmodules --features=-swift.use_global_module_cache";
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 				CC = "$BAZEL_STUBS_DIR/clang-stub";
@@ -422,6 +427,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = /tests/macos/xcodeproj;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "-DREQUIRED_DEFINED_FLAG=1 -DFLAG_WITH_VALUE_ZERO=0";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -20,21 +20,17 @@ settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS
 END
 
-set +u
-if [[ -n $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]]
+if [[ -n ${BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS:-} ]]
 then
-set -u
-cat <<-END >> ~/.lldbinit-source-map
+  cat <<-END >> ~/.lldbinit-source-map
 settings set -- target.swift-extra-clang-flags $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS
 END
 fi
-set -u
 
 BAZEL_EXTERNAL_DIRNAME="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
-if [ -d $BAZEL_EXTERNAL_DIRNAME ]
+if [ -d "$BAZEL_EXTERNAL_DIRNAME" ]
 then
-cat <<-END >> ~/.lldbinit-source-map
-settings append target.source-map ./external/ $BAZEL_EXTERNAL_DIRNAME
+  cat <<-END >> ~/.lldbinit-source-map
+settings append target.source-map ./external/ "$BAZEL_EXTERNAL_DIRNAME"
 END
 fi
-

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -20,3 +20,10 @@ settings append target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
 settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS
 END
+
+if [ -v BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]
+then
+cat <<-END > ~/.lldbinit-source-map
+settings set -- target.swift-extra-clang-flags $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS
+END
+fi

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -15,15 +15,26 @@ set -euo pipefail
 #
 #     command source ~/.lldbinit-source-map
 cat <<-END > ~/.lldbinit-source-map
-settings set target.source-map ./external/ "$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
-settings append target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
+settings set target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
 settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS
 END
 
-if [ -v BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]
+set +u
+if [[ -n $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]]
 then
-cat <<-END > ~/.lldbinit-source-map
+set -u
+cat <<-END >> ~/.lldbinit-source-map
 settings set -- target.swift-extra-clang-flags $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS
 END
 fi
+set -u
+
+BAZEL_EXTERNAL_DIRNAME="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
+if [ -d $BAZEL_EXTERNAL_DIRNAME ]
+then
+cat <<-END >> ~/.lldbinit-source-map
+settings append target.source-map ./external/ $BAZEL_EXTERNAL_DIRNAME
+END
+fi
+

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
@@ -404,9 +404,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-e11e4ada49a5/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-e11e4ada49a5/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -423,9 +424,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-e11e4ada49a5/bin/tests/ios/unit-test/test-imports-app/SomeFramework\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-e11e4ada49a5/bin/tests/ios/unit-test/test-imports-app/SomeFramework\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				INFOPLIST_FILE = "$BAZEL_STUBS_DIR/Info-stub.plist";
@@ -442,9 +444,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-e11e4ada49a5/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-e11e4ada49a5/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -461,6 +464,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test";
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
@@ -480,9 +484,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test/test-imports-app";
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-e11e4ada49a5/bin/tests/ios/unit-test/test-imports-app/SomeFramework\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-e11e4ada49a5/bin/tests/ios/unit-test/test-imports-app/SomeFramework\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				INFOPLIST_FILE = "$BAZEL_STUBS_DIR/Info-stub.plist";
@@ -504,7 +509,7 @@
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
-				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled --features=-swift.cacheable_swiftmodules --features=-swift.use_global_module_cache";
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 				CC = "$BAZEL_STUBS_DIR/clang-stub";
@@ -526,6 +531,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = /rules/test_host_app;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
@@ -545,6 +551,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = /rules/test_host_app;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
@@ -569,7 +576,7 @@
 				BAZEL_INSTALLERS_DIR = $PROJECT_FILE_PATH/bazelinstallers;
 				BAZEL_OUTPUT_PROCESSOR = "$BAZEL_STUBS_DIR/output-processor.rb";
 				BAZEL_PATH = bazelisk;
-				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled --features=-swift.cacheable_swiftmodules --features=-swift.use_global_module_cache";
+				BAZEL_RULES_IOS_OPTIONS = "--@build_bazel_rules_ios//rules:local_debug_options_enabled";
 				BAZEL_STUBS_DIR = $PROJECT_FILE_PATH/bazelstubs;
 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 				CC = "$BAZEL_STUBS_DIR/clang-stub";
@@ -593,6 +600,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test";
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";

--- a/tools/xcodeproj_shims/installers/lldb-settings.sh
+++ b/tools/xcodeproj_shims/installers/lldb-settings.sh
@@ -20,21 +20,17 @@ settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS
 END
 
-set +u
-if [[ -n $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]]
+if [[ -n ${BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS:-} ]]
 then
-set -u
-cat <<-END >> ~/.lldbinit-source-map
+  cat <<-END >> ~/.lldbinit-source-map
 settings set -- target.swift-extra-clang-flags $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS
 END
 fi
-set -u
 
 BAZEL_EXTERNAL_DIRNAME="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
-if [ -d $BAZEL_EXTERNAL_DIRNAME ]
+if [ -d "$BAZEL_EXTERNAL_DIRNAME" ]
 then
-cat <<-END >> ~/.lldbinit-source-map
-settings append target.source-map ./external/ $BAZEL_EXTERNAL_DIRNAME
+  cat <<-END >> ~/.lldbinit-source-map
+settings append target.source-map ./external/ "$BAZEL_EXTERNAL_DIRNAME"
 END
 fi
-

--- a/tools/xcodeproj_shims/installers/lldb-settings.sh
+++ b/tools/xcodeproj_shims/installers/lldb-settings.sh
@@ -20,3 +20,10 @@ settings append target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
 settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS
 END
+
+if [ -v BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]
+then
+cat <<-END > ~/.lldbinit-source-map
+settings set -- target.swift-extra-clang-flags $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS
+END
+fi

--- a/tools/xcodeproj_shims/installers/lldb-settings.sh
+++ b/tools/xcodeproj_shims/installers/lldb-settings.sh
@@ -15,15 +15,26 @@ set -euo pipefail
 #
 #     command source ~/.lldbinit-source-map
 cat <<-END > ~/.lldbinit-source-map
-settings set target.source-map ./external/ "$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
-settings append target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
+settings set target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
 settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS
 END
 
-if [ -v BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]
+set +u
+if [[ -n $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS ]]
 then
-cat <<-END > ~/.lldbinit-source-map
+set -u
+cat <<-END >> ~/.lldbinit-source-map
 settings set -- target.swift-extra-clang-flags $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS
 END
 fi
+set -u
+
+BAZEL_EXTERNAL_DIRNAME="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
+if [ -d $BAZEL_EXTERNAL_DIRNAME ]
+then
+cat <<-END >> ~/.lldbinit-source-map
+settings append target.source-map ./external/ $BAZEL_EXTERNAL_DIRNAME
+END
+fi
+


### PR DESCRIPTION
Debugging apps and tests with transitive swift when `cacheable_swiftmodules` was enabled was not working for us, because:
1. the LLDB swift-extra-clang-flags setting was not set, and
2. Frameworks that generated ASTs were not propagating the appropriate linker options to apps/tests that depended on them. `link_inputs` is a critical piece to propagate forward to the linker; according to the documentation (https://docs.bazel.build/versions/master/skylark/lib/ObjcProvider.html#link_inputs): "Link time artifacts from dependencies that do not fall into any other category such as libraries or archives. This catch-all provides a way to add arbitrary data (e.g. Swift AST files) to the linker. The rule that adds these is also responsible to add the necessary linker flags to 'linkopt'."

Note that when `cacheable_swiftmodules` is disabled, libraries are built with the `serialize-debugging-options` flag, so debugging works just fine. When `cacheable_swiftmodules` is enabled however, we need to give LLDB some additional information and also make sure all the dependent ASTs are linked into the final app/test binary.

The `dsymutil` command is being used in the tests to view the debugging sections of the generated app/test binary to ensure ALL necessary ASTs are linked to it.