### PR TITLE
Search for Vendored Cocoapods Frameworks

### DIFF
--- a/repository_rules/framework_builder.bzl
+++ b/repository_rules/framework_builder.bzl
@@ -15,13 +15,16 @@ def _create_buildfile_content(root, frameworks_subpath):
     binaries_path = root
     for element in frameworks_subpath.split("/"):
         binaries_path = binaries_path.get_child(element)
+        nested_framework_binaries_path = binaries_path.get_child("Frameworks")
+        if nested_framework_binaries_path.exists:
+            binaries_path = nested_framework_binaries_path.readdir()[0]
 
     if binaries_path.exists:
         frameworks = [path for path in binaries_path.readdir() if str(path).endswith(".framework")]
         for framework in frameworks:
             new_content = """\
 filegroup(
-    name = "%s", 
+    name = "%s",
     srcs = glob(["%s/%s/**/*"]),
     visibility = ["//visibility:public"],
 )\


### PR DESCRIPTION
When using the cocoapods framework builder rule with the follow Podfile, the current implementation is broken

`pod 'Google-Mobile-Ads-SDK',  :binary => true`

The reason is that the subpath for the framework for this pod is different than usual. The library expects

`Cocoapods/Pods/_Prebuild/GeneratedFrameworks/Google-Mobile-Ads-SDK`

but the right path is actually:

`Cocoapods/Pods/_Prebuild/GeneratedFrameworks/Google-Mobile-Ads-SDK/Frameworks/GoogleMobileAdsFramework-Current`

This PR adds logic to search additional paths to find these nested frameworks