### PR TITLE
Setting cwd explicitly to ensure lldb remote debugging works on relative paths in debug info etc.

### DIFF
--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -11,10 +11,15 @@ set -euo pipefail
 # the paths in the debug info. This lldb setting ensures that _project relative_
 # paths are remapped to _project absolute_ paths.
 #
+# The platform settings one points the current working directory (cwd) to workspace root.
+# This is needed for features relying on lldb remote debugging, such as `oso_prefix_is_pwd`.
+#
 # NOTE: In order to use this, add this line to `~/.lldbinit`:
 #
 #     command source ~/.lldbinit-source-map
 cat <<-END > ~/.lldbinit-source-map
+platform settings -w "$BAZEL_WORKSPACE_ROOT/"
+
 settings set target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
 settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -11,10 +11,15 @@ set -euo pipefail
 # the paths in the debug info. This lldb setting ensures that _project relative_
 # paths are remapped to _project absolute_ paths.
 #
+# The platform settings one points the current working directory (cwd) to workspace root.
+# This is needed for features relying on lldb remote debugging, such as `oso_prefix_is_pwd`.
+#
 # NOTE: In order to use this, add this line to `~/.lldbinit`:
 #
 #     command source ~/.lldbinit-source-map
 cat <<-END > ~/.lldbinit-source-map
+platform settings -w "$BAZEL_WORKSPACE_ROOT/"
+
 settings set target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
 settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -11,10 +11,15 @@ set -euo pipefail
 # the paths in the debug info. This lldb setting ensures that _project relative_
 # paths are remapped to _project absolute_ paths.
 #
+# The platform settings one points the current working directory (cwd) to workspace root.
+# This is needed for features relying on lldb remote debugging, such as `oso_prefix_is_pwd`.
+#
 # NOTE: In order to use this, add this line to `~/.lldbinit`:
 #
 #     command source ~/.lldbinit-source-map
 cat <<-END > ~/.lldbinit-source-map
+platform settings -w "$BAZEL_WORKSPACE_ROOT/"
+
 settings set target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
 settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -11,10 +11,15 @@ set -euo pipefail
 # the paths in the debug info. This lldb setting ensures that _project relative_
 # paths are remapped to _project absolute_ paths.
 #
+# The platform settings one points the current working directory (cwd) to workspace root.
+# This is needed for features relying on lldb remote debugging, such as `oso_prefix_is_pwd`.
+#
 # NOTE: In order to use this, add this line to `~/.lldbinit`:
 #
 #     command source ~/.lldbinit-source-map
 cat <<-END > ~/.lldbinit-source-map
+platform settings -w "$BAZEL_WORKSPACE_ROOT/"
+
 settings set target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
 settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -11,10 +11,15 @@ set -euo pipefail
 # the paths in the debug info. This lldb setting ensures that _project relative_
 # paths are remapped to _project absolute_ paths.
 #
+# The platform settings one points the current working directory (cwd) to workspace root.
+# This is needed for features relying on lldb remote debugging, such as `oso_prefix_is_pwd`.
+#
 # NOTE: In order to use this, add this line to `~/.lldbinit`:
 #
 #     command source ~/.lldbinit-source-map
 cat <<-END > ~/.lldbinit-source-map
+platform settings -w "$BAZEL_WORKSPACE_ROOT/"
+
 settings set target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
 settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -11,10 +11,15 @@ set -euo pipefail
 # the paths in the debug info. This lldb setting ensures that _project relative_
 # paths are remapped to _project absolute_ paths.
 #
+# The platform settings one points the current working directory (cwd) to workspace root.
+# This is needed for features relying on lldb remote debugging, such as `oso_prefix_is_pwd`.
+#
 # NOTE: In order to use this, add this line to `~/.lldbinit`:
 #
 #     command source ~/.lldbinit-source-map
 cat <<-END > ~/.lldbinit-source-map
+platform settings -w "$BAZEL_WORKSPACE_ROOT/"
+
 settings set target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
 settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS

--- a/tools/xcodeproj_shims/installers/lldb-settings.sh
+++ b/tools/xcodeproj_shims/installers/lldb-settings.sh
@@ -11,10 +11,15 @@ set -euo pipefail
 # the paths in the debug info. This lldb setting ensures that _project relative_
 # paths are remapped to _project absolute_ paths.
 #
+# The platform settings one points the current working directory (cwd) to workspace root.
+# This is needed for features relying on lldb remote debugging, such as `oso_prefix_is_pwd`.
+#
 # NOTE: In order to use this, add this line to `~/.lldbinit`:
 #
 #     command source ~/.lldbinit-source-map
 cat <<-END > ~/.lldbinit-source-map
+platform settings -w "$BAZEL_WORKSPACE_ROOT/"
+
 settings set target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
 settings set target.sdk-path $SDKROOT
 settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS


### PR DESCRIPTION
This is important for lldb debugger to work correctly according to https://lldb.llvm.org/use/remote.html#id6
In future we can ask developers to run `platform status` inside lldb to ensure some metadata is correct.

Without this change, do `platform shell pwd` in lldb says `/` and after this it becomes whatever workspace you are actually in.

This might be a solution to some past/existing issues related to lldb debugger.
Testing against downstream project to make sure this works.