### PR TITLE
Unable to use spaces in test env

### DIFF
--- a/tests/ios/unit-test/BUILD.bazel
+++ b/tests/ios/unit-test/BUILD.bazel
@@ -34,6 +34,20 @@ ios_unit_test(
 )
 
 ios_unit_test(
+    name = "UnitTestWithSpaceEnvVars",
+    srcs = [
+        "assertspaces.swift",
+        "empty.m",
+        "empty.swift",
+    ],
+    env = {
+        "myvar1": "this has spaces",
+        "myvar2": "I guess this one has some too",
+    },
+    minimum_os_version = "12.0",
+)
+
+ios_unit_test(
     name = "ResourcesAddedToUnitTestBundle",
     srcs = [
         "empty.m",

--- a/tests/ios/unit-test/assertspaces.swift
+++ b/tests/ios/unit-test/assertspaces.swift
@@ -1,0 +1,9 @@
+import Foundation
+import XCTest
+
+class AssertSpacesTests : XCTestCase {
+  func testPasses() {
+      XCTAssertEqual(ProcessInfo.processInfo.environment["myvar1"], "this has spaces")
+      XCTAssertEqual(ProcessInfo.processInfo.environment["myvar2"], "I guess this one has some too")
+  }
+}


### PR DESCRIPTION
It appears that we cannot use spaces in test env variables, yet this is supported in rules_apple https://github.com/bazelbuild/rules_apple/commit/424c73847eba4d2a093fa59df1aa22b5629b0fda . Where am I going wrong here?