### PR TITLE
Bazel build produces error when adding generated header to .h file

### DIFF
--- a/tests/ios/frameworks/mixed-source/only-source/MixedSourceFramework/Logger/DoubleQuoteNamespacedLogger.h
+++ b/tests/ios/frameworks/mixed-source/only-source/MixedSourceFramework/Logger/DoubleQuoteNamespacedLogger.h
@@ -2,6 +2,7 @@
 #define DoubleQuoteNamespacedLogger_h
 
 #import <Foundation/Foundation.h>
+#import "MixedSourceFramework/MixedSourceFramework-Swift.h"
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
See failed build in this PR, only change is adding the -swift.h file
If doing the same thing in a xcode generated project, it will be fine and pointing to the generated `-swift` file

Unless this is not supported?