### PR TITLE
Include header files and modulemap for framework packaging in the DefaultInfo provider

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -302,7 +302,7 @@ def _apple_framework_packaging_impl(ctx):
         cc_common.merge_cc_infos(direct_cc_infos = [cc_info_provider], cc_infos = [dep[CcInfo] for dep in ctx.attr.transitive_deps if CcInfo in dep]),
         swift_common.create_swift_info(**swift_info_fields),
         # bare minimum to ensure compilation and package framework with modules and headers
-        DefaultInfo(files = depset(binary_out + swiftmodule_out + header_out + private_header_out + modulemap_out)),  
+        DefaultInfo(files = depset(binary_out + swiftmodule_out + header_out + private_header_out + modulemap_out)),
         AppleBundleInfo(
             archive = None,
             archive_root = None,

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -301,7 +301,8 @@ def _apple_framework_packaging_impl(ctx):
         objc_provider,
         cc_common.merge_cc_infos(direct_cc_infos = [cc_info_provider], cc_infos = [dep[CcInfo] for dep in ctx.attr.transitive_deps if CcInfo in dep]),
         swift_common.create_swift_info(**swift_info_fields),
-        DefaultInfo(files = depset(binary_out + swiftmodule_out)),  # bare minimum to ensure compilation
+        # bare minimum to ensure compilation and package framework with modules and headers
+        DefaultInfo(files = depset(binary_out + swiftmodule_out + header_out + private_header_out + modulemap_out)),  
         AppleBundleInfo(
             archive = None,
             archive_root = None,


### PR DESCRIPTION
Framework directories for frameworks with swift code need to include (1) a header that bridges Swift <-> Objc (i.e. a FWName-Swift.h file) and (2) a modulemap. The framework packaging rule packages the public and private headers and the modulemap in the final FW package. However, these files were not showing up in the `.framework` directory that is under bazel-out. Returning these fields in the provider fixes the problem.

You can repro the problem and verify that this PR solves it by running `bazelisk build tests/ios/unit-test/test-imports-app:SomeFramework`. After that, run `ls -lR bazel-out/applebin_ios-ios_x86_64-dbg-ST-5dc50b810145/bin/tests/ios/unit-test/test-imports-app/SomeFramework/SomeFramework.framework` to see the contents of the final framework package. In the broken case, there are no Headers and no modulemap in the final framework under bazel-out.