### PR TITLE
Ensures the deletion of stale files in non-sandboxed mode

### DIFF
--- a/rules/framework/framework_packaging.py
+++ b/rules/framework/framework_packaging.py
@@ -9,11 +9,9 @@ import shutil
 import subprocess
 import sys
 
-
 def _mkdir(path):
     if not os.path.exists(path):
         os.makedirs(path)
-
 
 def _cp(src, dest):
     shutil.copyfile(src, dest)
@@ -41,6 +39,16 @@ def _merge_binaries(framework_root, framework_name, binary_in):
                     "-o", output_path
                     ] + binary_in
         subprocess.check_call(commands)
+
+def _copy_modulemap(framework_root, modulemap_path):
+    """Copy modulemaps to its destination.
+    Args:
+        framework_root: root folder of the framework
+        modulemap_path: path of the original modulemap
+    """
+    dest = os.path.join(framework_root, "Modules", "module.modulemap")
+    _mkdir(os.path.dirname(dest))
+    _cp(modulemap_path, dest)
 
 def _clean(framework_root, manifest_file, output_manifest_file):
     """Remove stale files from the framework root.
@@ -94,6 +102,8 @@ def main():
     actions = {
         "binary":
             lambda args: _merge_binaries(args.framework_root, args.framework_name, args.inputs),
+        "modulemap":
+            lambda args: _copy_modulemap(args.framework_root, args.input()),
         "swiftmodule":
             lambda args: _cp(args.input(), args.output()),
         "swiftdoc":


### PR DESCRIPTION
# Problem 

We previously symlink both headers and module_map which don't depend on the clean action to delete stale files.
When compiling objc files depending on the current framework, the framework might have stale header files, which will cause the compilation failure.

# The fix

Instead of symlinking module_map, we run the framework_packaging action for the module_map (which copies the file). It depends on the clean action and will trigger it.
As module_map is part of the the objc_provider, the framework_packaging action must be triggered before compiling downstream objc files.

# Other solutions tried but failed

1. Instead of using actions.symlink, I tried to manually create the symlink in framework_packaging.py. But build fails with error as bazel failed to cache the dangling symlink.
2. Added the binary to the objc_provider as static_framework_file. It also failed.
