### PR TITLE
Added support for vendored frameworks to the build_cocoapods_frameworks repository rule

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -59,7 +59,7 @@ load("@build_bazel_rules_ios//repository_rules:framework_builder.bzl", "build_ca
 
 build_carthage_frameworks(
     name = "carthage",
-    carthage_version = "0.34.0",
+    carthage_version = "0.36.0",
     directory = "tests/ios/frameworks/sources-with-prebuilt-binaries",
 )
 

--- a/tests/ios/frameworks/sources-with-prebuilt-binaries/BUILD.bazel
+++ b/tests/ios/frameworks/sources-with-prebuilt-binaries/BUILD.bazel
@@ -2,15 +2,24 @@ load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
 load("@build_bazel_rules_ios//rules:apple_patched.bzl", "apple_dynamic_framework_import")
 load("@build_bazel_rules_ios//rules:test.bzl", "ios_unit_test")
 
+# A framework built with carthage
 apple_dynamic_framework_import(
     name = "InputMask",
     framework_imports = ["@carthage//:InputMask"],
     visibility = ["//visibility:public"],
 )
 
+# A framework built with cocoapods-binary
 apple_dynamic_framework_import(
     name = "SnapKit",
     framework_imports = ["@cocoapods//:SnapKit"],
+    visibility = ["//visibility:public"],
+)
+
+# A prebuilt vendored_framework distributed with cocoapods
+apple_dynamic_framework_import(
+    name = "GoogleMobileAds",
+    framework_imports = ["@cocoapods//:GoogleMobileAds"],
     visibility = ["//visibility:public"],
 )
 
@@ -26,6 +35,7 @@ apple_framework(
     ),
     visibility = ["//visibility:public"],
     deps = [
+        ":GoogleMobileAds",
         ":InputMask",
         ":SnapKit",
     ],

--- a/tests/ios/frameworks/sources-with-prebuilt-binaries/MixedSourceFramework/Framework.swift
+++ b/tests/ios/frameworks/sources-with-prebuilt-binaries/MixedSourceFramework/Framework.swift
@@ -1,5 +1,6 @@
-import InputMask
-import SnapKit
+import GoogleMobileAds // A prebuilt vendored_framework distributed with cocoapods
+import InputMask // A framework built with carthage
+import SnapKit // A framework built with cocoapods-binary
 
 /* Declaring this extension used to make the framework build fail with the error:
  * ...MixedSourceFramework-Swift.h:184:9: fatal error: module 'SwiftLibrary' not found
@@ -14,3 +15,4 @@ public extension MaskedTextInputListener {
 }
 
 public let snapKitClass = String(reflecting: Constraint.self)
+public let googleMobileAdsClass = String(reflecting: GoogleMobileAds.DFPBannerView.self)

--- a/tests/ios/frameworks/sources-with-prebuilt-binaries/MixedSourceFrameworkTests/Tests.swift
+++ b/tests/ios/frameworks/sources-with-prebuilt-binaries/MixedSourceFrameworkTests/Tests.swift
@@ -7,5 +7,6 @@ class Tests: XCTestCase {
     func test() {
         XCTAssertEqual(snapKitClass, "SnapKit.Constraint")
         XCTAssertEqual(MaskedTextInputListener.inputMaskClass, "InputMask.MaskedTextInputListener")
+        XCTAssertEqual(googleMobileAdsClass, "DFPBannerView")
     }
 }

--- a/tests/ios/frameworks/sources-with-prebuilt-binaries/Podfile
+++ b/tests/ios/frameworks/sources-with-prebuilt-binaries/Podfile
@@ -23,6 +23,7 @@ end
 #################
 
 pod 'SnapKit', '5.0.1', :binary => $useBinaries
+pod 'Google-Mobile-Ads-SDK', '7.66.0', :binary => $useBinaries
 
 #################
 # Set swift versions for pods that do not specify them


### PR DESCRIPTION
Fixes https://github.com/bazel-ios/rules_ios/pull/126

In this PR:
* Added support for vendored frameworks to the build_cocoapods_frameworks repository rule: now find all frameworks recursively under `Pods/_Prebuild/GeneratedFrameworks`. Also added tests
* Refactor code to a simpler implementation