### PR TITLE
Bump rules_apple and fix deprecated `direct_swiftmodules`

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -164,7 +164,7 @@ def _apple_framework_packaging_impl(ctx):
                 # only thing is the generated module map -- we don't want it
                 continue
 
-            if SwiftInfo in dep and dep[SwiftInfo].direct_swiftmodules:
+            if SwiftInfo in dep and dep[SwiftInfo].direct_modules:
                 # apple_common.Objc.direct_module_maps is broken coming from swift_library
                 # (it contains one level of transitive module maps), so ignore SwiftInfo from swift_library,
                 # since it doesn't have a module_map field anyway

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -47,10 +47,10 @@ def rules_ios_dependencies():
     _maybe(
         github_repo,
         name = "build_bazel_rules_apple",
-        ref = "37a2e525fa048cb9b7bf2ce776804f622c5a4262",
+        ref = "572aee29236aa6aa850484d5706b79aa2a098219",
         project = "bazelbuild",
         repo = "rules_apple",
-        sha256 = "a7245fc42c288655be3941f31752246966d10024e6abf2ef9ef055feac77ddf0",
+        sha256 = "1fff3fa1e565111a8f678b4698792101844f57b2e78c5e374431d0ebe97f6b6c",
     )
 
     _maybe(

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -211,7 +211,7 @@ def _xcodeproj_aspect_impl(target, ctx):
         if SwiftInfo in target:
             swift_defines.append(depset(target[SwiftInfo].direct_defines))
             swift_defines.append(target[SwiftInfo].transitive_defines)
-            swift_module_paths = [m.path for m in target[SwiftInfo].direct_swiftmodules]
+            swift_module_paths = [m.swift.swiftmodule.path for m in target[SwiftInfo].direct_modules]
         providers.append(
             _SrcsInfo(
                 srcs = depset(srcs, transitive = _get_attr_values_for_name(deps, _SrcsInfo, "srcs")),


### PR DESCRIPTION
I'm testing the `xcodeproj` rule in our project and since we're on a newer version of `rules_apple` that removed the already deprecated `direct_swiftmodules`, the `xcodeproj` rule would fail. I fixed this and tested it in a Swift project of ours, and it worked.

I understand that `rules_apple` is creating releases every now and then, so I'm not sure if you'd like to follow that release cadence, or you would be fine with following a commit more at HEAD.

I'm happy to hear your thoughts here.

