### PR TITLE
Add `strings` attribute to ios_application

### DIFF
--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -18,6 +18,7 @@ _IOS_APPLICATION_KWARGS = [
     "resources",
     "app_icons",
     "tags",
+    "strings",
 ]
 
 def write_info_plists_if_needed(name, plists):


### PR DESCRIPTION
Allows users to use the `strings` attribute on `ios_application` rules