### PR TITLE
Pass "extensions" keyword argument to ios_application from rules_apple

### DIFF
--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -9,6 +9,7 @@ _IOS_APPLICATION_KWARGS = [
     "test_host",
     "families",
     "entitlements",
+    "extensions",
     "visibility",
     "launch_storyboard",
     "provisioning_profile",

--- a/tests/ios/app/BUILD.bazel
+++ b/tests/ios/app/BUILD.bazel
@@ -41,6 +41,21 @@ ios_application(
 )
 
 ios_application(
+    name = "AppWithExtension",
+    srcs = ["App/main.m"],
+    bundle_id = "com.example.app",
+    extensions = [
+        "//tests/ios/extensions:ExampleExtension",
+    ],
+    minimum_os_version = "10.0",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":FW",
+        ":OnlySources",
+    ],
+)
+
+ios_application(
     name = "AppWithEmptyDep",
     srcs = ["App/main.m"],
     bundle_id = "com.example.app",

--- a/tests/ios/extensions/BUILD.bazel
+++ b/tests/ios/extensions/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_extension")
+
+ios_extension(
+    name = "ExampleExtension",
+    bundle_id = "com.example.app.example-extension",
+    families = [
+        "iphone",
+    ],
+    infoplists = [
+        "ExampleExtension/Info.plist",
+    ],
+    minimum_os_version = "10.0",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tests/ios/app:FW",
+    ],
+)

--- a/tests/ios/extensions/ExampleExtension/Info.plist
+++ b/tests/ios/extensions/ExampleExtension/Info.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>SillyShare</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.example.app.example-extension</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.0</string>
+	<key>CFBundleVersion</key>
+	<string>1.0.0</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<string>TRUEPREDICATE</string>
+		</dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+	</dict>
+</dict>
+</plist>
+


### PR DESCRIPTION
Add `extensions` keyword argument to this list of argument names that are forwarded on to the `ios_application` rule from `rules_apple`.