### PR TITLE
Add an entry point to xcodeproj rule for overriding project attributes

### DIFF
--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -683,8 +683,11 @@ def _xcodeproj_impl(ctx):
         if _is_current_project_file(f)
     ]
 
+    attributes = {}
+    attributes.update(ctx.attr.project_attributes_overrides)
     xcodeproj_info = struct(
         name = paths.split_extension(project_name)[0],
+        attributes = attributes,
         options = proj_options,
         settings = proj_settings,
         targets = xcodeproj_targets_by_name,
@@ -777,6 +780,7 @@ Tags for configuration:
         "project_name": attr.string(mandatory = False),
         "bazel_path": attr.string(mandatory = False, default = "bazel"),
         "scheme_existing_envvar_overrides": attr.string_dict(allow_empty = True, default = {}, mandatory = False),
+        "project_attributes_overrides": attr.string_dict(allow_empty = True, mandatory = False, default = {}, doc = "Overrides for attributes that can be set at project base level"),
         "generate_schemes_for_product_types": attr.string_list(mandatory = False, allow_empty = True, default = [], doc = """\
 Generate schemes only for the specified product types if this list is not empty.
 Product types must be valid apple product types, e.g. application, bundle.unit-test, framework.

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -778,7 +778,7 @@ Tags for configuration:
         "project_name": attr.string(mandatory = False),
         "bazel_path": attr.string(mandatory = False, default = "bazel"),
         "scheme_existing_envvar_overrides": attr.string_dict(allow_empty = True, default = {}, mandatory = False),
-        "project_attributes_overrides": attr.string_dict(allow_empty = True, mandatory = False, default = {}, doc = "Overrides for attributes that can be set at project base level"),
+        "project_attributes_overrides": attr.string_dict(allow_empty = True, mandatory = False, default = {}, doc = "Overrides for attributes that can be set at the project base level."),
         "generate_schemes_for_product_types": attr.string_list(mandatory = False, allow_empty = True, default = [], doc = """\
 Generate schemes only for the specified product types if this list is not empty.
 Product types must be valid apple product types, e.g. application, bundle.unit-test, framework.

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -683,11 +683,9 @@ def _xcodeproj_impl(ctx):
         if _is_current_project_file(f)
     ]
 
-    attributes = {}
-    attributes.update(ctx.attr.project_attributes_overrides)
     xcodeproj_info = struct(
         name = paths.split_extension(project_name)[0],
-        attributes = attributes,
+        attributes = ctx.attr.project_attributes_overrides,
         options = proj_options,
         settings = proj_settings,
         targets = xcodeproj_targets_by_name,

--- a/tests/ios/xcodeproj/BUILD.bazel
+++ b/tests/ios/xcodeproj/BUILD.bazel
@@ -9,6 +9,7 @@ xcodeproj(
         "bundle.unit-test",
     ],
     include_transitive_targets = True,
+    project_attributes_overrides = {"ORGANIZATIONNAME": "rules_ios"},
     deps = [
         "//tests/ios/frameworks/objc:ObjcFramework",
         "//tests/ios/frameworks/objc:ObjcFrameworkTests",

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1020;
+				ORGANIZATIONNAME = rules_ios;
 				TargetAttributes = {
 				};
 			};


### PR DESCRIPTION
### Why this change
Need to provide a way to insert custom attributes for downstream projects
Was thinking about using a `project_overrides` where one can pass `{'attributes': {key: value}, 'options': {key: value}, 'settings' {key: value}}` to cover other fields that we have default values for. But according to Bazel doc https://docs.bazel.build/versions/master/skylark/lib/attr.html#string_dict values for `string_dict` can only be string, so have to break them up into individual fields like the change proposed here.

Please let me know if there is a better way so that we can allow customization done easily for downstream projects.

### Tests
After adding one to a sample project, it indeed gets reflected in the corresponding generated project