### PR TITLE
Disable use headermap on xcode side

### DIFF
--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -571,7 +571,10 @@ def _xcodeproj_impl(ctx):
         "groupSortPosition": "none",
         "settingPresets": "none",
     }
-    proj_settings_base = {
+    proj_settings_base = {}
+
+    # User defined macro for Bazel only
+    proj_settings_base.update({
         "BAZEL_BUILD_EXEC": "$BAZEL_STUBS_DIR/build-wrapper",
         "BAZEL_OUTPUT_PROCESSOR": "$BAZEL_STUBS_DIR/output-processor.rb",
         "BAZEL_PATH": ctx.attr.bazel_path,
@@ -581,18 +584,33 @@ def _xcodeproj_impl(ctx):
         "BAZEL_INSTALLERS_DIR": "$PROJECT_FILE_PATH/bazelinstallers",
         "BAZEL_INSTALLER": "$BAZEL_INSTALLERS_DIR/%s" % ctx.executable.installer.basename,
         "BAZEL_EXECUTION_LOG_ENABLED": False,
+    })
+
+    # Stubbding main executable used by xcode so no actual building happening on Xcode side
+    proj_settings_base.update({
         "CC": "$BAZEL_STUBS_DIR/clang-stub",
         "CXX": "$CC",
         "CLANG_ANALYZER_EXEC": "$CC",
-        "CODE_SIGNING_ALLOWED": False,
-        "DEBUG_INFORMATION_FORMAT": "dwarf",
-        "DONT_RUN_SWIFT_STDLIB_TOOL": True,
         "LD": "$BAZEL_STUBS_DIR/ld-stub",
         "LIBTOOL": "/usr/bin/true",
         "SWIFT_EXEC": "$BAZEL_STUBS_DIR/swiftc-stub",
+    })
+
+    # Change of settings to help params used for compiling individual files to match closer to Bazel
+    proj_settings_base.update({
+        "USE_HEADERMAP": False,
+    })
+
+    # Other misc. settings changes
+    proj_settings_base.update({
+        "CODE_SIGNING_ALLOWED": False,
+        "DEBUG_INFORMATION_FORMAT": "dwarf",
+        "DONT_RUN_SWIFT_STDLIB_TOOL": True,
         "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
         "SWIFT_VERSION": 5,
-    }
+    })
+
+    # For debugging config only:
     proj_settings_debug = {
         "GCC_PREPROCESSOR_DEFINITIONS": "DEBUG",
         "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
@@ -317,6 +317,7 @@
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_VERSION = 5;
+				USE_HEADERMAP = 0;
 			};
 			name = Debug;
 		};
@@ -380,6 +381,7 @@
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_VERSION = 5;
+				USE_HEADERMAP = 0;
 			};
 			name = Release;
 		};

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.pbxproj
@@ -306,6 +306,7 @@
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_VERSION = 5;
+				USE_HEADERMAP = 0;
 			};
 			name = Debug;
 		};
@@ -333,6 +334,7 @@
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_VERSION = 5;
+				USE_HEADERMAP = 0;
 			};
 			name = Release;
 		};

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/project.pbxproj
@@ -438,6 +438,7 @@
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_VERSION = 5;
+				USE_HEADERMAP = 0;
 			};
 			name = Debug;
 		};
@@ -559,6 +560,7 @@
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_VERSION = 5;
+				USE_HEADERMAP = 0;
 			};
 			name = Release;
 		};

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/project.pbxproj
@@ -368,6 +368,7 @@
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_VERSION = 5;
+				USE_HEADERMAP = 0;
 			};
 			name = Debug;
 		};
@@ -413,6 +414,7 @@
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_VERSION = 5;
+				USE_HEADERMAP = 0;
 			};
 			name = Release;
 		};

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.pbxproj
@@ -276,6 +276,7 @@
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_VERSION = 5;
+				USE_HEADERMAP = 0;
 			};
 			name = Debug;
 		};
@@ -343,6 +344,7 @@
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_VERSION = 5;
+				USE_HEADERMAP = 0;
 			};
 			name = Release;
 		};

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
@@ -364,6 +364,7 @@
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_VERSION = 5;
+				USE_HEADERMAP = 0;
 			};
 			name = Debug;
 		};
@@ -391,6 +392,7 @@
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_VERSION = 5;
+				USE_HEADERMAP = 0;
 			};
 			name = Release;
 		};

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
@@ -341,6 +341,7 @@
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_VERSION = 5;
+				USE_HEADERMAP = 0;
 			};
 			name = Release;
 		};
@@ -429,6 +430,7 @@
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_VERSION = 5;
+				USE_HEADERMAP = 0;
 			};
 			name = Debug;
 		};

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
@@ -533,6 +533,7 @@
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_VERSION = 5;
+				USE_HEADERMAP = 0;
 			};
 			name = Release;
 		};
@@ -602,6 +603,7 @@
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_VERSION = 5;
+				USE_HEADERMAP = 0;
 			};
 			name = Debug;
 		};


### PR DESCRIPTION
### Why this change:
- We found that letting this enabled by default causes some header import problems (`foo header not found`) during source indexing, because having this added a compiler option `-I<path_to_hmap_under_derived_source>` for clang invocation, resulting in a different behavior than Bazel (Bazel will never use anything under Derived data for compiling)
### Testing:
No red-green test case found under rules_ios as no testing project is complicated enough that having this setting changed makes a difference for header search.
Testing against downstream project that uses this change did help fix some header import problem, and not making things worse (we have an existing existing test set)
