### PR TITLE
Fix bazel coverage binary parameter

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -310,7 +310,7 @@ def _apple_framework_packaging_impl(ctx):
         AppleBundleInfo(
             archive = None,
             archive_root = None,
-            binary = binary_out,
+            binary = binary_out[0] if len(binary_out) > 0 else None,
             bundle_id = bundle_id,
             bundle_name = framework_name,
             bundle_extension = bundle_extension,

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -310,7 +310,7 @@ def _apple_framework_packaging_impl(ctx):
         AppleBundleInfo(
             archive = None,
             archive_root = None,
-            binary = binary_out[0] if len(binary_out) > 0 else None,
+            binary = binary_out[0] if binary_out else None,
             bundle_id = bundle_id,
             bundle_name = framework_name,
             bundle_extension = bundle_extension,


### PR DESCRIPTION
We get the following error when building a framework and collecting its code coverage:

```
/testing/apple_test_rule_support.bzl", line 83, column 38, in _coverage_files_aspect_impl
		covered_binaries = depset(
Error in depset: depsets cannot contain items of type 'list'
ERROR: Analysis of target '//tests/ios/frameworks/target-xib:TargetXIBTests' failed; build aborted: Analysis of target '//tests/ios/frameworks/target-xib:TargetXIB' failed
```

How to reproduce:
Running the next command in this repo:
```bazelisk coverage --experimental_use_llvm_covmap --test_env=LCOV_MERGER=/usr/bin/true //tests/ios/...```

AppleBundleInfo from rules_apple expects a File instead of a list, we pass the first element of binary_out if it exists to solve the problem.
https://github.com/bazelbuild/rules_apple/blob/master/apple/providers.bzl
