### PR TITLE
Add bridging header to TestImportsApp unit tests

### DIFF
--- a/tests/ios/unit-test/test-imports-app/BUILD.bazel
+++ b/tests/ios/unit-test/test-imports-app/BUILD.bazel
@@ -20,7 +20,7 @@ ios_application(
         "main.m",
     ],
     bundle_id = "com.example.TestImports-App",
-    families = ["ipad"],
+    families = ["iphone"],
     minimum_os_version = "12.0",
     module_name = "TestImports_App",
     resource_bundles = {"ResourceBundle": glob(
@@ -61,10 +61,13 @@ ios_unit_test(
     srcs = [
         "test.m",
         "test.swift",
+        "testhelper.h",
+        "testhelper.m",
     ],
     minimum_os_version = "12.0",
     module_name = "TestImports_Unit_Tests",
     sdk_frameworks = ["XCTest"],
+    swift_objc_bridging_header = "TestImports-Unit-Tests-Bridging-Header.h",
     test_host = ":TestImports-App",
     # Adding visibility so the xcodeproject tests can depend on this target
     visibility = ["//visibility:public"],

--- a/tests/ios/unit-test/test-imports-app/BUILD.bazel
+++ b/tests/ios/unit-test/test-imports-app/BUILD.bazel
@@ -20,7 +20,7 @@ ios_application(
         "main.m",
     ],
     bundle_id = "com.example.TestImports-App",
-    families = ["iphone"],
+    families = ["ipad"],
     minimum_os_version = "12.0",
     module_name = "TestImports_App",
     resource_bundles = {"ResourceBundle": glob(

--- a/tests/ios/unit-test/test-imports-app/Header2.h
+++ b/tests/ios/unit-test/test-imports-app/Header2.h
@@ -3,7 +3,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_CLOSED_ENUM(NSInteger, AppErrorCode) {
-    Unknown = 0
+    AppErrorCodeUnknown = 1
 };
 
 NS_ASSUME_NONNULL_END

--- a/tests/ios/unit-test/test-imports-app/TestImports-App-Bridging-Header.h
+++ b/tests/ios/unit-test/test-imports-app/TestImports-App-Bridging-Header.h
@@ -1,1 +1,1 @@
-#import "Header2.h"
+#import <TestImports-App/Header2.h>

--- a/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests-Bridging-Header.h
+++ b/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests-Bridging-Header.h
@@ -1,0 +1,2 @@
+#import <TestImports-Unit-Tests/testhelper.h>
+#import <TestImports-App/Header2.h>

--- a/tests/ios/unit-test/test-imports-app/test.swift
+++ b/tests/ios/unit-test/test-imports-app/test.swift
@@ -5,5 +5,6 @@ class SwiftTests : XCTestCase {
   func testPasses() {
       _ = EmptyStruct()
       XCTAssertTrue(true)
+      XCTAssertEqual(TestHelper.createString(), "ObjcTestHelperString_EnumValue=1")
   }
 }

--- a/tests/ios/unit-test/test-imports-app/testhelper.h
+++ b/tests/ios/unit-test/test-imports-app/testhelper.h
@@ -1,0 +1,13 @@
+
+@import Foundation;
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_SWIFT_NAME(TestHelper)
+@interface ObjCTestHelper : NSObject
+
++ (NSString *)createString;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/tests/ios/unit-test/test-imports-app/testhelper.m
+++ b/tests/ios/unit-test/test-imports-app/testhelper.m
@@ -1,0 +1,10 @@
+#import "testhelper.h"
+#import <TestImports-App/Header2.h>
+
+@implementation ObjCTestHelper
+
++ (NSString *)createString {
+    return [NSString stringWithFormat:@"ObjcTestHelperString_EnumValue=%ld", AppErrorCodeUnknown];
+}
+
+@end

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		318F5B16837DD5CFA4D00889 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = B776E1DCA016E54FFA3DD126 /* main.m */; };
 		C7087EC243FF0E3AB1AB011E /* test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9CDCA4AFFA244654BAAF8B /* test.swift */; };
 		E99867EE1F1D782F81A4FE00 /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED99215913B1CD2AA84B255 /* empty.swift */; };
+		EFADD50C4F0A43EB535E96A2 /* testhelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 40DADB6CCA7C34899493F0DF /* testhelper.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -30,9 +31,12 @@
 		2782A0E3F33311285AE36FC8 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		2EF81609D3AA2C86BD531FC9 /* test.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = test.m; sourceTree = "<group>"; };
 		3D8C6FABE401A5C37EEACCF7 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
+		40DADB6CCA7C34899493F0DF /* testhelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = testhelper.m; sourceTree = "<group>"; };
 		4EA47E87D37B93163DC37DFE /* Header2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Header2.h; sourceTree = "<group>"; };
 		4ED99215913B1CD2AA84B255 /* empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = empty.swift; sourceTree = "<group>"; };
 		632CFB9DFB491CE5041EE814 /* TestStickers.xcstickers */ = {isa = PBXFileReference; lastKnownFileType = folder.stickers; path = TestStickers.xcstickers; sourceTree = "<group>"; };
+		8CEB7F29BE7079D1C68021EB /* TestImports-Unit-Tests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TestImports-Unit-Tests-Bridging-Header.h"; sourceTree = "<group>"; };
+		9A0FD8DAF9B3FB660F838C23 /* testhelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = testhelper.h; sourceTree = "<group>"; };
 		A1558B75425B9A00EAECC6AA /* TestImports-App-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TestImports-App-Bridging-Header.h"; sourceTree = "<group>"; };
 		B3D32E19E3BA9A9FCC8FCBCF /* common.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = common.pch; sourceTree = "<group>"; };
 		B4CD841B3F2A7DEE174D9413 /* Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Header.h; sourceTree = "<group>"; };
@@ -93,7 +97,10 @@
 				22A8A4218E2455208F73FDF0 /* Resources */,
 				2EF81609D3AA2C86BD531FC9 /* test.m */,
 				0A9CDCA4AFFA244654BAAF8B /* test.swift */,
+				9A0FD8DAF9B3FB660F838C23 /* testhelper.h */,
+				40DADB6CCA7C34899493F0DF /* testhelper.m */,
 				A1558B75425B9A00EAECC6AA /* TestImports-App-Bridging-Header.h */,
+				8CEB7F29BE7079D1C68021EB /* TestImports-Unit-Tests-Bridging-Header.h */,
 			);
 			path = "test-imports-app";
 			sourceTree = "<group>";
@@ -259,6 +266,7 @@
 			files = (
 				28DC502501A36DE46FB2FDAE /* test.m in Sources */,
 				C7087EC243FF0E3AB1AB011E /* test.swift in Sources */,
+				EFADD50C4F0A43EB535E96A2 /* testhelper.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -352,7 +360,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-966875f8ada8/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-966875f8ada8/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_doublequote_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_angle_bracket_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_doublequote_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_angle_bracket_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_doublequote_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_angle_bracket_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_doublequote_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_angle_bracket_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACH_O_TYPE = "$(inherited)";
 				ONLY_ACTIVE_ARCH = YES;
@@ -423,7 +431,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-966875f8ada8/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-966875f8ada8/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_doublequote_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_angle_bracket_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_doublequote_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_angle_bracket_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_doublequote_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_angle_bracket_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_doublequote_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_angle_bracket_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACH_O_TYPE = "$(inherited)";
 				ONLY_ACTIVE_ARCH = YES;

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		A92FEA9E7CEAA5C1D707216B /* test.m in Sources */ = {isa = PBXBuildFile; fileRef = EC2BF9F658BA7B0FF93BA215 /* test.m */; };
 		C61986BF5CBA4DAEAF33BE91 /* empty.m in Sources */ = {isa = PBXBuildFile; fileRef = 018DA4ABD245EA72FEA9BA46 /* empty.m */; };
 		C6B1D1CBC7730A53A2C04E0D /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5478D8BA2BE2A548270A80 /* empty.swift */; };
+		C95405553A2746A500C5E3E6 /* testhelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 4BF0C0F5D81C125CD2559615 /* testhelper.m */; };
 		E676560B3EE63A86606530C8 /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5AC323968F3E7DC9BAFEC85 /* empty.swift */; };
 /* End PBXBuildFile section */
 
@@ -42,12 +43,15 @@
 		211B0D62D65A5D8BEFE42153 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		3CCFF4E96CDD4C2949F0F71A /* Header2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Header2.h; sourceTree = "<group>"; };
 		3ECF1D7133544DD5E82A3EB0 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		4BF0C0F5D81C125CD2559615 /* testhelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = testhelper.m; sourceTree = "<group>"; };
+		4DACF9F33F414B6BED4E227B /* testhelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = testhelper.h; sourceTree = "<group>"; };
 		57D04511C7357979F7EB5058 /* TestModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = TestModel.xcdatamodel; sourceTree = "<group>"; };
 		5BE4EAFF6C0B54947E66B439 /* ios.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ios.entitlements; sourceTree = "<group>"; };
 		5EF21FC7C23005F0603AD4F0 /* test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = test.swift; sourceTree = "<group>"; };
 		61CE3CBBAD0BFAFC0953377B /* TestImports-App.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "TestImports-App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B5478D8BA2BE2A548270A80 /* empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = empty.swift; sourceTree = "<group>"; };
 		6E1E57A5D2E549D270B1B1A7 /* resource_bundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = resource_bundle.plist; sourceTree = "<group>"; };
+		6F61436FF5DC80B583273E47 /* TestImports-Unit-Tests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TestImports-Unit-Tests-Bridging-Header.h"; sourceTree = "<group>"; };
 		8BBBE8333A9A3A09CEFFD917 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		9683E3E05D116FBB2D85DC23 /* TestImports-App-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TestImports-App-Bridging-Header.h"; sourceTree = "<group>"; };
 		9E7E8177A9991D407C446EF6 /* TestImports-Unit-Tests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = "TestImports-Unit-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -138,7 +142,10 @@
 				DC21B9839449D8D9195E4A22 /* Resources */,
 				EC2BF9F658BA7B0FF93BA215 /* test.m */,
 				5EF21FC7C23005F0603AD4F0 /* test.swift */,
+				4DACF9F33F414B6BED4E227B /* testhelper.h */,
+				4BF0C0F5D81C125CD2559615 /* testhelper.m */,
 				9683E3E05D116FBB2D85DC23 /* TestImports-App-Bridging-Header.h */,
+				6F61436FF5DC80B583273E47 /* TestImports-Unit-Tests-Bridging-Header.h */,
 			);
 			path = "test-imports-app";
 			sourceTree = "<group>";
@@ -364,6 +371,7 @@
 			files = (
 				A92FEA9E7CEAA5C1D707216B /* test.m in Sources */,
 				9C997105C8FCCC97A52F3C37 /* test.swift in Sources */,
+				C95405553A2746A500C5E3E6 /* testhelper.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -421,7 +429,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-966875f8ada8/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-966875f8ada8/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_doublequote_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_angle_bracket_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_doublequote_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_angle_bracket_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_doublequote_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_angle_bracket_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_doublequote_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_angle_bracket_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACH_O_TYPE = "$(inherited)";
 				ONLY_ACTIVE_ARCH = YES;
@@ -468,7 +476,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-966875f8ada8/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-966875f8ada8/bin/tests/ios/unit-test/test-imports-app/TestImports-App_framework_unlinked\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_doublequote_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_angle_bracket_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_doublequote_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_angle_bracket_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_doublequote_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_angle_bracket_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_doublequote_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-9754431daf72/bin/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests_swift_angle_bracket_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACH_O_TYPE = "$(inherited)";
 				ONLY_ACTIVE_ARCH = YES;


### PR DESCRIPTION
Expands the TestImportsApp to include a bridging header