### PR TITLE
Writeup doc on Index While Building

### DIFF
--- a/docs/index_while_building.md
+++ b/docs/index_while_building.md
@@ -93,9 +93,9 @@ xcbuild ( e.g. XCBuildKit ) protocol messages, in xcconfig by means of the
 
 ### Preliminary
 
-- [x] Profile and determine impact of current state of IWB
-    compilation https://github.com/bazelbuild/rules_swift/issues/561
-    consumption of index in Xcode https://github.com/bazel-ios/rules_ios/issues/203
+- [x] Profile and determine impact of current state of IWB.
+- [x] Swift compilation https://github.com/bazelbuild/rules_swift/issues/561
+- [x] Consumption of index in Xcode https://github.com/bazel-ios/rules_ios/issues/203
 
 ### Determine direction forward with prototypes - spiking
 
@@ -110,7 +110,7 @@ There are a couple avenues here:
 now: it doesn't work with remote caching
 
 2. Disable "Index while building" and correspondingly index-import
-Need to consider the user facing impact
+Need to consider the user facing impact: e.g. faster build times, can't index out-of-focus impl files.
 
 ### Index while building V2 - first pass
 
@@ -122,7 +122,7 @@ Need to consider the user facing impact
 - [ ] CI script to compile `index-import`
 - [ ] Patch `rules_ios` to use first pass
 
-### Sans index-import for local builds
+### Sans index-import for local execution
 
 - [ ] Remove the need to use `index-import` for local execution
 - [ ] Implement an aspect to quickly pull remotely built indexes

--- a/docs/index_while_building.md
+++ b/docs/index_while_building.md
@@ -27,9 +27,8 @@ Like the current implementation, index while building V2 piggy backs on the
 `-index-store-path` feature in clang and swift. However, in V2 of index while
 building, `swift` and `clang` compilers use a global index cache internally to
 preserve performance. Finally, to integrate with remote caching, actions copy
-data into `bazel-out`. In other words, bazel actions import relevant units and
-records to a tree artifact output in to so Bazel can write to the tree artifact
-to caches.
+data into `bazel-out`. In other words, Bazel actions import relevant units and
+records to a tree artifact output so Bazel can write the data to caches.
 
 ### Per compilation index management
 
@@ -41,7 +40,7 @@ The program operates at the compilation level rather than caching the entire
 global index by mapping compiler outputs to unit files. The program uses the
 LLVM index store library to interface with index store primitives e.g. units and
 records. _[This program](https://github.com/lyft/index-import/pull/53) is
-orthogonal to and may may not end up as part of Lyft's index-import_.
+orthogonal to and may or may not end up as part of Lyft's index-import_.
 
 ### rules_swift workers
 

--- a/docs/index_while_building.md
+++ b/docs/index_while_building.md
@@ -26,9 +26,10 @@ global index and interoperate with Bazel's remote execution and caching.
 Like the current implementation, index while building V2 piggy backs on the
 `-index-store-path` feature in clang and swift. However, in V2 of index while
 building, `swift` and `clang` compilers use a global index cache internally to
-preserve performance. Finally, to integrate with remote caching, actions copy
-data into `bazel-out`. In other words, Bazel actions import relevant units and
-records to a tree artifact output so Bazel can write the data to caches.
+preserve performance. Finally, to integrate with remote caching, actions copy a
+small subset of data into `bazel-out`. In other words, Bazel actions import
+relevant units and records to a tree artifact output so Bazel can write a small
+subset of the index data to caches.
 
 ### Per compilation index management
 
@@ -53,9 +54,11 @@ action output. Multiple actions cannot specify the same indexstore directory as 
 
 ### clang compilation
 
-The native rules currently don't have an specify indexstore as a clang compilation action output.
-[Task 2](#Task roadmap) is to update rules_cc compilation actions to write to a global index internally and
-then copy the updated units+records to an output directory to ensure remote caching will work.
+The native rules currently don't have an specify indexstore as a clang
+compilation action output.  It may use rules_cc compilation actions to write to
+a global index internally and then copy the updated units+records to an output
+directory to ensure remote caching will work. Here, it uses rules_cc to add an
+extra compilation output for the translation unit / source file.
 
 ### Incrementally importing remotely compiled indexes
 

--- a/docs/index_while_building.md
+++ b/docs/index_while_building.md
@@ -114,16 +114,17 @@ Need to consider the user facing impact
 
 ### Index while building V2 - first pass
 
-- [x] Propose changes to `rules_swift` for compilation
+- [x] Propose changes to `rules_swift` for compilation https://github.com/bazelbuild/rules_swift/pull/567
 - [x] Propose changes to `index-import` for Bazel action helper binary https://github.com/lyft/index-import/pull/53
 - [x] Evaluate possibilities to remove `index-import` for local execution
 - [x] Fork `rules_swift` to `rules_ios` to iterate until upstream PR lands
 - [ ] Fork `index-import` to `rules_ios`
+- [ ] CI script to compile `index-import`
 - [ ] Patch `rules_ios` to use first pass
 
 ### Sans index-import for local builds
 
-- [ ] Remove the need to use `index-import` for local builds
+- [ ] Remove the need to use `index-import` for local execution
 - [ ] Implement an aspect to quickly pull remotely built indexes
 
 ### objc remote cache support

--- a/docs/index_while_building.md
+++ b/docs/index_while_building.md
@@ -1,9 +1,9 @@
 # Index While Building in Bazel
 
 This document summarizes the status of index while building in Bazel and the
-plan to improve it. "Index while building" encompases the writing of index data
-from swift and clang and then consumption of that inside of that data in Xcode.
-For a high level design of the feature in LLVM, check the whitepaper [Adding Index-While-Building support to Clang](https://docs.google.com/document/d/1cH2sTpgSnJZCkZtJl1aY-rzy4uGPcrI-6RrUpdATO2Q/edit)
+plan to improve it. "Index while building" encompasses the writing of index data
+from swift and clang and the usage of that data in Xcode.
+For a high level design of the feature in LLVM, check the paper [Adding Index-While-Building support to Clang](https://docs.google.com/document/d/1cH2sTpgSnJZCkZtJl1aY-rzy4uGPcrI-6RrUpdATO2Q/edit)
 
 ## High level summary and status
 
@@ -15,7 +15,7 @@ time in testing.
 index-store-path. When using a transient per-swift-library index, it writes O(
 M imports * N libs) indexer data and slows down compilation significantly: to
 the tune of 300% slow down and 6GB+ index data in benchmarks. `rules_swift`
-likes to use per `swift_library` data in order to remote cache indexes
+likes to use per `swift_library` data in order to remote cache indexes.
 `rules_ios` uses a per `apple_library` index to reduce `index-import` wallclock
 time.  Adding "Index while building" to Bazel needs special consideration to
 both preserve performance characteristics of the original architecture of a

--- a/docs/index_while_building.md
+++ b/docs/index_while_building.md
@@ -78,7 +78,7 @@ One major shortcut exists locally to remove index-import: Xcode is fixed to read
 directly from Bazel's global index store. Then, instead of writing to global
 index and copying to `bazel-out` for remote caching, Xcode should can read right
 from Bazels' global index. A "out of band" sentenial value can noop the code
-path for `bazel-out`.
+path for `bazel-out`. _(out of band means abstracted from Bazel)_
 
 In order to remove the requirement to "index-import" bazel indexes, there are
 special considerations in the way that Xcode and Bazel invoke compilation and
@@ -91,8 +91,16 @@ xcbuild ( e.g. XCBuildKit ) protocol messages, in xcconfig by means of the
 
 ## Task roadmap
 
+### Preliminary
 
-## T0 - Determine direction forward with prototypes
+- [x] Profile and determine impact of current state of IWB
+    compilation https://github.com/bazelbuild/rules_swift/issues/561
+    consumption of index in Xcode https://github.com/bazel-ios/rules_ios/issues/203
+
+### Determine direction forward with prototypes - spiking
+
+- [x] Output design doc and map out tasks
+
 1. Consider possibilities of improving performance of "Index while building"
 There are a couple avenues here:
 
@@ -104,13 +112,23 @@ now: it doesn't work with remote caching
 2. Disable "Index while building" and correspondingly index-import
 Need to consider the user facing impact
 
+### Index while building V2 - first pass
 
-## T1 - Index while building V2 - first pass
+- [x] Propose changes to `rules_swift` for compilation
+- [x] Propose changes to `index-import` for Bazel action helper binary https://github.com/lyft/index-import/pull/53
+- [x] Evaluate possibilities to remove `index-import` for local execution
+- [x] Fork `rules_swift` to `rules_ios` to iterate until upstream PR lands
+- [ ] Fork `index-import` to `rules_ios`
+- [ ] Patch `rules_ios` to use first pass
 
-1. Propose changes to `rules_swift` for compilation
-2. Implement an aspect to quickly pull remotely built indexes
-3. Evaluate possibilities to remove `index-import` for local execution
-4. Patch `rules_ios` to pass the global index for objc/cpp
+### Sans index-import for local builds
 
-## T2 - Index while building V2 - objc support
-1. determine a pattern to add index while building to objc with remote caching
+- [ ] Remove the need to use `index-import` for local builds
+- [ ] Implement an aspect to quickly pull remotely built indexes
+
+### objc remote cache support
+
+- [ ] determine a pattern to add Index While Building to objc with remote caching
+- [ ] consider adding an extra action output for `rules_ios` for translation
+    unit index
+

--- a/docs/index_while_building.md
+++ b/docs/index_while_building.md
@@ -55,8 +55,8 @@ Initially the feature will work the same locally as it does remotely.
 However, one major shortcut exists locally to remove index-import. Xcode should
 read directly from Bazel's global index store. In other words, instead of
 writing to the per module index, and copying to `bazel-out` for remote caching,
-Xcode should pull right from that index. A sential can be added in order to
-noop the code path for `bazel-out` when writing remotely built indexes.
+Xcode should pull right from that index. A "out of band" sentenial value can noop
+the code path for `bazel-out`.
 
 In order to remove the requirement to "index-import" bazel indexes, there are
 special considerations in the way that Xcode and Bazel invoke compilation and

--- a/docs/index_while_building.md
+++ b/docs/index_while_building.md
@@ -21,20 +21,22 @@ time.  Adding "Index while building" to bazel needs special consideration to
 preserve performance characteristics of the original architecture of a global
 index while interoperating with remote execution and caching.
 
-## rules_swift workers
+## Index while building V2
+
+### rules_swift workers
 
 Workers are extended to use a global index internally. Records and units into
 the remote cache by copying material from the worker's global index into
 `bazel-out`. This fixes
 
-## clang compilation
+### clang compilation
 
 The native rules don't have an extra output for indexstore. These rules are
 updated to use the global index and in M3 remote caching for clang compilation
 is added.
 
 
-### Incrementally - importing remotely compiled indexes
+#### Incrementally importing remotely compiled indexes
 
 In order to import indexs into Xcode incrementally, a program is invoked to
 "import" remotely compiled indexes. This may be an aspect that runs during the
@@ -74,9 +76,9 @@ xcbuild ( e.g. XCBuildKit ) protocol messages, in xcconfig by means of the
 1. Consider possibilities of improving performance of "Index while building"
 There are a couple avenues here:
 
-1a. A solution that works with remote caching
+- solution that works with remote caching
 
-1b. A solution that only runs locally. This is the status quo of objc right
+- A solution that only runs locally. This is the status quo of objc right
 now: it doesn't work with remote caching
 
 2. Disable "Index while building" and correspondingly index-import

--- a/docs/index_while_building.md
+++ b/docs/index_while_building.md
@@ -23,6 +23,12 @@ global index and interoperate with Bazel's remote execution and caching.
 
 ## Index while building V2
 
+Like the current implementation, index while building V2 piggy backs on the
+`-index-store-path` feature in clang and swift. However, in V2 of index while
+building, `swift` and `clang` compilers use a global index cache internally to
+preserve performance. Finally, to integrate with remote caching, actions copy
+data into `bazel-out`.
+
 ### rules_swift workers
 
 Workers are extended to use a global index internally. Then, it writes records

--- a/docs/index_while_building.md
+++ b/docs/index_while_building.md
@@ -14,20 +14,20 @@ time in testing.
 `swift` and `clang` write index data based on the status of what resides in
 index-store-path. When using a transient per-swift-library index, it writes O(
 M imports * N libs) indexer data and slows down compilation significantly: to
-the tune of 300% slow down and 6GB+ index data in my testing. `rules_swift`
+the tune of 300% slow down and 6GB+ index data in benchmarks. `rules_swift`
 likes to use per `swift_library` data in order to remote cache indexes
 `rules_ios` uses a per `apple_library` index to reduce `index-import` wallclock
-time.  Adding "Index while building" to bazel needs special consideration to
-preserve performance characteristics of the original architecture of a global
-index while interoperating with remote execution and caching.
+time.  Adding "Index while building" to Bazel needs special consideration to
+both preserve performance characteristics of the original architecture of a
+global index and interoperate with Bazel's remote execution and caching.
 
 ## Index while building V2
 
 ### rules_swift workers
 
-Workers are extended to use a global index internally. Records and units into
-the remote cache by copying material from the worker's global index into
-`bazel-out`. This fixes
+Workers are extended to use a global index internally. Then, it writes records
+and units into the remote cache by copying material from the worker's global
+index into `bazel-out`. 
 
 ### clang compilation
 

--- a/docs/index_while_building.md
+++ b/docs/index_while_building.md
@@ -1,9 +1,9 @@
 # Index While Building in Bazel
 
 This document summarizes the status of index while building in Bazel and the
-plan to implement it. "Index while building" encompases the writing of index
-data from swift and clang and then consumption of that inside of that data in
-Xcode.
+plan to improve it. "Index while building" encompases the writing of index data
+from swift and clang and then consumption of that inside of that data in Xcode.
+For a high level design of the feature in LLVM, check the whitepaper [Adding Index-While-Building support to Clang](https://docs.google.com/document/d/1cH2sTpgSnJZCkZtJl1aY-rzy4uGPcrI-6RrUpdATO2Q/edit)
 
 ## High level summary and status
 

--- a/docs/index_while_building.md
+++ b/docs/index_while_building.md
@@ -1,0 +1,94 @@
+# Index While Building in Bazel
+
+This document summarizes the status of index while building in Bazel and the
+plan to implement it. "Index while building" encompases the writing of index
+data from swift and clang and then consumption of that inside of that data in
+Xcode.
+
+## High level summary and status
+
+At the time of writing there's prior art that adds `-index-store-path` to
+`rules_swift` and `rules_ios` but enabling these code paths slows down build
+time in testing.
+
+`swift` and `clang` write index data based on the status of what resides in
+index-store-path. When using a transient per-swift-library index, it writes O(
+M imports * N libs) indexer data and slows down compilation significantly: to
+the tune of 300% slow down and 6GB+ index data in my testing. `rules_swift`
+likes to use per `swift_library` data in order to remote cache indexes
+`rules_ios` uses a per `apple_library` index to reduce `index-import` wallclock
+time.  Adding "Index while building" to bazel needs special consideration to
+preserve performance characteristics of the original architecture of a global
+index while interoperating with remote execution and caching.
+
+## rules_swift workers
+
+Workers are extended to use a global index internally. Records and units into
+the remote cache by copying material from the worker's global index into
+`bazel-out`. This fixes
+
+## clang compilation
+
+The native rules don't have an extra output for indexstore. These rules are
+updated to use the global index and in M3 remote caching for clang compilation
+is added.
+
+
+### Incrementally - importing remotely compiled indexes
+
+In order to import indexs into Xcode incrementally, a program is invoked to
+"import" remotely compiled indexes. This may be an aspect that runs during the
+Xcode build in order to pass an output file map to index import, or an ad-hoc
+program picking up output maps from build events.
+
+By default clang and swift seem to write absolute paths into the Index. If this
+is invariant continues to hold, it needs to be accounted for in Bazel. e.g.
+Unless all source code and compilation resided at the same directory remotely
+and locally there will likely need to be a `remap`ing of paths. The previously
+mentioned importing program will be smart enough to govern this - and import
+only the files that were recompiled.
+
+### Local optimization - sans index-import
+
+Initially the feature will work the same locally as it does remotely.
+
+However, one major shortcut exists locally to remove index-import. Xcode should
+read directly from Bazel's global index store. In other words, instead of
+writing to the per module index, and copying to `bazel-out` for remote caching,
+Xcode should pull right from that index. A sential can be added in order to
+noop the code path for `bazel-out` when writing remotely built indexes.
+
+In order to remove the requirement to "index-import" bazel indexes, there are
+special considerations in the way that Xcode and Bazel invoke compilation and
+index-while-building abilities. Specifically, the file paths that Xcode and
+Bazel use to address index records must be aligned. This may be achievable by
+just aligning outputs between Xcode and Bazel: for example in the build system
+xcbuild ( e.g. XCBuildKit ) protocol messages, in xcconfig by means of the
+`.xcspec` features, or by plugin.
+
+
+## Task roadmap 
+
+
+## Determine direction forward with prototypes
+1. Consider possibilities of improving performance of "Index while building"
+There are a couple avenues here:
+
+1a. A solution that works with remote caching
+
+1b. A solution that only runs locally. This is the status quo of objc right
+now: it doesn't work with remote caching
+
+2. Disable "Index while building" and correspondingly index-import
+Need to consider the user facing impact  MDX-3735
+
+
+## Land index while building V2 - first pass
+
+1. Propose changes to `rules_swift` for compilation
+2. Implement an aspect to quickly pull remotely built indexes
+3. Evaluate possibilities to remove `index-import` for local execution
+4. Patch `rules_ios` to pass the global index for objc/cpp
+
+## Land index while building V2 - objc support
+1. determine a pattern to add index while building to objc with remote caching

--- a/docs/index_while_building.md
+++ b/docs/index_while_building.md
@@ -49,19 +49,18 @@ and units into the remote cache by copying material from the worker's global
 index into `bazel-out`. This logic lives in the action binary to optimize
 performance and interface per compilation records with Bazel. _note: it's also
 not currently possible or gainful to express the global index store in a Bazel
-action ouput._
+action output. Multiple actions cannot specify the same indexstore directory as an output._
 
 ### clang compilation
 
-The native rules don't have an extra output for indexstore. These rules are
-updated to use the global index and in remote caching for clang compilation is
-added. Like swift, this is behavior is also internal to the action. _This will
-be added as a followup - see [Task 2](#Task roadmap)._
+The native rules currently don't have an specify indexstore as a clang compilation action output.
+[Task 2](#Task roadmap) is to update rules_cc compilation actions to write to a global index internally and
+then copy the updated units+records to an output directory to ensure remote caching will work.
 
 ### Incrementally importing remotely compiled indexes
 
 In order to import indexes into a local, global index incrementally, a program
-is invoked to "import" remotely compiled indexes based on action ouputs. This
+is invoked to "import" remotely compiled indexes based on action outputs. This
 may be an aspect that runs during the Xcode build in order to pass an output
 file map to index import, or an ad-hoc program picking up output maps from build
 events.
@@ -78,7 +77,7 @@ only the files that were recompiled.
 One major shortcut exists locally to remove index-import: Xcode is fixed to read
 directly from Bazel's global index store. Then, instead of writing to global
 index and copying to `bazel-out` for remote caching, Xcode should can read right
-from Bazels' globlal index. A "out of band" sentenial value can noop the code
+from Bazels' global index. A "out of band" sentenial value can noop the code
 path for `bazel-out`.
 
 In order to remove the requirement to "index-import" bazel indexes, there are


### PR DESCRIPTION
Overall architecture of design for "Index While Building" in Bazel

- https://github.com/lyft/index-import/pull/53
- https://github.com/bazelbuild/rules_swift/pull/567
- https://github.com/bazelbuild/rules_swift/issues/561