### PR TITLE
Add provisioning_profile to ios_application kwargs

### DIFF
--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -11,6 +11,7 @@ _IOS_APPLICATION_KWARGS = [
     "entitlements",
     "visibility",
     "launch_storyboard",
+    "provisioning_profile",
     "resources",
     "app_icons",
     "tags",


### PR DESCRIPTION
Passes the `provisioning_profile` argument through to [rules_apple's `ios_application`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-ios.md#ios_application).

(We've been adding these as we've needed them, happy to do a more thorough review of all of the `attr`s that we may need to cut down on PR noise if that is preferable.)