### PR TITLE
Small bugfix to patched apple_static_framework_import

### DIFF
--- a/rules/apple_patched.bzl
+++ b/rules/apple_patched.bzl
@@ -38,7 +38,7 @@ def apple_static_framework_import(name, **kwargs):
     """
 
     visibility = kwargs.pop("visibility", None)
-    tags = kwargs.get("tags", [])
+    tags = kwargs.pop("tags", [])
 
     legacy_target_label = "_" + name
     apple_static_framework_import_original(


### PR DESCRIPTION
Small bugfix to patched apple_static_framework_import: use pop instead of get when extracting the tags attribute from the kwargs