### PR TITLE
Add "build_with_xcodebuild" attribute to xcodeproj rule

### DIFF
--- a/tests/ios/xcodeproj/BUILD.bazel
+++ b/tests/ios/xcodeproj/BUILD.bazel
@@ -16,6 +16,22 @@ xcodeproj(
 )
 
 xcodeproj(
+    name = "Xcodebuild-Single-Static-Framework-Project",
+    testonly = True,
+    bazel_path = "bazelisk",
+    build_with_xcodebuild = True,
+    generate_schemes_for_product_types = [
+        "framework.static",
+        "bundle.unit-test",
+    ],
+    include_transitive_targets = True,
+    deps = [
+        "//tests/ios/frameworks/objc:ObjcFramework",
+        "//tests/ios/frameworks/objc:ObjcFrameworkTests",
+    ],
+)
+
+xcodeproj(
     name = "Test-Imports-App-Project",
     testonly = True,
     bazel_path = "bazelisk",

--- a/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Import Bazel built indexstores into Xcode. See https://github.com/lyft/index-import
+#
+# This makes use of a number of Xcode's provided environment variables. These
+# file remappings are not specific to this project, the apply to all projects
+# built with Bazel and rules_swift.
+
+# Example: /private/var/tmp/_bazel_<username>/<hash>/execroot/<workspacename>
+readonly bazel_root="^/private/var/tmp/_bazel_.+?/.+?/execroot/[^/]+"
+readonly bazel_bin="^(?:$bazel_root/)?bazel-out/.+?/bin"
+
+# Object file paths are fundamental to how Xcode loads from the indexstore. If
+# the `OutputFile` does not match what Xcode looks for, then those parts of the
+# indexstore will not be found and used.
+readonly bazel_swift_object="$bazel_bin/.*/(.+?)(?:_swift)?_objs/.*/(.+?)[.]swift[.]o$"
+readonly bazel_objc_object="$bazel_bin/.*/_objs/(?:arc/|non_arc/)?(.+?)-(?:objc|cpp)/(.+?)[.]o$"
+readonly xcode_object="$CONFIGURATION_TEMP_DIR/\$1.build/Objects-normal/$ARCHS/\$2.o"
+
+# Bazel built `.swiftmodule` files are copied to `DerivedData`. Since modules
+# are referenced by indexstores, their paths are remapped.
+readonly bazel_module="$bazel_bin/.*/(.+?)[.]swiftmodule$"
+readonly xcode_module="$BUILT_PRODUCTS_DIR/\$1.swiftmodule/$ARCHS.swiftmodule"
+
+# External dependencies are available via the `bazel-<workspacename>` symlink.
+# This remapping, in combination with `xcode-index-preferences.json`, enables
+# index features for external dependencies, such as jump-to-definition.
+readonly bazel_external="$bazel_root/external"
+readonly xcode_external="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$SRCROOT")/external"
+
+
+$BAZEL_INSTALLERS_DIR/index-import \
+    -remap "$bazel_module=$xcode_module" \
+    -remap "$bazel_swift_object=$xcode_object" \
+    -remap "$bazel_objc_object=$xcode_object" \
+    -remap "$bazel_external=$xcode_external" \
+    -remap "$bazel_root=$BAZEL_WORKSPACE_ROOT" \
+    -remap "^([^//])=$BAZEL_WORKSPACE_ROOT/\$1" \
+    "$@" \
+    "$BUILD_DIR"/../../Index/DataStore

--- a/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/bazelinstallers/_swiftmodule.sh
+++ b/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/bazelinstallers/_swiftmodule.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+for module in "$@"; do
+    doc="${module%.swiftmodule}.swiftdoc"
+    module_name=$(basename "$module")
+    module_bundle="$BUILT_PRODUCTS_DIR/$module_name"
+    mkdir -p "$module_bundle"
+
+    cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule"
+    cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc"
+
+    ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
+    cp "$module" "$module_bundle/$ios_module_name.swiftmodule"
+    cp "$doc" "$module_bundle/$ios_module_name.swiftdoc"
+
+    chmod -R +w "$module_bundle"
+done

--- a/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# See `_indexstore.sh` for full details.
+
+echo "Start remapping index files at `date`"
+
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq`
+
+declare -a EXISTING_INDEXSTORES=()
+for i in $FOUND_INDEXSTORES
+do
+  if [ -d $i ]
+  then
+    EXISTING_INDEXSTORES+=($i)
+  fi
+done
+
+echo "Found ${#EXISTING_INDEXSTORES[@]} existing indexstores"
+
+if [ ${#EXISTING_INDEXSTORES[@]} -ne 0 ]
+then
+  "$BAZEL_INSTALLERS_DIR/_indexstore.sh" ${EXISTING_INDEXSTORES[*]}
+else
+  echo "No indexstores found"
+fi
+
+echo "Finish remapping index files at `date`"
+
+ls -ltR $BUILD_DIR/../../Index/DataStore/ > $BAZEL_DIAGNOSTICS_DIR/indexstores-contents-$DATE_SUFFIX.log

--- a/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/bazelinstallers/install.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+# Install the runnable products so that Xcode can run it. This includes `.app`s,
+# `.xctest`s, and also command line binaries.
+
+set -eux
+
+# Delete all logfiles that are older than 7 days
+find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
+
+case "${PRODUCT_TYPE}" in
+com.apple.product-type.framework)
+    input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    ;;
+com.apple.product-type.framework.static)
+    # For static library, as the output is not under bazel-bin, we have to get it based on build event
+    # Example of such entry inside build event:
+    # important_output {
+    #   name: ".../SomeFramework.framework/SomeFramework"
+    #   uri: "file:///private/var/tmp/.../.../SomeFramework.framework/SomeFramework"
+    #   path_prefix:...
+    #   ...
+    #  }
+    # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
+    QUERY=$(grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///")
+    if [[ -z $QUERY ]]; then
+        echo "Unable to locate resource for framework of ${TARGET_NAME}"
+        exit 1
+    fi
+    input_options=($(dirname "${QUERY}"))
+    ;;
+com.apple.product-type.bundle.unit-test)
+    input_options=(
+        "bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}"
+        "bazel-bin/$BAZEL_BIN_SUBDIR/$TARGET_NAME.__internal__.__test_bundle_archive-root/$TARGET_NAME${WRAPPER_SUFFIX:-}"
+        "bazel-bin/$BAZEL_BIN_SUBDIR/${BAZEL_BUILD_TARGET_LABEL#*:}.runfiles/${BAZEL_BUILD_TARGET_WORKSPACE}/${BAZEL_BIN_SUBDIR}/${FULL_PRODUCT_NAME}"
+        "bazel-bin/$BAZEL_BIN_SUBDIR/${BAZEL_BUILD_TARGET_LABEL#*:}.runfiles/${BAZEL_BUILD_TARGET_WORKSPACE}/${BAZEL_BIN_SUBDIR}/$TARGET_NAME.zip"
+    )
+    ;;
+com.apple.product-type.application)
+    input_options=(
+        "bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}"
+        "bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}_archive-root/Payload/$TARGET_NAME${WRAPPER_SUFFIX:-}"
+        "bazel-bin/$BAZEL_BIN_SUBDIR/${BAZEL_BUILD_TARGET_LABEL#*:}.runfiles/${BAZEL_BUILD_TARGET_WORKSPACE}/${BAZEL_BIN_SUBDIR}/${FULL_PRODUCT_NAME}"
+        "bazel-bin/$BAZEL_BIN_SUBDIR/${BAZEL_BUILD_TARGET_LABEL#*:}.runfiles/${BAZEL_BUILD_TARGET_WORKSPACE}/${BAZEL_BIN_SUBDIR}/$TARGET_NAME.zip"
+    )
+    ;;
+*)
+    echo "Error: Installing ${TARGET_NAME} of type ${PRODUCT_TYPE} is unsupported" >&2
+    exit 1
+    ;;
+esac
+output="$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME"
+
+mkdir -p $OBJECT_FILE_DIR_normal/$CURRENT_ARCH/
+chmod -R +w $OBJECT_FILE_DIR_normal/$CURRENT_ARCH/
+
+for swiftmodulefile in ${BAZEL_SWIFTMODULEFILES_TO_COPY:-}; do
+    if [[ -e $swiftmodulefile ]]; then
+        cp $swiftmodulefile $OBJECT_FILE_DIR_normal/$CURRENT_ARCH/
+    fi
+done
+
+mkdir -p "$(dirname "$output")"
+copied=false
+
+for input in "${input_options[@]}"; do
+    if [[ -z $input ]] || [ $input = "." ] || [ $input = "/" ]; then
+        # rsync can be a dangerous operation when it tries to copy entire root dir into the $output
+        echo "Error: illegal input \"${input}\" for installing ${TARGET_NAME} of type ${PRODUCT_TYPE}" >&2
+        exit 1
+    fi
+    if [[ -d $input ]]; then
+        # Copy bundle contents, into the destination bundle.
+        # This avoids self-nesting, like: Foo.app/Foo.app
+        input+="/"
+    elif [[ ! -f $input ]] || [[ $input != *.zip ]]; then
+        continue
+    fi
+
+    if [[ $input == *.zip ]]; then
+        rm -rf "$output"
+        unzip -qq -d "$TARGET_BUILD_DIR" "$input"
+    else
+        rsync \
+            --recursive --chmod=u+w --delete \
+            "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
+    fi
+
+    if [[ -n "${SWIFT_OBJC_INTERFACE_HEADER_NAME:-}" ]]; then
+        cp -f "$input/Headers/$SWIFT_OBJC_INTERFACE_HEADER_NAME" "$OBJECT_FILE_DIR_normal/$CURRENT_ARCH/"
+    fi
+
+    copied=true
+    break
+done
+
+if [[ ! -d "$output" ]] || [[ "$copied" = 'false' ]]; then
+    echo "error: failed to find $FULL_PRODUCT_NAME in expected locations: ${input_options[*]}"
+    exit 1
+fi
+
+"$BAZEL_INSTALLERS_DIR"/lldb-settings.sh >"$BAZEL_DIAGNOSTICS_DIR"/lldb-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/lldb-stderr-"$DATE_SUFFIX".log
+
+# Part of the build intermediary output will be swiftmodule files
+# which XCode will use for indexing. Let's keep those.
+"$BAZEL_INSTALLERS_DIR"/swiftmodules.sh >"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/indexstores.sh >"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &

--- a/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/bazelinstallers/installer
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+# Install the runnable products so that Xcode can run it. This includes `.app`s,
+# `.xctest`s, and also command line binaries.
+
+set -eux
+
+# Delete all logfiles that are older than 7 days
+find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
+
+case "${PRODUCT_TYPE}" in
+com.apple.product-type.framework)
+    input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    ;;
+com.apple.product-type.framework.static)
+    # For static library, as the output is not under bazel-bin, we have to get it based on build event
+    # Example of such entry inside build event:
+    # important_output {
+    #   name: ".../SomeFramework.framework/SomeFramework"
+    #   uri: "file:///private/var/tmp/.../.../SomeFramework.framework/SomeFramework"
+    #   path_prefix:...
+    #   ...
+    #  }
+    # We only care about the entry ending with TARGET_NAME" so that we can get the path to its directory
+    QUERY=$(grep -A 2 important_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep ${TARGET_NAME}\" | sed "s/uri: \"file:\/\///")
+    if [[ -z $QUERY ]]; then
+        echo "Unable to locate resource for framework of ${TARGET_NAME}"
+        exit 1
+    fi
+    input_options=($(dirname "${QUERY}"))
+    ;;
+com.apple.product-type.bundle.unit-test)
+    input_options=(
+        "bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}"
+        "bazel-bin/$BAZEL_BIN_SUBDIR/$TARGET_NAME.__internal__.__test_bundle_archive-root/$TARGET_NAME${WRAPPER_SUFFIX:-}"
+        "bazel-bin/$BAZEL_BIN_SUBDIR/${BAZEL_BUILD_TARGET_LABEL#*:}.runfiles/${BAZEL_BUILD_TARGET_WORKSPACE}/${BAZEL_BIN_SUBDIR}/${FULL_PRODUCT_NAME}"
+        "bazel-bin/$BAZEL_BIN_SUBDIR/${BAZEL_BUILD_TARGET_LABEL#*:}.runfiles/${BAZEL_BUILD_TARGET_WORKSPACE}/${BAZEL_BIN_SUBDIR}/$TARGET_NAME.zip"
+    )
+    ;;
+com.apple.product-type.application)
+    input_options=(
+        "bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}"
+        "bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}_archive-root/Payload/$TARGET_NAME${WRAPPER_SUFFIX:-}"
+        "bazel-bin/$BAZEL_BIN_SUBDIR/${BAZEL_BUILD_TARGET_LABEL#*:}.runfiles/${BAZEL_BUILD_TARGET_WORKSPACE}/${BAZEL_BIN_SUBDIR}/${FULL_PRODUCT_NAME}"
+        "bazel-bin/$BAZEL_BIN_SUBDIR/${BAZEL_BUILD_TARGET_LABEL#*:}.runfiles/${BAZEL_BUILD_TARGET_WORKSPACE}/${BAZEL_BIN_SUBDIR}/$TARGET_NAME.zip"
+    )
+    ;;
+*)
+    echo "Error: Installing ${TARGET_NAME} of type ${PRODUCT_TYPE} is unsupported" >&2
+    exit 1
+    ;;
+esac
+output="$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME"
+
+mkdir -p $OBJECT_FILE_DIR_normal/$CURRENT_ARCH/
+chmod -R +w $OBJECT_FILE_DIR_normal/$CURRENT_ARCH/
+
+for swiftmodulefile in ${BAZEL_SWIFTMODULEFILES_TO_COPY:-}; do
+    if [[ -e $swiftmodulefile ]]; then
+        cp $swiftmodulefile $OBJECT_FILE_DIR_normal/$CURRENT_ARCH/
+    fi
+done
+
+mkdir -p "$(dirname "$output")"
+copied=false
+
+for input in "${input_options[@]}"; do
+    if [[ -z $input ]] || [ $input = "." ] || [ $input = "/" ]; then
+        # rsync can be a dangerous operation when it tries to copy entire root dir into the $output
+        echo "Error: illegal input \"${input}\" for installing ${TARGET_NAME} of type ${PRODUCT_TYPE}" >&2
+        exit 1
+    fi
+    if [[ -d $input ]]; then
+        # Copy bundle contents, into the destination bundle.
+        # This avoids self-nesting, like: Foo.app/Foo.app
+        input+="/"
+    elif [[ ! -f $input ]] || [[ $input != *.zip ]]; then
+        continue
+    fi
+
+    if [[ $input == *.zip ]]; then
+        rm -rf "$output"
+        unzip -qq -d "$TARGET_BUILD_DIR" "$input"
+    else
+        rsync \
+            --recursive --chmod=u+w --delete \
+            "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
+    fi
+
+    if [[ -n "${SWIFT_OBJC_INTERFACE_HEADER_NAME:-}" ]]; then
+        cp -f "$input/Headers/$SWIFT_OBJC_INTERFACE_HEADER_NAME" "$OBJECT_FILE_DIR_normal/$CURRENT_ARCH/"
+    fi
+
+    copied=true
+    break
+done
+
+if [[ ! -d "$output" ]] || [[ "$copied" = 'false' ]]; then
+    echo "error: failed to find $FULL_PRODUCT_NAME in expected locations: ${input_options[*]}"
+    exit 1
+fi
+
+"$BAZEL_INSTALLERS_DIR"/lldb-settings.sh >"$BAZEL_DIAGNOSTICS_DIR"/lldb-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/lldb-stderr-"$DATE_SUFFIX".log
+
+# Part of the build intermediary output will be swiftmodule files
+# which XCode will use for indexing. Let's keep those.
+"$BAZEL_INSTALLERS_DIR"/swiftmodules.sh >"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/indexstores.sh >"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &

--- a/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -euo pipefail
+
+
+# Bazel uses `-debug-prefix-map` to strip the bazel build directory from the
+# paths embedded in debug info. This means the debug info contains _project
+# relative_ paths instead of Bazel absolute paths.
+#
+# However, Xcode sets breakpoints via _project absolute_ paths, which are not
+# the paths in the debug info. This lldb setting ensures that _project relative_
+# paths are remapped to _project absolute_ paths.
+#
+# The platform settings one points the current working directory (cwd) to workspace root.
+# This is needed for features relying on lldb remote debugging, such as `oso_prefix_is_pwd`.
+#
+# NOTE: In order to use this, add this line to `~/.lldbinit`:
+#
+#     command source ~/.lldbinit-source-map
+cat <<-END > ~/.lldbinit-source-map
+platform settings -w "$BAZEL_WORKSPACE_ROOT/"
+
+settings set target.source-map ./ "$BAZEL_WORKSPACE_ROOT/"
+settings set target.sdk-path $SDKROOT
+settings set target.swift-framework-search-paths $FRAMEWORK_SEARCH_PATHS
+END
+
+if [[ -n ${BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS:-} ]]
+then
+  cat <<-END >> ~/.lldbinit-source-map
+settings set -- target.swift-extra-clang-flags $BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS
+END
+fi
+
+BAZEL_EXTERNAL_DIRNAME="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$BAZEL_WORKSPACE_ROOT")/external"
+if [ -d "$BAZEL_EXTERNAL_DIRNAME" ]
+then
+  cat <<-END >> ~/.lldbinit-source-map
+settings append target.source-map ./external/ "$BAZEL_EXTERNAL_DIRNAME"
+END
+fi

--- a/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Copy Bazel build `.swiftmodule` files to `DerivedData`. This is used by Xcode
+# and its indexing.
+echo "Start copying swiftmodules at `date`"
+FOUND_SWIFTMODULES=`grep -A 2 primary_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep "\.swiftmodule" | sed "s/uri: \"file:\/\///" || true`
+if [[ -z $FOUND_SWIFTMODULES ]]; then 
+    echo "No swiftmodules found, finished at `date`"
+    exit 0
+fi
+declare -a EXISTING_SWIFTMODULES=()
+for i in $FOUND_SWIFTMODULES
+do
+  if [[ -f $i ]]
+  then
+    EXISTING_SWIFTMODULES+=($i)
+  fi
+done
+echo "Found ${#EXISTING_SWIFTMODULES[@]} existing SWIFTMODULES"
+if [ ${#EXISTING_SWIFTMODULES[@]} -ne 0 ]
+then
+  "$BAZEL_INSTALLERS_DIR/_swiftmodule.sh" ${EXISTING_SWIFTMODULES[*]}
+else
+  echo "No SWIFTMODULES found"
+fi
+echo "Finish copying swiftmodules at `date`"

--- a/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/project.pbxproj
@@ -1,0 +1,480 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 51;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		1B22FA6E7093BC00D7219E9D /* FooFrameworkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 71B38A73C4C69056FD85E769 /* FooFrameworkTests.m */; };
+		C241AEA9A8BDAE45AC7B501B /* FooFrameworkTesting.m in Sources */ = {isa = PBXBuildFile; fileRef = F6A4BB1AAB4EB5654FD5FCAD /* FooFrameworkTesting.m */; };
+		DD74FE4D0C4614261667B493 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 03712AE2972A07852C89BF51 /* main.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		03712AE2972A07852C89BF51 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		06EDD6C022051EA69C920B28 /* ObjcFramework.framework */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.framework; path = ObjcFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2ED792D6DA8076A9ACDEAB1D /* FooFrameworkTesting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FooFrameworkTesting.h; sourceTree = "<group>"; };
+		34133FF9B9B30DC271CEA963 /* ObjcFrameworkTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = ObjcFrameworkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		5E4982689A60DBB9B5B4F148 /* HeaderA.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HeaderA.h; sourceTree = "<group>"; };
+		71B38A73C4C69056FD85E769 /* FooFrameworkTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FooFrameworkTests.m; sourceTree = "<group>"; };
+		A2766C3F21ACD3231A369AEA /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
+		A4056DD784521F8148DCDF78 /* ObjcFrameworkTestLib.framework */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.framework; path = ObjcFrameworkTestLib.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C101831ACAE826429FACB3CF /* common.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = common.pch; sourceTree = "<group>"; };
+		F6A4BB1AAB4EB5654FD5FCAD /* FooFrameworkTesting.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FooFrameworkTesting.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		12D32F0E7BBCCA933D126EEC /* tests */ = {
+			isa = PBXGroup;
+			children = (
+				71B38A73C4C69056FD85E769 /* FooFrameworkTests.m */,
+			);
+			path = tests;
+			sourceTree = "<group>";
+		};
+		17E6D06582F65712B938EDAC = {
+			isa = PBXGroup;
+			children = (
+				FCA51A57D0A72C7125405BB9 /* build_bazel_rules_ios */,
+				C21ADD3839D758B93CF249C8 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		5D01B4023F7C286276F280E0 /* testing */ = {
+			isa = PBXGroup;
+			children = (
+				2ED792D6DA8076A9ACDEAB1D /* FooFrameworkTesting.h */,
+				F6A4BB1AAB4EB5654FD5FCAD /* FooFrameworkTesting.m */,
+			);
+			path = testing;
+			sourceTree = "<group>";
+		};
+		6DC75D0321072FCD39CAA222 /* library */ = {
+			isa = PBXGroup;
+			children = (
+				C101831ACAE826429FACB3CF /* common.pch */,
+			);
+			path = library;
+			sourceTree = "<group>";
+		};
+		90D0BF96D0848DD2B4539B9B /* frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				B5546648DCD878C58EFFCF9E /* objc */,
+			);
+			path = frameworks;
+			sourceTree = "<group>";
+		};
+		958BCFC31009FE9D09DF35A3 /* ios */ = {
+			isa = PBXGroup;
+			children = (
+				90D0BF96D0848DD2B4539B9B /* frameworks */,
+			);
+			path = ios;
+			sourceTree = "<group>";
+		};
+		985F8D655978F724CA15B2BC /* rules */ = {
+			isa = PBXGroup;
+			children = (
+				6DC75D0321072FCD39CAA222 /* library */,
+			);
+			path = rules;
+			sourceTree = "<group>";
+		};
+		A09E80C8F953526DB0B41581 /* tests */ = {
+			isa = PBXGroup;
+			children = (
+				958BCFC31009FE9D09DF35A3 /* ios */,
+			);
+			path = tests;
+			sourceTree = "<group>";
+		};
+		B5546648DCD878C58EFFCF9E /* objc */ = {
+			isa = PBXGroup;
+			children = (
+				A2766C3F21ACD3231A369AEA /* BUILD.bazel */,
+				5E4982689A60DBB9B5B4F148 /* HeaderA.h */,
+				03712AE2972A07852C89BF51 /* main.m */,
+				5D01B4023F7C286276F280E0 /* testing */,
+				12D32F0E7BBCCA933D126EEC /* tests */,
+			);
+			path = objc;
+			sourceTree = "<group>";
+		};
+		C21ADD3839D758B93CF249C8 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				06EDD6C022051EA69C920B28 /* ObjcFramework.framework */,
+				A4056DD784521F8148DCDF78 /* ObjcFrameworkTestLib.framework */,
+				34133FF9B9B30DC271CEA963 /* ObjcFrameworkTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		FCA51A57D0A72C7125405BB9 /* build_bazel_rules_ios */ = {
+			isa = PBXGroup;
+			children = (
+				985F8D655978F724CA15B2BC /* rules */,
+				A09E80C8F953526DB0B41581 /* tests */,
+			);
+			name = build_bazel_rules_ios;
+			path = ../../..;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		36254ADB273AE97A60F75509 /* ObjcFrameworkTestLib */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5788F7782380D3838C83887A /* Build configuration list for PBXNativeTarget "ObjcFrameworkTestLib" */;
+			buildPhases = (
+				33E375BE73B9CD01B0D5F4EB /* Build with bazel */,
+				B3E01DFF8F12CF408B966843 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ObjcFrameworkTestLib;
+			productName = ObjcFrameworkTestLib;
+			productReference = A4056DD784521F8148DCDF78 /* ObjcFrameworkTestLib.framework */;
+			productType = "com.apple.product-type.framework.static";
+		};
+		3819563F655CC8C7D7C3C6AE /* ObjcFrameworkTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 012F347C2B10EDCAE740230C /* Build configuration list for PBXNativeTarget "ObjcFrameworkTests" */;
+			buildPhases = (
+				6522B6F4E0F35BA0870F2706 /* Build with bazel */,
+				8B44A9E97D6D38A238644965 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ObjcFrameworkTests;
+			productName = ObjcFrameworkTests;
+			productReference = 34133FF9B9B30DC271CEA963 /* ObjcFrameworkTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		9EBD5ED5F7C5C03CB4804DE3 /* ObjcFramework */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BCC9A55DDED404AD1056D098 /* Build configuration list for PBXNativeTarget "ObjcFramework" */;
+			buildPhases = (
+				664FCBDF2AE075BD785BDDAD /* Build with bazel */,
+				420D44581C2B4A6652F8C264 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ObjcFramework;
+			productName = ObjcFramework;
+			productReference = 06EDD6C022051EA69C920B28 /* ObjcFramework.framework */;
+			productType = "com.apple.product-type.framework.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		AF7405BC5F99810926E9B96A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1020;
+				TargetAttributes = {
+				};
+			};
+			buildConfigurationList = 2C7F68B16FB5ABF65D0BF718 /* Build configuration list for PBXProject "Xcodebuild-Single-Static-Framework-Project" */;
+			compatibilityVersion = "Xcode 10.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 17E6D06582F65712B938EDAC;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				9EBD5ED5F7C5C03CB4804DE3 /* ObjcFramework */,
+				36254ADB273AE97A60F75509 /* ObjcFrameworkTestLib */,
+				3819563F655CC8C7D7C3C6AE /* ObjcFrameworkTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		33E375BE73B9CD01B0D5F4EB /* Build with bazel */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Build with bazel";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\nenv -u RUBYOPT -u RUBY_HOME -u GEM_HOME $BAZEL_BUILD_EXEC $BAZEL_BUILD_TARGET_LABEL\n$BAZEL_INSTALLER\n";
+		};
+		6522B6F4E0F35BA0870F2706 /* Build with bazel */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Build with bazel";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\nenv -u RUBYOPT -u RUBY_HOME -u GEM_HOME $BAZEL_BUILD_EXEC $BAZEL_BUILD_TARGET_LABEL\n$BAZEL_INSTALLER\n";
+		};
+		664FCBDF2AE075BD785BDDAD /* Build with bazel */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Build with bazel";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\nenv -u RUBYOPT -u RUBY_HOME -u GEM_HOME $BAZEL_BUILD_EXEC $BAZEL_BUILD_TARGET_LABEL\n$BAZEL_INSTALLER\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		420D44581C2B4A6652F8C264 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DD74FE4D0C4614261667B493 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8B44A9E97D6D38A238644965 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1B22FA6E7093BC00D7219E9D /* FooFrameworkTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B3E01DFF8F12CF408B966843 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C241AEA9A8BDAE45AC7B501B /* FooFrameworkTesting.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		66031105B886CCF95271CCFB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
+				BAZEL_BUILD_TARGET_LABEL = "tests/ios/frameworks/objc:ObjcFramework";
+				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
+				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-7bf874b56ea0/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-7bf874b56ea0/bin/tests/ios/frameworks/objc/ObjcFramework_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-36e46a5aeba1/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-36e46a5aeba1/bin/tests/ios/frameworks/objc/ObjcFramework_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MACH_O_TYPE = "$(inherited)";
+				PRODUCT_NAME = ObjcFramework;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
+				VALID_ARCHS = "arm64 arm64e";
+			};
+			name = Release;
+		};
+		6DB659BCB94963374EBB3FB6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5;
+			};
+			name = Release;
+		};
+		7A33049F374A7CA38EF5B5B2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
+				BAZEL_BUILD_TARGET_LABEL = "tests/ios/frameworks/objc:ObjcFrameworkTestLib";
+				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
+				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-36e46a5aeba1/bin/tests/ios/frameworks/objc/ObjcFramework\"";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-ad27ed8b0869/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-ad27ed8b0869/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				MACH_O_TYPE = "$(inherited)";
+				PRODUCT_NAME = ObjcFrameworkTestLib;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
+				VALID_ARCHS = "arm64 arm64e";
+			};
+			name = Debug;
+		};
+		7B372BD4970D695DBB06AE33 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
+				BAZEL_BUILD_TARGET_LABEL = "tests/ios/frameworks/objc:ObjcFrameworkTests";
+				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
+				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-36e46a5aeba1/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-ad27ed8b0869/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-36e46a5aeba1/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-ad27ed8b0869/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\"";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MACH_O_TYPE = "$(inherited)";
+				PRODUCT_NAME = ObjcFrameworkTests;
+				SUPPORTS_MACCATALYST = 0;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
+				VALID_ARCHS = "arm64 arm64e";
+			};
+			name = Debug;
+		};
+		9F43131F1F2552DD64205507 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
+				BAZEL_BUILD_TARGET_LABEL = "tests/ios/frameworks/objc:ObjcFrameworkTestLib";
+				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
+				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-36e46a5aeba1/bin/tests/ios/frameworks/objc/ObjcFramework\"";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-ad27ed8b0869/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-ad27ed8b0869/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				MACH_O_TYPE = "$(inherited)";
+				PRODUCT_NAME = ObjcFrameworkTestLib;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
+				VALID_ARCHS = "arm64 arm64e";
+			};
+			name = Release;
+		};
+		B0D04E079E27AF7893D54AF1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 5;
+			};
+			name = Debug;
+		};
+		F5917DE04F056215EE0B9206 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
+				BAZEL_BUILD_TARGET_LABEL = "tests/ios/frameworks/objc:ObjcFramework";
+				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
+				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-7bf874b56ea0/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-7bf874b56ea0/bin/tests/ios/frameworks/objc/ObjcFramework_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-36e46a5aeba1/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-36e46a5aeba1/bin/tests/ios/frameworks/objc/ObjcFramework_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MACH_O_TYPE = "$(inherited)";
+				PRODUCT_NAME = ObjcFramework;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
+				VALID_ARCHS = "arm64 arm64e";
+			};
+			name = Debug;
+		};
+		FAB129E691E21AF69143C570 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
+				BAZEL_BUILD_TARGET_LABEL = "tests/ios/frameworks/objc:ObjcFrameworkTests";
+				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
+				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-36e46a5aeba1/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-ad27ed8b0869/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-36e46a5aeba1/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-ad27ed8b0869/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\"";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MACH_O_TYPE = "$(inherited)";
+				PRODUCT_NAME = ObjcFrameworkTests;
+				SUPPORTS_MACCATALYST = 0;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
+				VALID_ARCHS = "arm64 arm64e";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		012F347C2B10EDCAE740230C /* Build configuration list for PBXNativeTarget "ObjcFrameworkTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7B372BD4970D695DBB06AE33 /* Debug */,
+				FAB129E691E21AF69143C570 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		2C7F68B16FB5ABF65D0BF718 /* Build configuration list for PBXProject "Xcodebuild-Single-Static-Framework-Project" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B0D04E079E27AF7893D54AF1 /* Debug */,
+				6DB659BCB94963374EBB3FB6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		5788F7782380D3838C83887A /* Build configuration list for PBXNativeTarget "ObjcFrameworkTestLib" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7A33049F374A7CA38EF5B5B2 /* Debug */,
+				9F43131F1F2552DD64205507 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		BCC9A55DDED404AD1056D098 /* Build configuration list for PBXNativeTarget "ObjcFramework" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F5917DE04F056215EE0B9206 /* Debug */,
+				66031105B886CCF95271CCFB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = AF7405BC5F99810926E9B96A /* Project object */;
+}

--- a/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Xcodebuild-Single-Static-Framework-Project.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
+	<false/>
+</dict>
+</plist>

--- a/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/xcshareddata/xcschemes/ObjcFramework.xcscheme
+++ b/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/xcshareddata/xcschemes/ObjcFramework.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9EBD5ED5F7C5C03CB4804DE3"
+               BuildableName = "ObjcFramework.framework"
+               BlueprintName = "ObjcFramework"
+               ReferencedContainer = "container:Xcodebuild-Single-Static-Framework-Project.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9EBD5ED5F7C5C03CB4804DE3"
+            BuildableName = "ObjcFramework.framework"
+            BlueprintName = "ObjcFramework"
+            ReferencedContainer = "container:Xcodebuild-Single-Static-Framework-Project.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9EBD5ED5F7C5C03CB4804DE3"
+            BuildableName = "ObjcFramework.framework"
+            BlueprintName = "ObjcFramework"
+            ReferencedContainer = "container:Xcodebuild-Single-Static-Framework-Project.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9EBD5ED5F7C5C03CB4804DE3"
+            BuildableName = "ObjcFramework.framework"
+            BlueprintName = "ObjcFramework"
+            ReferencedContainer = "container:Xcodebuild-Single-Static-Framework-Project.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/xcshareddata/xcschemes/ObjcFrameworkTestLib.xcscheme
+++ b/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/xcshareddata/xcschemes/ObjcFrameworkTestLib.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "36254ADB273AE97A60F75509"
+               BuildableName = "ObjcFrameworkTestLib.framework"
+               BlueprintName = "ObjcFrameworkTestLib"
+               ReferencedContainer = "container:Xcodebuild-Single-Static-Framework-Project.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "36254ADB273AE97A60F75509"
+            BuildableName = "ObjcFrameworkTestLib.framework"
+            BlueprintName = "ObjcFrameworkTestLib"
+            ReferencedContainer = "container:Xcodebuild-Single-Static-Framework-Project.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "36254ADB273AE97A60F75509"
+            BuildableName = "ObjcFrameworkTestLib.framework"
+            BlueprintName = "ObjcFrameworkTestLib"
+            ReferencedContainer = "container:Xcodebuild-Single-Static-Framework-Project.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "36254ADB273AE97A60F75509"
+            BuildableName = "ObjcFrameworkTestLib.framework"
+            BlueprintName = "ObjcFrameworkTestLib"
+            ReferencedContainer = "container:Xcodebuild-Single-Static-Framework-Project.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/xcshareddata/xcschemes/ObjcFrameworkTests.xcscheme
+++ b/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/xcshareddata/xcschemes/ObjcFrameworkTests.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3819563F655CC8C7D7C3C6AE"
+               BuildableName = "ObjcFrameworkTests.xctest"
+               BlueprintName = "ObjcFrameworkTests"
+               ReferencedContainer = "container:Xcodebuild-Single-Static-Framework-Project.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3819563F655CC8C7D7C3C6AE"
+               BuildableName = "ObjcFrameworkTests.xctest"
+               BlueprintName = "ObjcFrameworkTests"
+               ReferencedContainer = "container:Xcodebuild-Single-Static-Framework-Project.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3819563F655CC8C7D7C3C6AE"
+            BuildableName = "ObjcFrameworkTests.xctest"
+            BlueprintName = "ObjcFrameworkTests"
+            ReferencedContainer = "container:Xcodebuild-Single-Static-Framework-Project.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3819563F655CC8C7D7C3C6AE"
+            BuildableName = "ObjcFrameworkTests.xctest"
+            BlueprintName = "ObjcFrameworkTests"
+            ReferencedContainer = "container:Xcodebuild-Single-Static-Framework-Project.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3819563F655CC8C7D7C3C6AE"
+            BuildableName = "ObjcFrameworkTests.xctest"
+            BlueprintName = "ObjcFrameworkTests"
+            ReferencedContainer = "container:Xcodebuild-Single-Static-Framework-Project.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
This PR is the start of modifying the xcodeproj rule to support generating projects that build with Xcode instead of Bazel.

The resulting Xcode project doesn't successfully build yet; I still need to remove the build script phase that invokes Bazel.

- Adds `build_with_xcodebuild` boolean attr to xcodeproj rule
- Removes the stub build settings from the generated xcode project when `build_with_xcodebuild` is enabled
- Generates a reference project