### PR TITLE
Additional icons support in iOS_application rule

### DIFF
--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -19,6 +19,7 @@ _IOS_APPLICATION_KWARGS = [
     "app_icons",
     "tags",
     "strings",
+    "alternate_icons",
 ]
 
 def write_info_plists_if_needed(name, plists):


### PR DESCRIPTION
Additional icons were added to `rules_ios` in this PR https://github.com/bazelbuild/rules_apple/pull/1032 . This change allows users to use this new feature when using `rules_ios`