### PR TITLE
[proposal] Add the static_framework_generator rule

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,7 +15,15 @@ build --test_output=errors # Prints log file output to the console on failure
 
 # By default do not build the tests for sources-with-prebuilt-binaries,
 # because it takes quite some time. They will only run on CI
-build --deleted_packages tests/ios/frameworks/sources-with-prebuilt-binaries
+#
+# By default do not run the tests under the static_framework_generator package, 
+# as it requires that tools/static_framework_generator:TargetXIBStaticFrameworkGenerator
+# is run first in order to generate the TargetXIB.framework to be consummed.
+# It will run only on CI
+build --deleted_packages \
+tests/ios/frameworks/sources-with-prebuilt-binaries,\
+tests/ios/static_framework_generator,\
+tools/static_framework_generator
 
 # Enable dbg compilation mode in this repo, so we can test xcodeproj-built
 # binaries contain debug symbol tables.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,10 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_11.6.app
       - name: Build and Test
         run: |
+          # Run the static_framework_generator, so the generated frameworks required for testing the 
+          # static_framework_generator package are available
+          bazelisk run --apple_platform_type=ios --deleted_packages='' tools/static_framework_generator:TargetXIBStaticFrameworkGenerator
+
           bazelisk test --local_test_jobs=1 -- //... -//tests/ios/...
           # `deleted_packages` is needed below in order to override the value of the .bazelrc file
           bazelisk test --local_test_jobs=1 --apple_platform_type=ios --deleted_packages='' -- //tests/ios/...

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -13,6 +13,7 @@ _RULES = [
     "substitute_build_settings",
     "test",
     "transition_support",
+    "static_framework_generator",
 ]
 
 _REPOSITORY_RULES = [

--- a/docs/static_framework_generator_doc.md
+++ b/docs/static_framework_generator_doc.md
@@ -1,0 +1,54 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+<a id="#static_framework_generator_test"></a>
+
+## static_framework_generator_test
+
+<pre>
+static_framework_generator_test(<a href="#static_framework_generator_test-name">name</a>, <a href="#static_framework_generator_test-destination_relative_to_package">destination_relative_to_package</a>,
+                                <a href="#static_framework_generator_test-destination_relative_to_workspace">destination_relative_to_workspace</a>, <a href="#static_framework_generator_test-targets">targets</a>)
+</pre>
+
+This generator moves the frameworks artifacts produced by Bazel to a location out of the cache.
+It is intended to be used as a tool to ease compatibility with other build systems.
+
+For example, it would be possible to integrate with cocoapods as follows:
+1- Build targets with Bazel
+2- Use this rule to generate frameworks for them
+3- Generate podspec files containing the generated frameworks as vendored_frameworks, so they can be 
+   integrated in a cocoapods setup, substituting their source code counterparts (useful to cut build time)
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="static_framework_generator_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="static_framework_generator_test-destination_relative_to_package"></a>destination_relative_to_package |  Destination folder for the generated frameworks, relative to the package   | String | optional | "" |
+| <a id="static_framework_generator_test-destination_relative_to_workspace"></a>destination_relative_to_workspace |  Destination folder for the generated frameworks, relative to the workspace   | String | optional | "static_framework_generator" |
+| <a id="static_framework_generator_test-targets"></a>targets |  The list of targets to use for generating the frameworks   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
+
+
+<a id="#static_framework_generator"></a>
+
+## static_framework_generator
+
+<pre>
+static_framework_generator(<a href="#static_framework_generator-kwargs">kwargs</a>)
+</pre>
+
+    A wrapper around static_framework_generator_test which disables the sandbox
+
+This rule writes its output to the WORKSPACE, which is a location out of the sandbox:
+in order for bazel to allow that, sandbox must be disabled
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="static_framework_generator-kwargs"></a>kwargs |  same as the parameters for static_framework_generator_test   |  none |
+
+

--- a/rules/apple_patched.bzl
+++ b/rules/apple_patched.bzl
@@ -5,7 +5,7 @@ load(
     apple_dynamic_framework_import_original = "apple_dynamic_framework_import",
     apple_static_framework_import_original = "apple_static_framework_import",
 )
-load("@build_bazel_rules_apple//apple:providers.bzl", "AppleFrameworkImportInfo")
+load("@build_bazel_rules_apple//apple:providers.bzl", "AppleFrameworkImportInfo", "AppleResourceInfo")
 load("@build_bazel_rules_swift//swift/internal:providers.bzl", "SwiftUsageInfo")
 
 def apple_dynamic_framework_import(name, **kwargs):
@@ -84,7 +84,7 @@ def _apple_framework_import_modulemap_impl(ctx):
     # is to list here the keys to all of them (you can see the keys for the existing providers of a
     # target by just printing the target)
     # For more information refer to https://groups.google.com/forum/#!topic/bazel-discuss/4KkflTjmUyk
-    other_provider_keys = [AppleFrameworkImportInfo, SwiftUsageInfo, apple_common.AppleDynamicFramework, OutputGroupInfo, DefaultInfo]
+    other_provider_keys = [AppleFrameworkImportInfo, SwiftUsageInfo, apple_common.AppleDynamicFramework, OutputGroupInfo, DefaultInfo, AppleResourceInfo]
     return [new_objc_provider, new_cc_info] + \
            [legacy_target[provider_key] for provider_key in other_provider_keys if provider_key in legacy_target]
 

--- a/rules/static_framework_generator.bzl
+++ b/rules/static_framework_generator.bzl
@@ -1,0 +1,214 @@
+"""This file contains rules to build framework binaries from your podfile or cartfile"""
+
+load("@build_bazel_rules_apple//apple:providers.bzl", "AppleResourceInfo")
+
+def static_framework_generator(**kwargs):
+    """
+    A wrapper around static_framework_generator_test which disables the sandbox
+
+    This rule writes its output to the WORKSPACE, which is a location out of the sandbox:
+    in order for bazel to allow that, sandbox must be disabled
+
+    Args:
+        **kwargs: same as the parameters for static_framework_generator_test
+    """
+
+    static_framework_generator_test(
+        tags = ["no-sandbox"],
+        **kwargs
+    )
+
+################
+# Aspect
+################
+
+def _get_resource_targets(deps):
+    return depset(transitive = _get_attr_values_for_name(deps, _TargetInfo, "owned_resource_targets"))
+
+_TargetInfo = provider()
+
+def _get_attr_values_for_name(deps, provider, field):
+    return [
+        getattr(dep[provider], field)
+        for dep in deps
+        if dep and provider in dep
+    ]
+
+def _collect_resources_aspect_impl(target, ctx):
+    resource_targets = []
+    if ctx.rule.kind == "alias":
+        actual = getattr(ctx.rule.attr, "actual")
+        if actual and _TargetInfo in actual:
+            resource_targets += actual[_TargetInfo].resource_targets
+    elif _is_resources_target(ctx):
+        resource_targets.append(target)
+
+    provider = _make_provider(ctx, resource_targets)
+    return [provider]
+
+def _is_top_level_target(ctx):
+    return ctx.rule.kind == "apple_framework_packaging"
+
+def _is_resources_target(ctx):
+    return ctx.rule.kind == "_precompiled_apple_resource_bundle"
+
+def _make_provider(ctx, resource_targets):
+    deps = getattr(ctx.rule.attr, "deps", [])
+    transitive_resource_targets = depset(
+        resource_targets,
+        transitive = _get_attr_values_for_name(deps, _TargetInfo, "transitive_resource_targets"),
+    )
+
+    return _TargetInfo(
+        transitive_resource_targets = depset([]) if _is_top_level_target(ctx) else transitive_resource_targets,
+        owned_resource_targets = transitive_resource_targets if _is_top_level_target(ctx) else depset([]),
+    )
+
+_collect_resources_aspect = aspect(
+    implementation = _collect_resources_aspect_impl,
+    attr_aspects = ["deps", "actual"],
+)
+
+################
+# Rule
+################
+
+def _declare_directory(ctx, framework_name, filename):
+    return ctx.actions.declare_directory("%s/%s/%s" % (ctx.label.name, framework_name, filename))
+
+def _declare_resource_bundles(ctx, target):
+    resource_bundles = []
+    for resource_target in _get_resource_targets([target]).to_list():
+        if AppleResourceInfo in resource_target:
+            for resource_group in resource_target[AppleResourceInfo].unprocessed:
+                resource_files = resource_group[2].to_list()
+                if len(resource_files) == 0:
+                    continue
+
+                bundle = _declare_directory(ctx, _get_existing_framework_name(target), "resources/%s" % resource_group[0])
+                paths_to_copy = " ".join([file.path for file in resource_files])
+                ctx.actions.run_shell(
+                    outputs = [bundle],
+                    inputs = resource_files,
+                    command = "ditto $1 $2",
+                    arguments = [paths_to_copy, bundle.path],
+                )
+                resource_bundles.append(bundle)
+    return resource_bundles
+
+def _get_existing_framework_path(target):
+    existing_framework_files = target.files.to_list()
+    if existing_framework_files:
+        framework_path = existing_framework_files[0].dirname
+        if framework_path.endswith(".framework"):
+            return framework_path
+
+    fail("The target %s does not produce any framework" % target.label.name)
+
+def _get_existing_framework_name(target):
+    existing_framework_files = target.files.to_list()
+    if existing_framework_files:
+        subpaths = existing_framework_files[0].dirname.split("/")
+        if subpaths:
+            framework_name = subpaths[-1]
+            if framework_name.endswith(".framework"):
+                return framework_name.replace(".framework", "")
+
+    fail("The target %s does not produce any framework" % target.label.name)
+
+def _declare_framework(ctx, target):
+    framework_name = _get_existing_framework_name(target)
+    return _declare_directory(ctx, framework_name, framework_name + ".framework")
+
+def _make_frameworks(ctx):
+    frameworks = []
+    for target in ctx.attr.targets:
+        framework = _declare_framework(ctx, target)
+        resource_bundles = _declare_resource_bundles(ctx, target)
+
+        existing_framework_files = target.files.to_list()
+        existing_framework_path = _get_existing_framework_path(target)
+
+        resource_paths = " ".join([bundle.path for bundle in resource_bundles])
+        ctx.actions.run_shell(
+            outputs = [framework],
+            inputs = existing_framework_files + resource_bundles,
+            command = 'rsync -a "$1/" "$3"; for resource in $2; do rsync -a "$resource" "$3/Resources"; done',
+            arguments = [existing_framework_path, resource_paths, framework.path],
+        )
+        frameworks.append(framework)
+    return frameworks
+
+def _make_destination(ctx):
+    if ctx.attr.destination_relative_to_package:
+        return ctx.label.package + "/" + ctx.attr.destination_relative_to_package
+    else:
+        return ctx.attr.destination_relative_to_workspace
+
+def _make_installer(ctx, subpath, files, destination):
+    installer = ctx.actions.declare_file(subpath + "/installer.sh")
+    ctx.actions.expand_template(
+        template = ctx.file._installer_template,
+        output = installer,
+        substitutions = {
+            "$(files)": " ".join(files),
+            "$(destination)": destination,
+        },
+        is_executable = True,
+    )
+    return installer
+
+def _static_framework_generator_impl(ctx):
+    frameworks = _make_frameworks(ctx)
+    destination = _make_destination(ctx)
+    installer = _make_installer(ctx, ctx.label.name, [framework.path for framework in frameworks], destination)
+    return [
+        DefaultInfo(
+            executable = installer,
+            runfiles = ctx.runfiles(files = frameworks),
+        ),
+    ]
+
+# Making below rule public in order to properly generate its documentation until the
+# https://github.com/bazelbuild/stardoc/issues/27 issue is resolved
+static_framework_generator_test = rule(
+    implementation = _static_framework_generator_impl,
+    doc = """\
+This generator moves the frameworks artifacts produced by Bazel to a location out of the cache.
+It is intended to be used as a tool to ease compatibility with other build systems.
+
+For example, it would be possible to integrate with cocoapods as follows:
+1- Build targets with Bazel
+2- Use this rule to generate frameworks for them
+3- Generate podspec files containing the generated frameworks as vendored_frameworks, so they can be 
+   integrated in a cocoapods setup, substituting their source code counterparts (useful to cut build time)
+""",
+    attrs = {
+        "targets": attr.label_list(
+            mandatory = True,
+            aspects = [_collect_resources_aspect],
+            doc = "The list of targets to use for generating the frameworks",
+        ),
+        "destination_relative_to_workspace": attr.string(
+            mandatory = False,
+            default = "static_framework_generator",
+            doc = "Destination folder for the generated frameworks, relative to the workspace",
+        ),
+        "destination_relative_to_package": attr.string(
+            mandatory = False,
+            doc = "Destination folder for the generated frameworks, relative to the package",
+        ),
+        "_installer_template": attr.label(
+            default = Label("//tools/static_framework_generator:installer.sh"),
+            allow_single_file = ["sh"],
+        ),
+    },
+    # Ideally this rule would not be a test: it would be an executable to be run with `bazel run`.
+    # The problem with `bazel run` is that you can only execute one target per `bazel run` invocation.
+    # See: https://github.com/bazelbuild/bazel/issues/10855
+    #
+    # A workaround is to mark this rule as a test, because `bazel test` allows to execute multiple
+    # test targets in paralel. Running `bazel test` once with multiple targets is much faster than
+    # running `bazel run` with one target multiple times
+    test = True,
+)

--- a/tests/ios/static_framework_generator/BUILD.bazel
+++ b/tests/ios/static_framework_generator/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
+load("@build_bazel_rules_ios//rules:apple_patched.bzl", "apple_static_framework_import")
+load("@build_bazel_rules_ios//rules:test.bzl", "ios_unit_test")
+
+apple_framework(
+    name = "TargetXIB",
+    srcs = glob(["TargetXIB/**/*.swift"]),
+    platforms = {"ios": "11.0"},
+    resource_bundles = {
+        "TargetXIB": glob(["TargetXIB/**/*.xib"]),
+    },
+    visibility = ["//visibility:public"],
+)
+
+# In order to run below tests, you have to first generate the framework by running
+# the TargetXIBStaticFrameworkGenerator target:
+# > bazelisk run --apple_platform_type=ios --deleted_packages='' tools/static_framework_generator:TargetXIBStaticFrameworkGenerator
+
+apple_static_framework_import(
+    name = "TargetXIBStaticFramework",
+    framework_imports = glob(["bazel-generated/TargetXIB.framework/**"]),
+    visibility = ["//visibility:public"],
+)
+
+apple_framework(
+    name = "TargetXIBTestsLib",
+    srcs = glob(["TargetXIBTests/**/*.swift"]),
+    platforms = {"ios": "11.0"},
+    visibility = ["//visibility:public"],
+    deps = ["TargetXIBStaticFramework"],
+)
+
+ios_unit_test(
+    name = "TargetXIBTests",
+    minimum_os_version = "11.0",
+    deps = [":TargetXIBTestsLib"],
+)

--- a/tests/ios/static_framework_generator/TargetXIB/CustomView.swift
+++ b/tests/ios/static_framework_generator/TargetXIB/CustomView.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+final class CustomView: UIView {
+
+    @IBOutlet private var label: UILabel!
+
+    static func fromNib() -> CustomView? {
+        let bundle = Bundle(for: CustomView.self)
+            .url(forResource: "TargetXIB", withExtension: "bundle").flatMap(Bundle.init(url:))
+        return bundle?.loadNibNamed("CustomView", owner: nil, options: nil)?.first as? CustomView
+    }
+}

--- a/tests/ios/static_framework_generator/TargetXIB/CustomView.xib
+++ b/tests/ios/static_framework_generator/TargetXIB/CustomView.xib
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="CustomView" customModule="TestXIB" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="200"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qFq-SM-pDh">
+                    <rect key="frame" x="16" y="60" width="382" height="124"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="qFq-SM-pDh" secondAttribute="bottom" constant="16" id="E3h-Wy-NIO"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="qFq-SM-pDh" secondAttribute="trailing" constant="16" id="UG6-pg-VJt"/>
+                <constraint firstItem="qFq-SM-pDh" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="16" id="bZ3-ip-0zW"/>
+                <constraint firstItem="qFq-SM-pDh" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="16" id="vye-Da-pMq"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <connections>
+                <outlet property="label" destination="qFq-SM-pDh" id="VcW-yF-0ka"/>
+            </connections>
+            <point key="canvasLocation" x="139" y="153"/>
+        </view>
+    </objects>
+</document>

--- a/tests/ios/static_framework_generator/TargetXIBTests/CustomViewTests.swift
+++ b/tests/ios/static_framework_generator/TargetXIBTests/CustomViewTests.swift
@@ -1,0 +1,11 @@
+import UIKit
+import XCTest
+@testable import TargetXIB
+
+final class CustomViewTests: XCTestCase {
+
+    func testCustomView() {
+        let view = CustomView.fromNib()
+        assert(view != nil, "CustomView is not instantiated.")
+    }
+}

--- a/tools/static_framework_generator/BUILD.bazel
+++ b/tools/static_framework_generator/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@build_bazel_rules_ios//rules:static_framework_generator.bzl", "static_framework_generator")
+
+exports_files([
+    "installer.sh",
+])
+
+static_framework_generator(
+    name = "TargetXIBStaticFrameworkGenerator",
+    destination_relative_to_workspace = "tests/ios/static_framework_generator/bazel-generated",
+    targets = ["//tests/ios/static_framework_generator:TargetXIB"],
+)

--- a/tools/static_framework_generator/installer.sh
+++ b/tools/static_framework_generator/installer.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# A script to copy a file from the bazel cache to the bazel workspace
+# In order for this to work, sandboxing has to be disabled
+#
+# The BUILD_WORKSPACE_DIRECTORY env variable is automatically injected by bazel when 
+# doing `bazel run`. See: https://docs.bazel.build/versions/master/user-manual.html#run
+#
+# But if this rule is executed doing `bazel test`, the BUILD_WORKSPACE_DIRECTORY
+# is not automatically injected by bazel, and instead it should be passed from 
+# command line when running bazel. For example:
+# ```
+# bazel test --test_env=BUILD_WORKSPACE_DIRECTORY="$(PWD)" <YOUR_TARGET_HERE>
+# ```
+#
+
+set -euo pipefail
+
+if [ -z ${BUILD_WORKSPACE_DIRECTORY+x} ]; then
+    echo 'The BUILD_WORKSPACE_DIRECTORY environmental variable is not set.
+If you are running this rule as a test type, you need to inject the BUILD_WORKSPACE_DIRECTORY
+environmental variable manually. For example:
+> bazel test --test_env=BUILD_WORKSPACE_DIRECTORY="$(PWD)" <YOUR_TARGET_HERE>
+'
+    exit 1
+fi
+
+destination_path="${BUILD_WORKSPACE_DIRECTORY}/$(destination)"
+
+mkdir -p "${destination_path}"
+for file in $(files); do
+    full_file_path="${BUILD_WORKSPACE_DIRECTORY}/${file}"
+    cp -crf "${full_file_path}" "${destination_path}"
+done
+
+# Since we are extracting files from the Bazel cache, they may be read-only.
+# Change that by adding write permissions
+chmod -R +w "${destination_path}"


### PR DESCRIPTION
Hey 👋 

I have a proposal PR here. I understand this may be something not wanted inside this repository: if that is the case, let me know.

**What is included in this PR?**

The `static_framework_generator`. With the introduction of the `apple_framework_packaging` and the `_precompiled_apple_resource_bundle` rules, it is now pretty easy to gather their outputs in order to generate a fully working static framework. This rule does that, and places a copy of the result out of the Bazel cache, so the generated frameworks can be consumed.

My main idea for how to use this rule is (using cocoapods as an example):
1. Build targets with Bazel
2. Use this rule to generate frameworks for them
3. Generate podspec files containing the generated frameworks as vendored_frameworks, so they can be integrated in a cocoapods setup, substituting their source code counterparts (useful to cut build time and indexing time)

There are two major usecases for the above:
1. If you are migrating to Bazel, you need integration with existing build tools: either cocoapods, carthage or swift package manager. All of them accept/support prebuilt frameworks, so you can build with Bazel part of your codebase, and then integrate the resulting frameworks in your existing setup
2. Providing Xcode support. For example: you could have a 100% Bazel setup, and still use cocoapods for project generation (as Bazel Xcode integration is still not 100% afaik). I imagine that the following workflow is interesting:
* Generate prebuilt static frameworks from the bazel cache with this rule
* Generate podspec wrappers for those frameworks
* Use cocoapods to generate the Xcode projects, only keeping in source code the dependencies under development, and using prebuilt static frameworks for the rest.

    If a change on a dependency integrated as a prebuilt framework happens, just re-run this rule so bazel re-builds what is needed and updates the prebuilt frameworks: it should be pretty fast.