### PR TITLE
Add sources to project, instead of the target

### DIFF
--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -425,6 +425,7 @@ def _populate_xcodeproj_targets_and_schemes(ctx, targets, src_dot_dots):
         compiled_sources = [{
             "path": paths.join(src_dot_dots, s.short_path),
             "optional": True,
+            "buildPhase": "none",
         } for s in target_info.srcs.to_list()]
         compiled_non_arc_sources = [{
             "path": paths.join(src_dot_dots, s.short_path),

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
@@ -6,11 +6,6 @@
 	objectVersion = 51;
 	objects = {
 
-/* Begin PBXBuildFile section */
-		0BD7FD856ED50175FA3D3BC9 /* FooFrameworkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 091655034CF618D208C22AE8 /* FooFrameworkTests.m */; };
-		5C8EED4DAAF3B4B069337569 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = CF7A2F537C999952921627A8 /* main.m */; };
-/* End PBXBuildFile section */
-
 /* Begin PBXFileReference section */
 		091655034CF618D208C22AE8 /* FooFrameworkTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FooFrameworkTests.m; sourceTree = "<group>"; };
 		11B98E6654D00F1E74B2DA47 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
@@ -251,7 +246,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5C8EED4DAAF3B4B069337569 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -266,7 +260,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0BD7FD856ED50175FA3D3BC9 /* FooFrameworkTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.pbxproj
@@ -6,12 +6,6 @@
 	objectVersion = 51;
 	objects = {
 
-/* Begin PBXBuildFile section */
-		31AA2C5800D29E42C589B56B /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52FB08B7C929A64386CDFE06 /* empty.swift */; };
-		83CAB78009AF4F0196136FB6 /* empty.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F973C72CDD8C3C263F6A615 /* empty.m */; };
-		90364CB6CB510200E694DB55 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B78B78C06FA82FF60423814 /* main.m */; };
-/* End PBXBuildFile section */
-
 /* Begin PBXContainerItemProxy section */
 		F38C65FC54D7CD052E02657E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -226,7 +220,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				90364CB6CB510200E694DB55 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -234,8 +227,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				83CAB78009AF4F0196136FB6 /* empty.m in Sources */,
-				31AA2C5800D29E42C589B56B /* empty.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
@@ -8,9 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		045D4161C1AD7DBC32E8B780 /* NonArcObject.m in Sources */ = {isa = PBXBuildFile; fileRef = EB0D04543A3924BA34C4E72B /* NonArcObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		2530CD9920C75C7CC2BE6EC7 /* test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8309CFF8A1900D3AB1BF293D /* test.swift */; };
-		92A134A20F5F9E93BCB6F756 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 705989AC65B3703138E736BB /* main.m */; };
-		EC6016D70E0EEF1F8C1B0F2D /* test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8309CFF8A1900D3AB1BF293D /* test.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -255,7 +252,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2530CD9920C75C7CC2BE6EC7 /* test.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -263,7 +259,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				92A134A20F5F9E93BCB6F756 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -272,7 +267,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				045D4161C1AD7DBC32E8B780 /* NonArcObject.m in Sources */,
-				EC6016D70E0EEF1F8C1B0F2D /* test.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
@@ -8,9 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		3F1AA37EFCFD35B3FC5C97AC /* NonArcObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D13FC12B4485F863BAAF03E /* NonArcObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		7F5FB90D81C2C0392B07F5C9 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 94000CEDD7AE8D8B38E4F95D /* main.m */; };
-		CAFA5ED3B2BFE4F760E7F4D5 /* test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059EDA0A0E4F8B6CC0164819 /* test.swift */; };
-		F9E1A08703A81C31CAF5D20C /* test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059EDA0A0E4F8B6CC0164819 /* test.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -256,7 +253,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				3F1AA37EFCFD35B3FC5C97AC /* NonArcObject.m in Sources */,
-				CAFA5ED3B2BFE4F760E7F4D5 /* test.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -264,7 +260,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7F5FB90D81C2C0392B07F5C9 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -272,7 +267,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F9E1A08703A81C31CAF5D20C /* test.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
@@ -6,16 +6,6 @@
 	objectVersion = 51;
 	objects = {
 
-/* Begin PBXBuildFile section */
-		4D9FC7A3A45FAD1826CE314F /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 3ECF1D7133544DD5E82A3EB0 /* main.m */; };
-		8B8703078ED965C24F7DFC6D /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 211B0D62D65A5D8BEFE42153 /* main.m */; };
-		9C997105C8FCCC97A52F3C37 /* test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF21FC7C23005F0603AD4F0 /* test.swift */; };
-		A92FEA9E7CEAA5C1D707216B /* test.m in Sources */ = {isa = PBXBuildFile; fileRef = EC2BF9F658BA7B0FF93BA215 /* test.m */; };
-		C61986BF5CBA4DAEAF33BE91 /* empty.m in Sources */ = {isa = PBXBuildFile; fileRef = 018DA4ABD245EA72FEA9BA46 /* empty.m */; };
-		C6B1D1CBC7730A53A2C04E0D /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5478D8BA2BE2A548270A80 /* empty.swift */; };
-		E676560B3EE63A86606530C8 /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5AC323968F3E7DC9BAFEC85 /* empty.swift */; };
-/* End PBXBuildFile section */
-
 /* Begin PBXContainerItemProxy section */
 		1DC2C8510A05B48300816294 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -362,8 +352,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A92FEA9E7CEAA5C1D707216B /* test.m in Sources */,
-				9C997105C8FCCC97A52F3C37 /* test.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -371,8 +359,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C61986BF5CBA4DAEAF33BE91 /* empty.m in Sources */,
-				C6B1D1CBC7730A53A2C04E0D /* empty.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -380,8 +366,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E676560B3EE63A86606530C8 /* empty.swift in Sources */,
-				4D9FC7A3A45FAD1826CE314F /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -389,7 +373,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8B8703078ED965C24F7DFC6D /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
- Ensures that the files will continue to show up in Xcode's 'Project
  Navigator'

- Ensures that the same files will _not_ show up in any target's
  'Compile Sources' build phase