### PR TITLE
Ignore maccatalyst slices in xcframeworks

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -266,6 +266,9 @@ def _xcframework(*, library_name, name, slices):
             if arch == "arm64" and platform_variant == "simulator":
                 # TODO: support sim on apple silicon by having a config setting for platform_variant
                 continue
+            elif arch == "x86_64" and platform_variant == "maccatalyst":
+                # TODO: support maccatalyst
+                continue
 
             arch_setting = "@build_bazel_rules_apple//apple:{}_{}".format(platform, arch)
             config_setting_name = "{}-{}".format(


### PR DESCRIPTION
Requires unreleased features in bazel to select against