### PR TITLE
Stop specifiying a manual group for xcodeproj sources

### DIFF
--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -127,8 +127,8 @@ native_binary(
     visibility = ["//visibility:public"],
 )
 """,
-        canonical_id = "xcodegen-2.17.0",
-        sha256 = "6d1e4a8617e7d13910366c25d1e3ab475158e91e3071cb17f44e3ea29c9a1a41",
+        canonical_id = "xcodegen-2.17.0-19-g775e14c",
+        sha256 = "5dbda77da860e615e32f80de8c662757e7ccb7e5012c7fa233b137a4baa36c3d",
         strip_prefix = "xcodegen",
-        urls = ["https://github.com/yonaskolb/XcodeGen/releases/download/2.17.0/xcodegen.zip"],
+        urls = ["https://github.com/segiddins/XcodeGen/releases/download/2.17.0-19-g775e14c/xcodegen.zip"],
     )

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -326,7 +326,6 @@ def _gather_asset_sources(target_info, path_prefix):
 
     for s in target_info.asset_srcs.to_list():
         short_path = s.short_path
-        group = paths.dirname(short_path)
         (extension, path_so_far) = _classify_asset(short_path)
 
         # Reference for logics below:
@@ -334,7 +333,6 @@ def _gather_asset_sources(target_info, path_prefix):
         if extension == None:
             payload = {
                 "path": paths.join(path_prefix, short_path),
-                "group": group,
                 "optional": True,
                 "buildPhase": "none",
             }
@@ -359,7 +357,6 @@ def _gather_asset_sources(target_info, path_prefix):
     for datamodel_key in datamodel_groups.keys():
         payload = {
             "path": paths.join(path_prefix, datamodel_key),
-            "group": paths.dirname(datamodel_key),
             "optional": True,
             "buildPhase": "none",
         }
@@ -368,7 +365,6 @@ def _gather_asset_sources(target_info, path_prefix):
     for asset_key in catalog_groups.keys():
         payload = {
             "path": paths.join(path_prefix, asset_key),
-            "group": paths.dirname(asset_key),
             "optional": True,
             "buildPhase": "none",
         }
@@ -377,7 +373,6 @@ def _gather_asset_sources(target_info, path_prefix):
     # Append BUILD.bazel files to project
     asset_sources += [{
         "path": paths.join(path_prefix, p),
-        "group": paths.dirname(p),
         "optional": True,
         "buildPhase": "none",
         # TODO: add source language type once https://github.com/yonaskolb/XcodeGen/issues/850 is resolved
@@ -429,12 +424,10 @@ def _populate_xcodeproj_targets_and_schemes(ctx, targets, src_dot_dots):
         target_macho_type = "staticlib" if product_type == "framework" else "$(inherited)"
         compiled_sources = [{
             "path": paths.join(src_dot_dots, s.short_path),
-            "group": paths.dirname(s.short_path),
             "optional": True,
         } for s in target_info.srcs.to_list()]
         compiled_non_arc_sources = [{
             "path": paths.join(src_dot_dots, s.short_path),
-            "group": paths.dirname(s.short_path),
             "optional": True,
             "compilerFlags": "-fno-objc-arc",
         } for s in target_info.non_arc_srcs.to_list()]

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
@@ -7,55 +7,79 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		486340F1844ADD3B94BFE9F6 /* FooFrameworkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F95CB476EBF28FCFE1BCE04F /* FooFrameworkTests.m */; };
-		D100BF9D72B5F6940F83816B /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 6902D1207F875225638DE30A /* main.m */; };
+		0BD7FD856ED50175FA3D3BC9 /* FooFrameworkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 091655034CF618D208C22AE8 /* FooFrameworkTests.m */; };
+		5C8EED4DAAF3B4B069337569 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = CF7A2F537C999952921627A8 /* main.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		091655034CF618D208C22AE8 /* FooFrameworkTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FooFrameworkTests.m; sourceTree = "<group>"; };
+		11B98E6654D00F1E74B2DA47 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
 		24C22223D1434365B1D0A956 /* ObjcFrameworkTestLib.framework */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.framework; path = ObjcFrameworkTestLib.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		413EA7F09E2ABDF7CFCB736D /* ObjcFrameworkTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = ObjcFrameworkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4BB7A0F977B290B8648FFDB0 /* ObjcFramework.framework */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.framework; path = ObjcFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		6902D1207F875225638DE30A /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = main.m; path = ../frameworks/objc/main.m; sourceTree = "<group>"; };
-		A889D4F5A404037DAAE41E2C /* common.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = common.pch; path = ../../../rules/library/common.pch; sourceTree = "<group>"; };
-		C7460A0CB5B34CD2836CB044 /* HeaderA.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = HeaderA.h; path = ../frameworks/objc/HeaderA.h; sourceTree = "<group>"; };
-		F9528189952DC1024F47A893 /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = ../frameworks/objc/BUILD.bazel; sourceTree = "<group>"; };
-		F95CB476EBF28FCFE1BCE04F /* FooFrameworkTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = FooFrameworkTests.m; path = ../frameworks/objc/tests/FooFrameworkTests.m; sourceTree = "<group>"; };
+		AD7402651F16555F753997F4 /* HeaderA.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HeaderA.h; sourceTree = "<group>"; };
+		BD4894AC90711E6A55CB1657 /* common.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = common.pch; sourceTree = "<group>"; };
+		CF7A2F537C999952921627A8 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
-		2E65D165D8CB3DA10A3241BB /* ios */ = {
+		0A2CB2A75E2EAAB1095F1214 /* objc */ = {
 			isa = PBXGroup;
 			children = (
-				F9780F090C099456FA802F03 /* frameworks */,
+				11B98E6654D00F1E74B2DA47 /* BUILD.bazel */,
+				AD7402651F16555F753997F4 /* HeaderA.h */,
+				CF7A2F537C999952921627A8 /* main.m */,
+				37D2E41255E69DF775A9E8A7 /* tests */,
 			);
-			name = ios;
+			path = objc;
 			sourceTree = "<group>";
 		};
-		6666B4FAC3B5C464339017A9 /* objc */ = {
+		1E3DFBAC8DCF4B75D9A8F878 /* tests */ = {
 			isa = PBXGroup;
 			children = (
-				F9528189952DC1024F47A893 /* BUILD.bazel */,
-				C7460A0CB5B34CD2836CB044 /* HeaderA.h */,
-				6902D1207F875225638DE30A /* main.m */,
-				C46EA7CD087E497DFB189040 /* tests */,
+				7EDC6B4DDC5CF54A9237A106 /* ios */,
 			);
-			name = objc;
+			path = tests;
 			sourceTree = "<group>";
 		};
-		A3598111BA39DE57BE267C48 /* tests */ = {
+		37D2E41255E69DF775A9E8A7 /* tests */ = {
 			isa = PBXGroup;
 			children = (
-				2E65D165D8CB3DA10A3241BB /* ios */,
+				091655034CF618D208C22AE8 /* FooFrameworkTests.m */,
 			);
-			name = tests;
+			path = tests;
 			sourceTree = "<group>";
 		};
-		C46EA7CD087E497DFB189040 /* tests */ = {
+		7EDC6B4DDC5CF54A9237A106 /* ios */ = {
 			isa = PBXGroup;
 			children = (
-				F95CB476EBF28FCFE1BCE04F /* FooFrameworkTests.m */,
+				D0115B467F0DE21A500FA41C /* frameworks */,
 			);
-			name = tests;
+			path = ios;
+			sourceTree = "<group>";
+		};
+		A2A2DE2B0CF19BE872E1DD76 /* library */ = {
+			isa = PBXGroup;
+			children = (
+				BD4894AC90711E6A55CB1657 /* common.pch */,
+			);
+			path = library;
+			sourceTree = "<group>";
+		};
+		D0115B467F0DE21A500FA41C /* frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				0A2CB2A75E2EAAB1095F1214 /* objc */,
+			);
+			path = frameworks;
+			sourceTree = "<group>";
+		};
+		D7905EC44A468549D712685E /* rules */ = {
+			isa = PBXGroup;
+			children = (
+				A2A2DE2B0CF19BE872E1DD76 /* library */,
+			);
+			path = rules;
 			sourceTree = "<group>";
 		};
 		D86E9FCCC4BB853B2A451672 /* Products */ = {
@@ -71,34 +95,19 @@
 		E8099B19B67C1115D200E916 = {
 			isa = PBXGroup;
 			children = (
-				F1E6E5D1773FF98D954EB32A /* rules */,
-				A3598111BA39DE57BE267C48 /* tests */,
+				EB104984AF478D5D5F2B07DE /* build_bazel_rules_ios */,
 				D86E9FCCC4BB853B2A451672 /* Products */,
 			);
 			sourceTree = "<group>";
 		};
-		F1E6E5D1773FF98D954EB32A /* rules */ = {
+		EB104984AF478D5D5F2B07DE /* build_bazel_rules_ios */ = {
 			isa = PBXGroup;
 			children = (
-				F5677F534CD0BBE67D08B11C /* library */,
+				D7905EC44A468549D712685E /* rules */,
+				1E3DFBAC8DCF4B75D9A8F878 /* tests */,
 			);
-			name = rules;
-			sourceTree = "<group>";
-		};
-		F5677F534CD0BBE67D08B11C /* library */ = {
-			isa = PBXGroup;
-			children = (
-				A889D4F5A404037DAAE41E2C /* common.pch */,
-			);
-			name = library;
-			sourceTree = "<group>";
-		};
-		F9780F090C099456FA802F03 /* frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				6666B4FAC3B5C464339017A9 /* objc */,
-			);
-			name = frameworks;
+			name = build_bazel_rules_ios;
+			path = ../../..;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -242,7 +251,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D100BF9D72B5F6940F83816B /* main.m in Sources */,
+				5C8EED4DAAF3B4B069337569 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -257,7 +266,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				486340F1844ADD3B94BFE9F6 /* FooFrameworkTests.m in Sources */,
+				0BD7FD856ED50175FA3D3BC9 /* FooFrameworkTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.pbxproj
@@ -7,10 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		21B461EAB7C0599E6E439C2A /* test.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFFCD75973B790B8428EF9E7 /* test.swift */; };
-		B9A7450627748CC2D7F58245 /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5EE49718CB8070C38416B64 /* empty.swift */; };
-		D22E20A62C92D4512E0FB68E /* test.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C00C28DA12F127AC0AE1387 /* test.m */; };
-		DD54889640478286F3D7EE39 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C080011EC2F624D38C590D3 /* main.m */; };
+		28DC502501A36DE46FB2FDAE /* test.m in Sources */ = {isa = PBXBuildFile; fileRef = 2EF81609D3AA2C86BD531FC9 /* test.m */; };
+		318F5B16837DD5CFA4D00889 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = B776E1DCA016E54FFA3DD126 /* main.m */; };
+		C7087EC243FF0E3AB1AB011E /* test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9CDCA4AFFA244654BAAF8B /* test.swift */; };
+		E99867EE1F1D782F81A4FE00 /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED99215913B1CD2AA84B255 /* empty.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -24,74 +24,101 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		034C629FFD4FA9DFBC427161 /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = "../unit-test/test-imports-app/BUILD.bazel"; sourceTree = "<group>"; };
-		2C080011EC2F624D38C590D3 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = main.m; path = "../unit-test/test-imports-app/main.m"; sourceTree = "<group>"; };
-		373EA069001CD4FC3561D226 /* TestStickers.xcstickers */ = {isa = PBXFileReference; lastKnownFileType = folder.stickers; name = TestStickers.xcstickers; path = "../unit-test/test-imports-app/Resources/TestStickers.xcstickers"; sourceTree = "<group>"; };
-		4AC4C1B394B3894431813BFA /* TestModelMapping.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; name = TestModelMapping.xcmappingmodel; path = "../unit-test/test-imports-app/Resources/TestModelMapping.xcmappingmodel"; sourceTree = "<group>"; };
-		4B218D3B14EACFE8F6D1A7D9 /* TestModel2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; name = TestModel2.xcdatamodel; path = "../unit-test/test-imports-app/Resources/TestModel2.xcdatamodel"; sourceTree = "<group>"; };
-		4C00C28DA12F127AC0AE1387 /* test.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = test.m; path = "../unit-test/test-imports-app/test.m"; sourceTree = "<group>"; };
-		58E87329BAD4527D85639045 /* common.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = common.pch; path = ../../../rules/library/common.pch; sourceTree = "<group>"; };
-		7658664DBA198AB4F6A9633C /* resource_bundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = resource_bundle.plist; path = ../../../rules/library/resource_bundle.plist; sourceTree = "<group>"; };
-		C5EE49718CB8070C38416B64 /* empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = empty.swift; path = "../unit-test/test-imports-app/empty.swift"; sourceTree = "<group>"; };
-		C73857A1D91F761A1128A896 /* Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Header.h; path = "../unit-test/test-imports-app/Header.h"; sourceTree = "<group>"; };
-		C81CD0924D905E721C028356 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = "../unit-test/test-imports-app/Resources/Images.xcassets"; sourceTree = "<group>"; };
-		DF561348FD5E569AB21F7F3D /* TestModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; name = TestModel.xcdatamodel; path = "../unit-test/test-imports-app/Resources/TestModel.xcdatamodel"; sourceTree = "<group>"; };
-		E275784281C69199FBA76C03 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = "../unit-test/test-imports-app/Resources/Resources2/Images.xcassets"; sourceTree = "<group>"; };
-		E6411D3FC8114DF5DE33DABC /* Header2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Header2.h; path = "../unit-test/test-imports-app/Header2.h"; sourceTree = "<group>"; };
+		0A9CDCA4AFFA244654BAAF8B /* test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = test.swift; sourceTree = "<group>"; };
+		0B582D2FC35395890994566A /* resource_bundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = resource_bundle.plist; sourceTree = "<group>"; };
+		13569230489FEDC63798F45E /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		2782A0E3F33311285AE36FC8 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		2EF81609D3AA2C86BD531FC9 /* test.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = test.m; sourceTree = "<group>"; };
+		3D8C6FABE401A5C37EEACCF7 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
+		4EA47E87D37B93163DC37DFE /* Header2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Header2.h; sourceTree = "<group>"; };
+		4ED99215913B1CD2AA84B255 /* empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = empty.swift; sourceTree = "<group>"; };
+		632CFB9DFB491CE5041EE814 /* TestStickers.xcstickers */ = {isa = PBXFileReference; lastKnownFileType = folder.stickers; path = TestStickers.xcstickers; sourceTree = "<group>"; };
+		B3D32E19E3BA9A9FCC8FCBCF /* common.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = common.pch; sourceTree = "<group>"; };
+		B4CD841B3F2A7DEE174D9413 /* Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Header.h; sourceTree = "<group>"; };
+		B776E1DCA016E54FFA3DD126 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		D3853399B479656CD9D1B02D /* TestModelMapping.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = TestModelMapping.xcmappingmodel; sourceTree = "<group>"; };
 		EC730E57A94AE56443A8D68E /* TestImports-App.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "TestImports-App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		EFFCD75973B790B8428EF9E7 /* test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = test.swift; path = "../unit-test/test-imports-app/test.swift"; sourceTree = "<group>"; };
+		EDE6AD266A3FA658551F1143 /* TestModel2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = TestModel2.xcdatamodel; sourceTree = "<group>"; };
+		EE15C7CB8FDCDB50A2BC13CF /* TestModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = TestModel.xcdatamodel; sourceTree = "<group>"; };
 		FFC67BEE5C0F371E96445C00 /* TestImports-Unit-Tests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = "TestImports-Unit-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
-		0FE10EE3091635571895E70D /* rules */ = {
+		16425F9DA3B24C7DB08487A0 /* ios */ = {
 			isa = PBXGroup;
 			children = (
-				5C497A439614A741544A6E1D /* library */,
+				3098D956609A70129E4CEF39 /* unit-test */,
 			);
-			name = rules;
+			path = ios;
+			sourceTree = "<group>";
+		};
+		22A8A4218E2455208F73FDF0 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				13569230489FEDC63798F45E /* Images.xcassets */,
+				49ACE10FF598298C0C4EA7D9 /* Resources2 */,
+				EE15C7CB8FDCDB50A2BC13CF /* TestModel.xcdatamodel */,
+				EDE6AD266A3FA658551F1143 /* TestModel2.xcdatamodel */,
+				D3853399B479656CD9D1B02D /* TestModelMapping.xcmappingmodel */,
+				632CFB9DFB491CE5041EE814 /* TestStickers.xcstickers */,
+			);
+			path = Resources;
 			sourceTree = "<group>";
 		};
 		26F69A463591D5BF4E58071F = {
 			isa = PBXGroup;
 			children = (
-				0FE10EE3091635571895E70D /* rules */,
-				4EE9EE45D0BA3C4F3C9940DC /* tests */,
+				BA2ACFB90DE930D947464421 /* build_bazel_rules_ios */,
 				8910DAC3B74F70E3EAF715F8 /* Products */,
 			);
 			sourceTree = "<group>";
 		};
-		3569A79348A02D3B2304900C /* unit-test */ = {
+		3098D956609A70129E4CEF39 /* unit-test */ = {
 			isa = PBXGroup;
 			children = (
-				B85CBF061C0EE7D29E6325E4 /* test-imports-app */,
+				429F6F81AE5D3CA395FC38CC /* test-imports-app */,
 			);
-			name = "unit-test";
+			path = "unit-test";
 			sourceTree = "<group>";
 		};
-		4EE9EE45D0BA3C4F3C9940DC /* tests */ = {
+		429F6F81AE5D3CA395FC38CC /* test-imports-app */ = {
 			isa = PBXGroup;
 			children = (
-				A8CE1638F1E0F10970A23913 /* ios */,
+				3D8C6FABE401A5C37EEACCF7 /* BUILD.bazel */,
+				4ED99215913B1CD2AA84B255 /* empty.swift */,
+				B4CD841B3F2A7DEE174D9413 /* Header.h */,
+				4EA47E87D37B93163DC37DFE /* Header2.h */,
+				B776E1DCA016E54FFA3DD126 /* main.m */,
+				22A8A4218E2455208F73FDF0 /* Resources */,
+				2EF81609D3AA2C86BD531FC9 /* test.m */,
+				0A9CDCA4AFFA244654BAAF8B /* test.swift */,
 			);
-			name = tests;
+			path = "test-imports-app";
 			sourceTree = "<group>";
 		};
-		5C497A439614A741544A6E1D /* library */ = {
+		49ACE10FF598298C0C4EA7D9 /* Resources2 */ = {
 			isa = PBXGroup;
 			children = (
-				58E87329BAD4527D85639045 /* common.pch */,
-				7658664DBA198AB4F6A9633C /* resource_bundle.plist */,
+				2782A0E3F33311285AE36FC8 /* Images.xcassets */,
 			);
-			name = library;
+			path = Resources2;
 			sourceTree = "<group>";
 		};
-		76E3C04E2FCE697285501653 /* Resources2 */ = {
+		52753EA7175AA78967732213 /* rules */ = {
 			isa = PBXGroup;
 			children = (
-				E275784281C69199FBA76C03 /* Images.xcassets */,
+				69BCA59A4DB8984153B811AA /* library */,
 			);
-			name = Resources2;
+			path = rules;
+			sourceTree = "<group>";
+		};
+		69BCA59A4DB8984153B811AA /* library */ = {
+			isa = PBXGroup;
+			children = (
+				B3D32E19E3BA9A9FCC8FCBCF /* common.pch */,
+				0B582D2FC35395890994566A /* resource_bundle.plist */,
+			);
+			path = library;
 			sourceTree = "<group>";
 		};
 		8910DAC3B74F70E3EAF715F8 /* Products */ = {
@@ -103,40 +130,22 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		A8CE1638F1E0F10970A23913 /* ios */ = {
+		BA2ACFB90DE930D947464421 /* build_bazel_rules_ios */ = {
 			isa = PBXGroup;
 			children = (
-				3569A79348A02D3B2304900C /* unit-test */,
+				52753EA7175AA78967732213 /* rules */,
+				DD3F59257AC4C8A5C0227F76 /* tests */,
 			);
-			name = ios;
+			name = build_bazel_rules_ios;
+			path = ../../..;
 			sourceTree = "<group>";
 		};
-		B85CBF061C0EE7D29E6325E4 /* test-imports-app */ = {
+		DD3F59257AC4C8A5C0227F76 /* tests */ = {
 			isa = PBXGroup;
 			children = (
-				034C629FFD4FA9DFBC427161 /* BUILD.bazel */,
-				C5EE49718CB8070C38416B64 /* empty.swift */,
-				C73857A1D91F761A1128A896 /* Header.h */,
-				E6411D3FC8114DF5DE33DABC /* Header2.h */,
-				2C080011EC2F624D38C590D3 /* main.m */,
-				EB86E0720942E17186A84231 /* Resources */,
-				4C00C28DA12F127AC0AE1387 /* test.m */,
-				EFFCD75973B790B8428EF9E7 /* test.swift */,
+				16425F9DA3B24C7DB08487A0 /* ios */,
 			);
-			name = "test-imports-app";
-			sourceTree = "<group>";
-		};
-		EB86E0720942E17186A84231 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				C81CD0924D905E721C028356 /* Images.xcassets */,
-				76E3C04E2FCE697285501653 /* Resources2 */,
-				DF561348FD5E569AB21F7F3D /* TestModel.xcdatamodel */,
-				4B218D3B14EACFE8F6D1A7D9 /* TestModel2.xcdatamodel */,
-				4AC4C1B394B3894431813BFA /* TestModelMapping.xcmappingmodel */,
-				373EA069001CD4FC3561D226 /* TestStickers.xcstickers */,
-			);
-			name = Resources;
+			path = tests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -246,8 +255,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D22E20A62C92D4512E0FB68E /* test.m in Sources */,
-				21B461EAB7C0599E6E439C2A /* test.swift in Sources */,
+				28DC502501A36DE46FB2FDAE /* test.m in Sources */,
+				C7087EC243FF0E3AB1AB011E /* test.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -255,8 +264,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B9A7450627748CC2D7F58245 /* empty.swift in Sources */,
-				DD54889640478286F3D7EE39 /* main.m in Sources */,
+				E99867EE1F1D782F81A4FE00 /* empty.swift in Sources */,
+				318F5B16837DD5CFA4D00889 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.pbxproj
@@ -7,9 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		45E7F8EFCCCC1A9DF4D72E93 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = EA28E49F9120D00949E5FAAB /* main.m */; };
-		8172AD24AC6E26E18F4BB8FE /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E5873201DE5FA7E56144FE7 /* empty.swift */; };
-		D6D88A405B801B83965A394E /* empty.m in Sources */ = {isa = PBXBuildFile; fileRef = FFEB9EB1C9B6406A04C9EEDD /* empty.m */; };
+		31AA2C5800D29E42C589B56B /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52FB08B7C929A64386CDFE06 /* empty.swift */; };
+		83CAB78009AF4F0196136FB6 /* empty.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F973C72CDD8C3C263F6A615 /* empty.m */; };
+		90364CB6CB510200E694DB55 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B78B78C06FA82FF60423814 /* main.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -23,46 +23,46 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		087F3B42D7BE6F86AB8C54F0 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
 		1A670BBD3E8C25AB89221850 /* iOS-9.3-AppHost.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "iOS-9.3-AppHost.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		252D1E153AD8984665E68A74 /* resource_bundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = resource_bundle.plist; path = ../../../rules/library/resource_bundle.plist; sourceTree = "<group>"; };
-		4C2573089396ADCB63FBB6FE /* AssetCatalogFixture.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = AssetCatalogFixture.xcassets; path = ../../../rules/test_host_app/AssetCatalogFixture.xcassets; sourceTree = "<group>"; };
-		4E5873201DE5FA7E56144FE7 /* empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = empty.swift; path = "../unit-test/empty.swift"; sourceTree = "<group>"; };
-		527A05AD0BFB9B9E5471D17D /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = "../unit-test/BUILD.bazel"; sourceTree = "<group>"; };
-		7623EBE7D0F49CEC82671A64 /* ios.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = ios.entitlements; path = ../../../rules/test_host_app/ios.entitlements; sourceTree = "<group>"; };
-		79E7AD8A4A8CCCE1B4980CEB /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = ../../../rules/test_host_app/BUILD.bazel; sourceTree = "<group>"; };
+		39917DE37B353186CF715BF8 /* resource_bundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = resource_bundle.plist; sourceTree = "<group>"; };
+		3F973C72CDD8C3C263F6A615 /* empty.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = empty.m; sourceTree = "<group>"; };
+		4B78B78C06FA82FF60423814 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		52FB08B7C929A64386CDFE06 /* empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = empty.swift; sourceTree = "<group>"; };
+		640958F271E540FA689954DB /* AssetCatalogFixture.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = AssetCatalogFixture.xcassets; sourceTree = "<group>"; };
+		6AA79D51459F5745C6597549 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
 		A7A135B2F45AA4AE95B5C366 /* ExplicitHosted.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = ExplicitHosted.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		EA28E49F9120D00949E5FAAB /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = main.m; path = ../../../rules/test_host_app/main.m; sourceTree = "<group>"; };
-		ED29AB1B1F4BCEE96C19748E /* common.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = common.pch; path = ../../../rules/library/common.pch; sourceTree = "<group>"; };
-		FFEB9EB1C9B6406A04C9EEDD /* empty.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = empty.m; path = "../unit-test/empty.m"; sourceTree = "<group>"; };
+		D94E8DA21E16E538B8F80977 /* ios.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ios.entitlements; sourceTree = "<group>"; };
+		E7221F8588A5E2BBC1C40983 /* common.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = common.pch; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
-		0B5CF4AEC90E36CC75780DCE /* unit-test */ = {
+		3F0ED6F34AF3A58C237AF38E /* rules */ = {
 			isa = PBXGroup;
 			children = (
-				527A05AD0BFB9B9E5471D17D /* BUILD.bazel */,
-				FFEB9EB1C9B6406A04C9EEDD /* empty.m */,
-				4E5873201DE5FA7E56144FE7 /* empty.swift */,
+				E07FD4C0CC80805A04C80894 /* library */,
+				48EC573E873376EF2328B54F /* test_host_app */,
 			);
-			name = "unit-test";
-			sourceTree = "<group>";
-		};
-		332607BCF31A55A4E232E977 /* library */ = {
-			isa = PBXGroup;
-			children = (
-				ED29AB1B1F4BCEE96C19748E /* common.pch */,
-				252D1E153AD8984665E68A74 /* resource_bundle.plist */,
-			);
-			name = library;
+			path = rules;
 			sourceTree = "<group>";
 		};
 		4458650FCF08ECB7D12D6103 = {
 			isa = PBXGroup;
 			children = (
-				DEF4341AB4D0B0E4410D5310 /* rules */,
-				F00067E7E50682821D2C107F /* tests */,
+				E0A6B3D7DB2877F8279F72D1 /* build_bazel_rules_ios */,
 				80B743DAD4870A59BE6681A5 /* Products */,
 			);
+			sourceTree = "<group>";
+		};
+		48EC573E873376EF2328B54F /* test_host_app */ = {
+			isa = PBXGroup;
+			children = (
+				640958F271E540FA689954DB /* AssetCatalogFixture.xcassets */,
+				087F3B42D7BE6F86AB8C54F0 /* BUILD.bazel */,
+				D94E8DA21E16E538B8F80977 /* ios.entitlements */,
+				4B78B78C06FA82FF60423814 /* main.m */,
+			);
+			path = test_host_app;
 			sourceTree = "<group>";
 		};
 		80B743DAD4870A59BE6681A5 /* Products */ = {
@@ -74,40 +74,49 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		DEF4341AB4D0B0E4410D5310 /* rules */ = {
+		9A72A8B989632B31533CCF07 /* unit-test */ = {
 			isa = PBXGroup;
 			children = (
-				332607BCF31A55A4E232E977 /* library */,
-				E66A304A2AFBA29E06A2C7F4 /* test_host_app */,
+				6AA79D51459F5745C6597549 /* BUILD.bazel */,
+				3F973C72CDD8C3C263F6A615 /* empty.m */,
+				52FB08B7C929A64386CDFE06 /* empty.swift */,
 			);
-			name = rules;
+			path = "unit-test";
 			sourceTree = "<group>";
 		};
-		E66A304A2AFBA29E06A2C7F4 /* test_host_app */ = {
+		A00021A91B77EC95CF688BAA /* ios */ = {
 			isa = PBXGroup;
 			children = (
-				4C2573089396ADCB63FBB6FE /* AssetCatalogFixture.xcassets */,
-				79E7AD8A4A8CCCE1B4980CEB /* BUILD.bazel */,
-				7623EBE7D0F49CEC82671A64 /* ios.entitlements */,
-				EA28E49F9120D00949E5FAAB /* main.m */,
+				9A72A8B989632B31533CCF07 /* unit-test */,
 			);
-			name = test_host_app;
+			path = ios;
 			sourceTree = "<group>";
 		};
-		F00067E7E50682821D2C107F /* tests */ = {
+		DCBB2E5ECC3355E25E5F9E3F /* tests */ = {
 			isa = PBXGroup;
 			children = (
-				FC860E9659513C5FA2ED11FB /* ios */,
+				A00021A91B77EC95CF688BAA /* ios */,
 			);
-			name = tests;
+			path = tests;
 			sourceTree = "<group>";
 		};
-		FC860E9659513C5FA2ED11FB /* ios */ = {
+		E07FD4C0CC80805A04C80894 /* library */ = {
 			isa = PBXGroup;
 			children = (
-				0B5CF4AEC90E36CC75780DCE /* unit-test */,
+				E7221F8588A5E2BBC1C40983 /* common.pch */,
+				39917DE37B353186CF715BF8 /* resource_bundle.plist */,
 			);
-			name = ios;
+			path = library;
+			sourceTree = "<group>";
+		};
+		E0A6B3D7DB2877F8279F72D1 /* build_bazel_rules_ios */ = {
+			isa = PBXGroup;
+			children = (
+				3F0ED6F34AF3A58C237AF38E /* rules */,
+				DCBB2E5ECC3355E25E5F9E3F /* tests */,
+			);
+			name = build_bazel_rules_ios;
+			path = ../../..;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -217,7 +226,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				45E7F8EFCCCC1A9DF4D72E93 /* main.m in Sources */,
+				90364CB6CB510200E694DB55 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -225,8 +234,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D6D88A405B801B83965A394E /* empty.m in Sources */,
-				8172AD24AC6E26E18F4BB8FE /* empty.swift in Sources */,
+				83CAB78009AF4F0196136FB6 /* empty.m in Sources */,
+				31AA2C5800D29E42C589B56B /* empty.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
@@ -7,47 +7,46 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0834EB3BB2BE0990DEED46BD /* test.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1162A80978C527830EDADEE /* test.swift */; };
-		6868785A8F571C49259B50E0 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = EEB1C98DB4C8E24414A69917 /* main.m */; };
-		8A8AC7C1D053F87A0D991815 /* NonArcObject.m in Sources */ = {isa = PBXBuildFile; fileRef = E881738E1AAC1FCA61D467D8 /* NonArcObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		E8D5A100DC66B1E35BB71538 /* test.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1162A80978C527830EDADEE /* test.swift */; };
+		045D4161C1AD7DBC32E8B780 /* NonArcObject.m in Sources */ = {isa = PBXBuildFile; fileRef = EB0D04543A3924BA34C4E72B /* NonArcObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		2530CD9920C75C7CC2BE6EC7 /* test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8309CFF8A1900D3AB1BF293D /* test.swift */; };
+		92A134A20F5F9E93BCB6F756 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 705989AC65B3703138E736BB /* main.m */; };
+		EC6016D70E0EEF1F8C1B0F2D /* test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8309CFF8A1900D3AB1BF293D /* test.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		291405E8869304FF16CEA948 /* AssetCatalogFixture.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = AssetCatalogFixture.xcassets; path = ../../../rules/test_host_app/AssetCatalogFixture.xcassets; sourceTree = "<group>"; };
-		4C5CCDAF660EA165B074B8BD /* resource_bundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = resource_bundle.plist; path = ../../../rules/library/resource_bundle.plist; sourceTree = "<group>"; };
+		0CED6BFA64273E7D643365B7 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
+		22A1FF4EF7BCD46937725C85 /* common.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = common.pch; sourceTree = "<group>"; };
+		2F394FC66350F2A3B26624E7 /* AssetCatalogFixture.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = AssetCatalogFixture.xcassets; sourceTree = "<group>"; };
+		3936F6C85BC43D9ABF078420 /* ios.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ios.entitlements; sourceTree = "<group>"; };
 		5976518F3C0E5F4753E44514 /* Single-Application-RunnableTestSuite.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = "Single-Application-RunnableTestSuite.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		705989AC65B3703138E736BB /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		78FAC8B505DC9C839473A482 /* iOS-12.0-AppHost.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "iOS-12.0-AppHost.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		7ABD95023B71172929B010EE /* common.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = common.pch; path = ../../../rules/library/common.pch; sourceTree = "<group>"; };
-		908EFE5EAE901D6B372D68F7 /* ios.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = ios.entitlements; path = ../../../rules/test_host_app/ios.entitlements; sourceTree = "<group>"; };
-		A05E016687115D20E64A5C60 /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = BUILD.bazel; sourceTree = "<group>"; };
-		B63432B3F93F02853868034C /* NonArcObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NonArcObject.h; path = NonArcObject.h; sourceTree = "<group>"; };
-		BA5C2481E04D8592323A7AD9 /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = ../../../rules/test_host_app/BUILD.bazel; sourceTree = "<group>"; };
-		E881738E1AAC1FCA61D467D8 /* NonArcObject.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = NonArcObject.m; path = NonArcObject.m; sourceTree = "<group>"; };
-		EEB1C98DB4C8E24414A69917 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = main.m; path = ../../../rules/test_host_app/main.m; sourceTree = "<group>"; };
+		8309CFF8A1900D3AB1BF293D /* test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = test.swift; sourceTree = "<group>"; };
+		A37BC5C944123D1C4F844A8D /* NonArcObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NonArcObject.h; sourceTree = "<group>"; };
+		BFAB336D87BC55D557A1C381 /* resource_bundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = resource_bundle.plist; sourceTree = "<group>"; };
+		D4C8DCB5E3E8D93979B164F7 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
+		EB0D04543A3924BA34C4E72B /* NonArcObject.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NonArcObject.m; sourceTree = "<group>"; };
 		EFADB1CE81C3F97F647C9255 /* Single-Application-UnitTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = "Single-Application-UnitTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		F1162A80978C527830EDADEE /* test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = test.swift; path = test.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
 		0E2CEDC8EC87B38723449716 = {
 			isa = PBXGroup;
 			children = (
-				D5DFC35BDCA2F1C8B03233AF /* rules */,
-				B9EA5090755F274681D48FBB /* tests */,
+				96AA1EC3CAE5469A1C1C2395 /* build_bazel_rules_ios */,
 				39BC217F37AF4DE132EB386D /* Products */,
 			);
 			sourceTree = "<group>";
 		};
-		180CD058CAE61A960B64C45A /* test_host_app */ = {
+		115C7AEB91C272085DB228D1 /* test_host_app */ = {
 			isa = PBXGroup;
 			children = (
-				291405E8869304FF16CEA948 /* AssetCatalogFixture.xcassets */,
-				BA5C2481E04D8592323A7AD9 /* BUILD.bazel */,
-				908EFE5EAE901D6B372D68F7 /* ios.entitlements */,
-				EEB1C98DB4C8E24414A69917 /* main.m */,
+				2F394FC66350F2A3B26624E7 /* AssetCatalogFixture.xcassets */,
+				0CED6BFA64273E7D643365B7 /* BUILD.bazel */,
+				3936F6C85BC43D9ABF078420 /* ios.entitlements */,
+				705989AC65B3703138E736BB /* main.m */,
 			);
-			name = test_host_app;
+			path = test_host_app;
 			sourceTree = "<group>";
 		};
 		39BC217F37AF4DE132EB386D /* Products */ = {
@@ -60,49 +59,59 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		5A1056A78C2ED4B5FBF2D10F /* library */ = {
+		5954C75FECF8C35239E1C677 /* macos */ = {
 			isa = PBXGroup;
 			children = (
-				7ABD95023B71172929B010EE /* common.pch */,
-				4C5CCDAF660EA165B074B8BD /* resource_bundle.plist */,
+				6475D4D028980AC2448C6B05 /* xcodeproj */,
 			);
-			name = library;
+			path = macos;
 			sourceTree = "<group>";
 		};
-		B9EA5090755F274681D48FBB /* tests */ = {
+		6475D4D028980AC2448C6B05 /* xcodeproj */ = {
 			isa = PBXGroup;
 			children = (
-				C605DB42F15FE4CE37586AC7 /* macos */,
+				D4C8DCB5E3E8D93979B164F7 /* BUILD.bazel */,
+				A37BC5C944123D1C4F844A8D /* NonArcObject.h */,
+				EB0D04543A3924BA34C4E72B /* NonArcObject.m */,
+				8309CFF8A1900D3AB1BF293D /* test.swift */,
 			);
-			name = tests;
+			path = xcodeproj;
 			sourceTree = "<group>";
 		};
-		C605DB42F15FE4CE37586AC7 /* macos */ = {
+		96AA1EC3CAE5469A1C1C2395 /* build_bazel_rules_ios */ = {
 			isa = PBXGroup;
 			children = (
-				F237C982F1E8CD4A105006B4 /* xcodeproj */,
+				FC403F79B12D53A4AED07C1A /* rules */,
+				EE1B6D796F7CE9D7186B65A5 /* tests */,
 			);
-			name = macos;
+			name = build_bazel_rules_ios;
+			path = ../../..;
 			sourceTree = "<group>";
 		};
-		D5DFC35BDCA2F1C8B03233AF /* rules */ = {
+		C415D064EB38E890B7155CE1 /* library */ = {
 			isa = PBXGroup;
 			children = (
-				5A1056A78C2ED4B5FBF2D10F /* library */,
-				180CD058CAE61A960B64C45A /* test_host_app */,
+				22A1FF4EF7BCD46937725C85 /* common.pch */,
+				BFAB336D87BC55D557A1C381 /* resource_bundle.plist */,
 			);
-			name = rules;
+			path = library;
 			sourceTree = "<group>";
 		};
-		F237C982F1E8CD4A105006B4 /* xcodeproj */ = {
+		EE1B6D796F7CE9D7186B65A5 /* tests */ = {
 			isa = PBXGroup;
 			children = (
-				A05E016687115D20E64A5C60 /* BUILD.bazel */,
-				B63432B3F93F02853868034C /* NonArcObject.h */,
-				E881738E1AAC1FCA61D467D8 /* NonArcObject.m */,
-				F1162A80978C527830EDADEE /* test.swift */,
+				5954C75FECF8C35239E1C677 /* macos */,
 			);
-			name = xcodeproj;
+			path = tests;
+			sourceTree = "<group>";
+		};
+		FC403F79B12D53A4AED07C1A /* rules */ = {
+			isa = PBXGroup;
+			children = (
+				C415D064EB38E890B7155CE1 /* library */,
+				115C7AEB91C272085DB228D1 /* test_host_app */,
+			);
+			path = rules;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -246,7 +255,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0834EB3BB2BE0990DEED46BD /* test.swift in Sources */,
+				2530CD9920C75C7CC2BE6EC7 /* test.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -254,7 +263,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6868785A8F571C49259B50E0 /* main.m in Sources */,
+				92A134A20F5F9E93BCB6F756 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -262,8 +271,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8A8AC7C1D053F87A0D991815 /* NonArcObject.m in Sources */,
-				E8D5A100DC66B1E35BB71538 /* test.swift in Sources */,
+				045D4161C1AD7DBC32E8B780 /* NonArcObject.m in Sources */,
+				EC6016D70E0EEF1F8C1B0F2D /* test.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
@@ -7,26 +7,26 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		53E65376450A485B39CE93FE /* test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BD63CC255956E60D898C7B7 /* test.swift */; };
-		706F35140D56EA1BB820A681 /* NonArcObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 77B1396A59924BC26C630854 /* NonArcObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		83D9B2BE42CE395FCC9356FB /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DA260AA799ED8A57078C331 /* main.m */; };
-		B868F40E021F743023B7764F /* test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BD63CC255956E60D898C7B7 /* test.swift */; };
+		3F1AA37EFCFD35B3FC5C97AC /* NonArcObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D13FC12B4485F863BAAF03E /* NonArcObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		7F5FB90D81C2C0392B07F5C9 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 94000CEDD7AE8D8B38E4F95D /* main.m */; };
+		CAFA5ED3B2BFE4F760E7F4D5 /* test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059EDA0A0E4F8B6CC0164819 /* test.swift */; };
+		F9E1A08703A81C31CAF5D20C /* test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059EDA0A0E4F8B6CC0164819 /* test.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		0BD63CC255956E60D898C7B7 /* test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = test.swift; path = test.swift; sourceTree = "<group>"; };
-		2B41830721183AA100B23D64 /* ios.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = ios.entitlements; path = ../../../rules/test_host_app/ios.entitlements; sourceTree = "<group>"; };
-		2DA260AA799ED8A57078C331 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = main.m; path = ../../../rules/test_host_app/main.m; sourceTree = "<group>"; };
-		4936F4D0B63B32AD09E63C43 /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = BUILD.bazel; sourceTree = "<group>"; };
+		059EDA0A0E4F8B6CC0164819 /* test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = test.swift; sourceTree = "<group>"; };
+		13B2E31F413103B9CBA4D1CB /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
+		208F9554F35C53545DD58C00 /* resource_bundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = resource_bundle.plist; sourceTree = "<group>"; };
+		242581154E1D9D701F08C906 /* AssetCatalogFixture.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = AssetCatalogFixture.xcassets; sourceTree = "<group>"; };
+		4D13FC12B4485F863BAAF03E /* NonArcObject.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NonArcObject.m; sourceTree = "<group>"; };
+		4E55BF6E6C589A4AA45D06C8 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
 		712BB7D3F966AAE042C40E4E /* iOS-12.0-AppHost.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "iOS-12.0-AppHost.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		77B1396A59924BC26C630854 /* NonArcObject.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = NonArcObject.m; path = NonArcObject.m; sourceTree = "<group>"; };
+		71385EF3D5F3851B35F520C5 /* ios.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ios.entitlements; sourceTree = "<group>"; };
+		94000CEDD7AE8D8B38E4F95D /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		9735D50F44B3B4D188BA18BF /* Single-Application-RunnableTestSuite.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = "Single-Application-RunnableTestSuite.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		CF248CD4BA2D7D91429E9BCB /* common.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = common.pch; path = ../../../rules/library/common.pch; sourceTree = "<group>"; };
+		B0197AD7F0C86A837943EF5F /* common.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = common.pch; sourceTree = "<group>"; };
+		C37150414972211018E2DDBF /* NonArcObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NonArcObject.h; sourceTree = "<group>"; };
 		E94B0DB5FD5082DE73F52008 /* Single-Application-UnitTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = "Single-Application-UnitTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		EAEB79BE70BFB649A6FBC92C /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = ../../../rules/test_host_app/BUILD.bazel; sourceTree = "<group>"; };
-		F68918EEDF76680E236B0A25 /* AssetCatalogFixture.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = AssetCatalogFixture.xcassets; path = ../../../rules/test_host_app/AssetCatalogFixture.xcassets; sourceTree = "<group>"; };
-		F689E871A09EA979611C589A /* resource_bundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = resource_bundle.plist; path = ../../../rules/library/resource_bundle.plist; sourceTree = "<group>"; };
-		FE2DCE7EA91C1CAF4050351A /* NonArcObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NonArcObject.h; path = NonArcObject.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -40,69 +40,78 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		1BF6ABA02E294B8954D24D4E /* rules */ = {
+		2834A2B442973EFD984F656E /* tests */ = {
 			isa = PBXGroup;
 			children = (
-				306ADAA7696198C3B4EDB2A3 /* library */,
-				2C1313338ABDD4C6E78C79FB /* test_host_app */,
+				E255BCCB31D33DD1489217CB /* macos */,
 			);
-			name = rules;
-			sourceTree = "<group>";
-		};
-		23F61884C8DD7A7A3209C3C3 /* macos */ = {
-			isa = PBXGroup;
-			children = (
-				F4FF0CBD8A1F7A37DB68252E /* xcodeproj */,
-			);
-			name = macos;
-			sourceTree = "<group>";
-		};
-		2C1313338ABDD4C6E78C79FB /* test_host_app */ = {
-			isa = PBXGroup;
-			children = (
-				F68918EEDF76680E236B0A25 /* AssetCatalogFixture.xcassets */,
-				EAEB79BE70BFB649A6FBC92C /* BUILD.bazel */,
-				2B41830721183AA100B23D64 /* ios.entitlements */,
-				2DA260AA799ED8A57078C331 /* main.m */,
-			);
-			name = test_host_app;
-			sourceTree = "<group>";
-		};
-		306ADAA7696198C3B4EDB2A3 /* library */ = {
-			isa = PBXGroup;
-			children = (
-				CF248CD4BA2D7D91429E9BCB /* common.pch */,
-				F689E871A09EA979611C589A /* resource_bundle.plist */,
-			);
-			name = library;
+			path = tests;
 			sourceTree = "<group>";
 		};
 		44007A98E52F88702C881F01 = {
 			isa = PBXGroup;
 			children = (
-				1BF6ABA02E294B8954D24D4E /* rules */,
-				CA2C43F0FB486B5331D5B5F8 /* tests */,
+				FA88291454894CF45D0AD631 /* build_bazel_rules_ios */,
 				145F97D311D32337031D7D4A /* Products */,
 			);
 			sourceTree = "<group>";
 		};
-		CA2C43F0FB486B5331D5B5F8 /* tests */ = {
+		805324EE3102DD62915C0754 /* rules */ = {
 			isa = PBXGroup;
 			children = (
-				23F61884C8DD7A7A3209C3C3 /* macos */,
+				F4BE127ED2847232A869C9EC /* library */,
+				BF7B50FCB34D99B2BC9D6775 /* test_host_app */,
 			);
-			name = tests;
+			path = rules;
 			sourceTree = "<group>";
 		};
-		F4FF0CBD8A1F7A37DB68252E /* xcodeproj */ = {
+		95C4A71BFABFE94EAF252C38 /* xcodeproj */ = {
 			isa = PBXGroup;
 			children = (
-				4936F4D0B63B32AD09E63C43 /* BUILD.bazel */,
-				FE2DCE7EA91C1CAF4050351A /* NonArcObject.h */,
-				77B1396A59924BC26C630854 /* NonArcObject.m */,
-				0BD63CC255956E60D898C7B7 /* test.swift */,
+				4E55BF6E6C589A4AA45D06C8 /* BUILD.bazel */,
+				C37150414972211018E2DDBF /* NonArcObject.h */,
+				4D13FC12B4485F863BAAF03E /* NonArcObject.m */,
+				059EDA0A0E4F8B6CC0164819 /* test.swift */,
 			);
-			name = xcodeproj;
+			path = xcodeproj;
+			sourceTree = "<group>";
+		};
+		BF7B50FCB34D99B2BC9D6775 /* test_host_app */ = {
+			isa = PBXGroup;
+			children = (
+				242581154E1D9D701F08C906 /* AssetCatalogFixture.xcassets */,
+				13B2E31F413103B9CBA4D1CB /* BUILD.bazel */,
+				71385EF3D5F3851B35F520C5 /* ios.entitlements */,
+				94000CEDD7AE8D8B38E4F95D /* main.m */,
+			);
+			path = test_host_app;
+			sourceTree = "<group>";
+		};
+		E255BCCB31D33DD1489217CB /* macos */ = {
+			isa = PBXGroup;
+			children = (
+				95C4A71BFABFE94EAF252C38 /* xcodeproj */,
+			);
+			path = macos;
+			sourceTree = "<group>";
+		};
+		F4BE127ED2847232A869C9EC /* library */ = {
+			isa = PBXGroup;
+			children = (
+				B0197AD7F0C86A837943EF5F /* common.pch */,
+				208F9554F35C53545DD58C00 /* resource_bundle.plist */,
+			);
+			path = library;
+			sourceTree = "<group>";
+		};
+		FA88291454894CF45D0AD631 /* build_bazel_rules_ios */ = {
+			isa = PBXGroup;
+			children = (
+				805324EE3102DD62915C0754 /* rules */,
+				2834A2B442973EFD984F656E /* tests */,
+			);
+			name = build_bazel_rules_ios;
+			path = ../../..;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -246,8 +255,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				706F35140D56EA1BB820A681 /* NonArcObject.m in Sources */,
-				53E65376450A485B39CE93FE /* test.swift in Sources */,
+				3F1AA37EFCFD35B3FC5C97AC /* NonArcObject.m in Sources */,
+				CAFA5ED3B2BFE4F760E7F4D5 /* test.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -255,7 +264,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				83D9B2BE42CE395FCC9356FB /* main.m in Sources */,
+				7F5FB90D81C2C0392B07F5C9 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -263,7 +272,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B868F40E021F743023B7764F /* test.swift in Sources */,
+				F9E1A08703A81C31CAF5D20C /* test.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
@@ -7,13 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		4541759E59ED815D18798894 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FE939800D5E84FA4B194548D /* main.m */; };
-		48C6C9814CEEF1CACD6D55A0 /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035030AE3B7F41C97A1EE910 /* empty.swift */; };
-		55E46FEA2FF714E40EA51316 /* test.m in Sources */ = {isa = PBXBuildFile; fileRef = 2263A980666D293D7413BE92 /* test.m */; };
-		68F6C55581B050CEA9AB6AFF /* test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246AA4985E50044D3CD8228A /* test.swift */; };
-		B8F9F9CA8BCC4CFF09734974 /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B65EED0A5FCC9038424593 /* empty.swift */; };
-		E2DE5A172CF0A78BF06C0140 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C55810C4D90EF86058DB06A /* main.m */; };
-		EB57E581728375686EE2959C /* empty.m in Sources */ = {isa = PBXBuildFile; fileRef = F42CC7E6159DCCC28D045A6C /* empty.m */; };
+		4D9FC7A3A45FAD1826CE314F /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 3ECF1D7133544DD5E82A3EB0 /* main.m */; };
+		8B8703078ED965C24F7DFC6D /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 211B0D62D65A5D8BEFE42153 /* main.m */; };
+		9C997105C8FCCC97A52F3C37 /* test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF21FC7C23005F0603AD4F0 /* test.swift */; };
+		A92FEA9E7CEAA5C1D707216B /* test.m in Sources */ = {isa = PBXBuildFile; fileRef = EC2BF9F658BA7B0FF93BA215 /* test.m */; };
+		C61986BF5CBA4DAEAF33BE91 /* empty.m in Sources */ = {isa = PBXBuildFile; fileRef = 018DA4ABD245EA72FEA9BA46 /* empty.m */; };
+		C6B1D1CBC7730A53A2C04E0D /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5478D8BA2BE2A548270A80 /* empty.swift */; };
+		E676560B3EE63A86606530C8 /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5AC323968F3E7DC9BAFEC85 /* empty.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -35,54 +35,59 @@
 
 /* Begin PBXFileReference section */
 		0052687FF99FFC1CF0644A94 /* iOS-10.0-AppHost.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "iOS-10.0-AppHost.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		035030AE3B7F41C97A1EE910 /* empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = empty.swift; path = "../../ios/unit-test/test-imports-app/empty.swift"; sourceTree = "<group>"; };
-		08D20BAAC5B1A41903E13B27 /* Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Header.h; path = "../../ios/unit-test/test-imports-app/Header.h"; sourceTree = "<group>"; };
-		0C55810C4D90EF86058DB06A /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = main.m; path = "../../ios/unit-test/test-imports-app/main.m"; sourceTree = "<group>"; };
-		0E1A2D407EDFADA150631F26 /* resource_bundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = resource_bundle.plist; path = ../../../rules/library/resource_bundle.plist; sourceTree = "<group>"; };
-		10ED0FBA33677AAD264EF3D3 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = "../../ios/unit-test/test-imports-app/Resources/Images.xcassets"; sourceTree = "<group>"; };
+		018DA4ABD245EA72FEA9BA46 /* empty.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = empty.m; sourceTree = "<group>"; };
+		0A3BB7488A9B93655A5A80A7 /* TestModelMapping.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = TestModelMapping.xcmappingmodel; sourceTree = "<group>"; };
+		0DEBE921687BED0630F2E803 /* common.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = common.pch; sourceTree = "<group>"; };
 		1AC28A58E3C7738C108353BE /* DefaultHosted.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = DefaultHosted.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		2238C255CB7ED2E848A7FC51 /* common.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = common.pch; path = ../../../rules/library/common.pch; sourceTree = "<group>"; };
-		2263A980666D293D7413BE92 /* test.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = test.m; path = "../../ios/unit-test/test-imports-app/test.m"; sourceTree = "<group>"; };
-		246AA4985E50044D3CD8228A /* test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = test.swift; path = "../../ios/unit-test/test-imports-app/test.swift"; sourceTree = "<group>"; };
-		29A682D26AECECF5058D991B /* TestModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; name = TestModel.xcdatamodel; path = "../../ios/unit-test/test-imports-app/Resources/TestModel.xcdatamodel"; sourceTree = "<group>"; };
-		300321A84FA667D38500A4EE /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = ../../../rules/test_host_app/BUILD.bazel; sourceTree = "<group>"; };
-		31B65EED0A5FCC9038424593 /* empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = empty.swift; path = "../../ios/unit-test/empty.swift"; sourceTree = "<group>"; };
-		36C5066BFCF7F5E1A169E184 /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = "../../ios/unit-test/BUILD.bazel"; sourceTree = "<group>"; };
+		211B0D62D65A5D8BEFE42153 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		3CCFF4E96CDD4C2949F0F71A /* Header2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Header2.h; sourceTree = "<group>"; };
+		3ECF1D7133544DD5E82A3EB0 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		57D04511C7357979F7EB5058 /* TestModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = TestModel.xcdatamodel; sourceTree = "<group>"; };
+		5BE4EAFF6C0B54947E66B439 /* ios.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ios.entitlements; sourceTree = "<group>"; };
+		5EF21FC7C23005F0603AD4F0 /* test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = test.swift; sourceTree = "<group>"; };
 		61CE3CBBAD0BFAFC0953377B /* TestImports-App.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "TestImports-App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		6725F1A1E5A5BAFC1EE01F00 /* Header2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Header2.h; path = "../../ios/unit-test/test-imports-app/Header2.h"; sourceTree = "<group>"; };
-		94D89E404CDBA8D5D8F2A11C /* TestStickers.xcstickers */ = {isa = PBXFileReference; lastKnownFileType = folder.stickers; name = TestStickers.xcstickers; path = "../../ios/unit-test/test-imports-app/Resources/TestStickers.xcstickers"; sourceTree = "<group>"; };
+		652BABC45FC498B9E08F96B8 /* AssetCatalogFixture.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = AssetCatalogFixture.xcassets; sourceTree = "<group>"; };
+		6B5478D8BA2BE2A548270A80 /* empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = empty.swift; sourceTree = "<group>"; };
+		6E1E57A5D2E549D270B1B1A7 /* resource_bundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = resource_bundle.plist; sourceTree = "<group>"; };
+		8BBBE8333A9A3A09CEFFD917 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		9E7E8177A9991D407C446EF6 /* TestImports-Unit-Tests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = "TestImports-Unit-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		AB4C6651E31A8BAA65B71170 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = "../../ios/unit-test/test-imports-app/Resources/Resources2/Images.xcassets"; sourceTree = "<group>"; };
-		B07BC976C01F7FFC817868EC /* TestModel2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; name = TestModel2.xcdatamodel; path = "../../ios/unit-test/test-imports-app/Resources/TestModel2.xcdatamodel"; sourceTree = "<group>"; };
-		B68CDE19D4CB716811CCC0D1 /* TestModelMapping.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; name = TestModelMapping.xcmappingmodel; path = "../../ios/unit-test/test-imports-app/Resources/TestModelMapping.xcmappingmodel"; sourceTree = "<group>"; };
-		BC8493575E7FDD7052346981 /* BUILD.bazel */ = {isa = PBXFileReference; name = BUILD.bazel; path = "../../ios/unit-test/test-imports-app/BUILD.bazel"; sourceTree = "<group>"; };
-		CD38E215541F1766D3CAFBEE /* ios.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = ios.entitlements; path = ../../../rules/test_host_app/ios.entitlements; sourceTree = "<group>"; };
-		D91B075B8A3A245F26D08A11 /* AssetCatalogFixture.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = AssetCatalogFixture.xcassets; path = ../../../rules/test_host_app/AssetCatalogFixture.xcassets; sourceTree = "<group>"; };
-		F42CC7E6159DCCC28D045A6C /* empty.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = empty.m; path = "../../ios/unit-test/empty.m"; sourceTree = "<group>"; };
-		FE939800D5E84FA4B194548D /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = main.m; path = ../../../rules/test_host_app/main.m; sourceTree = "<group>"; };
+		A038F6999FF698D9E7E393F6 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
+		A5AC323968F3E7DC9BAFEC85 /* empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = empty.swift; sourceTree = "<group>"; };
+		AF7BF530BE9F3ED2CB34B356 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
+		BE18C5CC5D69DC93C244A788 /* TestModel2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = TestModel2.xcdatamodel; sourceTree = "<group>"; };
+		BFBF7DC447A9E302E7E2946B /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		C3241F917953C6BD1D2BE62A /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
+		D08289E7727590A63B67489C /* Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Header.h; sourceTree = "<group>"; };
+		D229E599DDBCC713FF997122 /* TestStickers.xcstickers */ = {isa = PBXFileReference; lastKnownFileType = folder.stickers; path = TestStickers.xcstickers; sourceTree = "<group>"; };
+		EC2BF9F658BA7B0FF93BA215 /* test.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = test.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
-		0116E61A70E2F030EEFB0081 /* library */ = {
+		06B23FF0DFF8BD111D851949 /* ios */ = {
 			isa = PBXGroup;
 			children = (
-				2238C255CB7ED2E848A7FC51 /* common.pch */,
-				0E1A2D407EDFADA150631F26 /* resource_bundle.plist */,
+				64B768958760ECC68D48BCA8 /* unit-test */,
 			);
-			name = library;
+			path = ios;
 			sourceTree = "<group>";
 		};
-		04C2FDC1FEE0E4D66A74C119 /* Resources */ = {
+		086FBDD761E762B1598CC05E /* test_host_app */ = {
 			isa = PBXGroup;
 			children = (
-				10ED0FBA33677AAD264EF3D3 /* Images.xcassets */,
-				E4C6BADCBA75DF4644F9AAB6 /* Resources2 */,
-				29A682D26AECECF5058D991B /* TestModel.xcdatamodel */,
-				B07BC976C01F7FFC817868EC /* TestModel2.xcdatamodel */,
-				B68CDE19D4CB716811CCC0D1 /* TestModelMapping.xcmappingmodel */,
-				94D89E404CDBA8D5D8F2A11C /* TestStickers.xcstickers */,
+				652BABC45FC498B9E08F96B8 /* AssetCatalogFixture.xcassets */,
+				C3241F917953C6BD1D2BE62A /* BUILD.bazel */,
+				5BE4EAFF6C0B54947E66B439 /* ios.entitlements */,
+				211B0D62D65A5D8BEFE42153 /* main.m */,
 			);
-			name = Resources;
+			path = test_host_app;
+			sourceTree = "<group>";
+		};
+		12AC35FA4ADBC321A4E27AFC /* tests */ = {
+			isa = PBXGroup;
+			children = (
+				06B23FF0DFF8BD111D851949 /* ios */,
+			);
+			path = tests;
 			sourceTree = "<group>";
 		};
 		41BE2FF5579DA46E599A01EC /* Products */ = {
@@ -96,83 +101,87 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		47EF8E9B0D250B2E77846871 /* test-imports-app */ = {
+		53A1C0AA09C71D538BA9031C /* Resources2 */ = {
 			isa = PBXGroup;
 			children = (
-				BC8493575E7FDD7052346981 /* BUILD.bazel */,
-				035030AE3B7F41C97A1EE910 /* empty.swift */,
-				08D20BAAC5B1A41903E13B27 /* Header.h */,
-				6725F1A1E5A5BAFC1EE01F00 /* Header2.h */,
-				0C55810C4D90EF86058DB06A /* main.m */,
-				04C2FDC1FEE0E4D66A74C119 /* Resources */,
-				2263A980666D293D7413BE92 /* test.m */,
-				246AA4985E50044D3CD8228A /* test.swift */,
+				BFBF7DC447A9E302E7E2946B /* Images.xcassets */,
 			);
-			name = "test-imports-app";
+			path = Resources2;
+			sourceTree = "<group>";
+		};
+		64B768958760ECC68D48BCA8 /* unit-test */ = {
+			isa = PBXGroup;
+			children = (
+				A038F6999FF698D9E7E393F6 /* BUILD.bazel */,
+				018DA4ABD245EA72FEA9BA46 /* empty.m */,
+				6B5478D8BA2BE2A548270A80 /* empty.swift */,
+				9D68117D7BA652584708D01D /* test-imports-app */,
+			);
+			path = "unit-test";
 			sourceTree = "<group>";
 		};
 		7CECA2AB833A306EC3500168 = {
 			isa = PBXGroup;
 			children = (
-				9E8242FA9938A76F7FEA9FF8 /* rules */,
-				A072D583870C5D55D7FDE9AA /* tests */,
+				EEFB98134D768549E03E39A5 /* build_bazel_rules_ios */,
 				41BE2FF5579DA46E599A01EC /* Products */,
 			);
 			sourceTree = "<group>";
 		};
-		9E8242FA9938A76F7FEA9FF8 /* rules */ = {
+		9D68117D7BA652584708D01D /* test-imports-app */ = {
 			isa = PBXGroup;
 			children = (
-				0116E61A70E2F030EEFB0081 /* library */,
-				AFC31966959E7E95E45AEEBE /* test_host_app */,
+				AF7BF530BE9F3ED2CB34B356 /* BUILD.bazel */,
+				A5AC323968F3E7DC9BAFEC85 /* empty.swift */,
+				D08289E7727590A63B67489C /* Header.h */,
+				3CCFF4E96CDD4C2949F0F71A /* Header2.h */,
+				3ECF1D7133544DD5E82A3EB0 /* main.m */,
+				DC21B9839449D8D9195E4A22 /* Resources */,
+				EC2BF9F658BA7B0FF93BA215 /* test.m */,
+				5EF21FC7C23005F0603AD4F0 /* test.swift */,
 			);
-			name = rules;
+			path = "test-imports-app";
 			sourceTree = "<group>";
 		};
-		A072D583870C5D55D7FDE9AA /* tests */ = {
+		B0B40062B117F993E7D160D6 /* rules */ = {
 			isa = PBXGroup;
 			children = (
-				FFF381863D683B5DD79A5D6F /* ios */,
+				E58B9C8B7E68050BE38EEF27 /* library */,
+				086FBDD761E762B1598CC05E /* test_host_app */,
 			);
-			name = tests;
+			path = rules;
 			sourceTree = "<group>";
 		};
-		AFC31966959E7E95E45AEEBE /* test_host_app */ = {
+		DC21B9839449D8D9195E4A22 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				D91B075B8A3A245F26D08A11 /* AssetCatalogFixture.xcassets */,
-				300321A84FA667D38500A4EE /* BUILD.bazel */,
-				CD38E215541F1766D3CAFBEE /* ios.entitlements */,
-				FE939800D5E84FA4B194548D /* main.m */,
+				8BBBE8333A9A3A09CEFFD917 /* Images.xcassets */,
+				53A1C0AA09C71D538BA9031C /* Resources2 */,
+				57D04511C7357979F7EB5058 /* TestModel.xcdatamodel */,
+				BE18C5CC5D69DC93C244A788 /* TestModel2.xcdatamodel */,
+				0A3BB7488A9B93655A5A80A7 /* TestModelMapping.xcmappingmodel */,
+				D229E599DDBCC713FF997122 /* TestStickers.xcstickers */,
 			);
-			name = test_host_app;
+			path = Resources;
 			sourceTree = "<group>";
 		};
-		D09C5AAC3E8F31379C981C8F /* unit-test */ = {
+		E58B9C8B7E68050BE38EEF27 /* library */ = {
 			isa = PBXGroup;
 			children = (
-				36C5066BFCF7F5E1A169E184 /* BUILD.bazel */,
-				F42CC7E6159DCCC28D045A6C /* empty.m */,
-				31B65EED0A5FCC9038424593 /* empty.swift */,
-				47EF8E9B0D250B2E77846871 /* test-imports-app */,
+				0DEBE921687BED0630F2E803 /* common.pch */,
+				6E1E57A5D2E549D270B1B1A7 /* resource_bundle.plist */,
 			);
-			name = "unit-test";
+			path = library;
 			sourceTree = "<group>";
 		};
-		E4C6BADCBA75DF4644F9AAB6 /* Resources2 */ = {
+		EEFB98134D768549E03E39A5 /* build_bazel_rules_ios */ = {
 			isa = PBXGroup;
 			children = (
-				AB4C6651E31A8BAA65B71170 /* Images.xcassets */,
+				B0B40062B117F993E7D160D6 /* rules */,
+				12AC35FA4ADBC321A4E27AFC /* tests */,
 			);
-			name = Resources2;
-			sourceTree = "<group>";
-		};
-		FFF381863D683B5DD79A5D6F /* ios */ = {
-			isa = PBXGroup;
-			children = (
-				D09C5AAC3E8F31379C981C8F /* unit-test */,
-			);
-			name = ios;
+			name = build_bazel_rules_ios;
+			path = ../../..;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -353,8 +362,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				55E46FEA2FF714E40EA51316 /* test.m in Sources */,
-				68F6C55581B050CEA9AB6AFF /* test.swift in Sources */,
+				A92FEA9E7CEAA5C1D707216B /* test.m in Sources */,
+				9C997105C8FCCC97A52F3C37 /* test.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -362,8 +371,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EB57E581728375686EE2959C /* empty.m in Sources */,
-				B8F9F9CA8BCC4CFF09734974 /* empty.swift in Sources */,
+				C61986BF5CBA4DAEAF33BE91 /* empty.m in Sources */,
+				C6B1D1CBC7730A53A2C04E0D /* empty.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -371,8 +380,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				48C6C9814CEEF1CACD6D55A0 /* empty.swift in Sources */,
-				E2DE5A172CF0A78BF06C0140 /* main.m in Sources */,
+				E676560B3EE63A86606530C8 /* empty.swift in Sources */,
+				4D9FC7A3A45FAD1826CE314F /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -380,7 +389,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4541759E59ED815D18798894 /* main.m in Sources */,
+				8B8703078ED965C24F7DFC6D /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Xcodegen can now intuit groups properly for paths that start with .., and are above the current directly on disk

(thanks to https://github.com/yonaskolb/XcodeGen/pull/892).

Pointing to my fork for now, since there hasn't been a recent release