### PR TITLE
Conditionally pass DEBUG flag to LLDB

### DIFF
--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -825,6 +825,12 @@ Tags for configuration:
     xcodeproj-ignore-as-target: Add this to a rule declaration so that this rule will not generates a scheme for this target
 """,
     attrs = {
+        # Important! The `Debug` is being used to conditionally pass
+        # flags to LLDB, so if this behaviour ever changes that needs
+        # to be considered otherwise debugging swift files will stop working
+        #
+        # See the logic around setting the `-D DEBUG` flag in
+        # https://github.com/bazel-ios/rules_ios/blob/master/tools/xcodeproj_shims/installers/lldb-settings.sh
         "configs": attr.string_list(mandatory = False, default = [], doc = """
         List of bazel configs present in the .bazelrc file that can be used to build targets.
 

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -40,6 +40,24 @@ for fsp in $FRAMEWORK_SEARCH_PATHS; do
   # so we can just pass them without any modification
   LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
 done
+# If on the `Debug` config append
+# the `-D DEBUG` flag so the debugger
+# works properly
+#
+# Note that this is connected to the available
+# build configurations and at this time we're
+# creating `Debug` and `Release` by default
+#
+# Once we move away from that approach and start
+# fully mirroring the configs in the `.bazelrc`
+# file this needs to be changed and added to all
+# configs of type `debug`
+#
+# See: https://github.com/bazel-ios/rules_ios/blob/master/rules/xcodeproj.bzl#L828-L837
+if [[ "$CONFIGURATION" = "Debug" ]]
+then
+  LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -D DEBUG")
+fi
 # Set all swift-extra-clang-flags if 'LLDB_SWIFT_EXTRA_CLANG_FLAGS'
 # is not empty
 if [[ ${#LLDB_SWIFT_EXTRA_CLANG_FLAGS[@]} -ne 0 ]]

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -40,6 +40,24 @@ for fsp in $FRAMEWORK_SEARCH_PATHS; do
   # so we can just pass them without any modification
   LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
 done
+# If on the `Debug` config append
+# the `-D DEBUG` flag so the debugger
+# works properly
+#
+# Note that this is connected to the available
+# build configurations and at this time we're
+# creating `Debug` and `Release` by default
+#
+# Once we move away from that approach and start
+# fully mirroring the configs in the `.bazelrc`
+# file this needs to be changed and added to all
+# configs of type `debug`
+#
+# See: https://github.com/bazel-ios/rules_ios/blob/master/rules/xcodeproj.bzl#L828-L837
+if [[ "$CONFIGURATION" = "Debug" ]]
+then
+  LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -D DEBUG")
+fi
 # Set all swift-extra-clang-flags if 'LLDB_SWIFT_EXTRA_CLANG_FLAGS'
 # is not empty
 if [[ ${#LLDB_SWIFT_EXTRA_CLANG_FLAGS[@]} -ne 0 ]]

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -40,6 +40,24 @@ for fsp in $FRAMEWORK_SEARCH_PATHS; do
   # so we can just pass them without any modification
   LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
 done
+# If on the `Debug` config append
+# the `-D DEBUG` flag so the debugger
+# works properly
+#
+# Note that this is connected to the available
+# build configurations and at this time we're
+# creating `Debug` and `Release` by default
+#
+# Once we move away from that approach and start
+# fully mirroring the configs in the `.bazelrc`
+# file this needs to be changed and added to all
+# configs of type `debug`
+#
+# See: https://github.com/bazel-ios/rules_ios/blob/master/rules/xcodeproj.bzl#L828-L837
+if [[ "$CONFIGURATION" = "Debug" ]]
+then
+  LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -D DEBUG")
+fi
 # Set all swift-extra-clang-flags if 'LLDB_SWIFT_EXTRA_CLANG_FLAGS'
 # is not empty
 if [[ ${#LLDB_SWIFT_EXTRA_CLANG_FLAGS[@]} -ne 0 ]]

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -40,6 +40,24 @@ for fsp in $FRAMEWORK_SEARCH_PATHS; do
   # so we can just pass them without any modification
   LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
 done
+# If on the `Debug` config append
+# the `-D DEBUG` flag so the debugger
+# works properly
+#
+# Note that this is connected to the available
+# build configurations and at this time we're
+# creating `Debug` and `Release` by default
+#
+# Once we move away from that approach and start
+# fully mirroring the configs in the `.bazelrc`
+# file this needs to be changed and added to all
+# configs of type `debug`
+#
+# See: https://github.com/bazel-ios/rules_ios/blob/master/rules/xcodeproj.bzl#L828-L837
+if [[ "$CONFIGURATION" = "Debug" ]]
+then
+  LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -D DEBUG")
+fi
 # Set all swift-extra-clang-flags if 'LLDB_SWIFT_EXTRA_CLANG_FLAGS'
 # is not empty
 if [[ ${#LLDB_SWIFT_EXTRA_CLANG_FLAGS[@]} -ne 0 ]]

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -40,6 +40,24 @@ for fsp in $FRAMEWORK_SEARCH_PATHS; do
   # so we can just pass them without any modification
   LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
 done
+# If on the `Debug` config append
+# the `-D DEBUG` flag so the debugger
+# works properly
+#
+# Note that this is connected to the available
+# build configurations and at this time we're
+# creating `Debug` and `Release` by default
+#
+# Once we move away from that approach and start
+# fully mirroring the configs in the `.bazelrc`
+# file this needs to be changed and added to all
+# configs of type `debug`
+#
+# See: https://github.com/bazel-ios/rules_ios/blob/master/rules/xcodeproj.bzl#L828-L837
+if [[ "$CONFIGURATION" = "Debug" ]]
+then
+  LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -D DEBUG")
+fi
 # Set all swift-extra-clang-flags if 'LLDB_SWIFT_EXTRA_CLANG_FLAGS'
 # is not empty
 if [[ ${#LLDB_SWIFT_EXTRA_CLANG_FLAGS[@]} -ne 0 ]]

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -40,6 +40,24 @@ for fsp in $FRAMEWORK_SEARCH_PATHS; do
   # so we can just pass them without any modification
   LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
 done
+# If on the `Debug` config append
+# the `-D DEBUG` flag so the debugger
+# works properly
+#
+# Note that this is connected to the available
+# build configurations and at this time we're
+# creating `Debug` and `Release` by default
+#
+# Once we move away from that approach and start
+# fully mirroring the configs in the `.bazelrc`
+# file this needs to be changed and added to all
+# configs of type `debug`
+#
+# See: https://github.com/bazel-ios/rules_ios/blob/master/rules/xcodeproj.bzl#L828-L837
+if [[ "$CONFIGURATION" = "Debug" ]]
+then
+  LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -D DEBUG")
+fi
 # Set all swift-extra-clang-flags if 'LLDB_SWIFT_EXTRA_CLANG_FLAGS'
 # is not empty
 if [[ ${#LLDB_SWIFT_EXTRA_CLANG_FLAGS[@]} -ne 0 ]]

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -40,6 +40,24 @@ for fsp in $FRAMEWORK_SEARCH_PATHS; do
   # so we can just pass them without any modification
   LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
 done
+# If on the `Debug` config append
+# the `-D DEBUG` flag so the debugger
+# works properly
+#
+# Note that this is connected to the available
+# build configurations and at this time we're
+# creating `Debug` and `Release` by default
+#
+# Once we move away from that approach and start
+# fully mirroring the configs in the `.bazelrc`
+# file this needs to be changed and added to all
+# configs of type `debug`
+#
+# See: https://github.com/bazel-ios/rules_ios/blob/master/rules/xcodeproj.bzl#L828-L837
+if [[ "$CONFIGURATION" = "Debug" ]]
+then
+  LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -D DEBUG")
+fi
 # Set all swift-extra-clang-flags if 'LLDB_SWIFT_EXTRA_CLANG_FLAGS'
 # is not empty
 if [[ ${#LLDB_SWIFT_EXTRA_CLANG_FLAGS[@]} -ne 0 ]]

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -40,6 +40,24 @@ for fsp in $FRAMEWORK_SEARCH_PATHS; do
   # so we can just pass them without any modification
   LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
 done
+# If on the `Debug` config append
+# the `-D DEBUG` flag so the debugger
+# works properly
+#
+# Note that this is connected to the available
+# build configurations and at this time we're
+# creating `Debug` and `Release` by default
+#
+# Once we move away from that approach and start
+# fully mirroring the configs in the `.bazelrc`
+# file this needs to be changed and added to all
+# configs of type `debug`
+#
+# See: https://github.com/bazel-ios/rules_ios/blob/master/rules/xcodeproj.bzl#L828-L837
+if [[ "$CONFIGURATION" = "Debug" ]]
+then
+  LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -D DEBUG")
+fi
 # Set all swift-extra-clang-flags if 'LLDB_SWIFT_EXTRA_CLANG_FLAGS'
 # is not empty
 if [[ ${#LLDB_SWIFT_EXTRA_CLANG_FLAGS[@]} -ne 0 ]]

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -40,6 +40,24 @@ for fsp in $FRAMEWORK_SEARCH_PATHS; do
   # so we can just pass them without any modification
   LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
 done
+# If on the `Debug` config append
+# the `-D DEBUG` flag so the debugger
+# works properly
+#
+# Note that this is connected to the available
+# build configurations and at this time we're
+# creating `Debug` and `Release` by default
+#
+# Once we move away from that approach and start
+# fully mirroring the configs in the `.bazelrc`
+# file this needs to be changed and added to all
+# configs of type `debug`
+#
+# See: https://github.com/bazel-ios/rules_ios/blob/master/rules/xcodeproj.bzl#L828-L837
+if [[ "$CONFIGURATION" = "Debug" ]]
+then
+  LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -D DEBUG")
+fi
 # Set all swift-extra-clang-flags if 'LLDB_SWIFT_EXTRA_CLANG_FLAGS'
 # is not empty
 if [[ ${#LLDB_SWIFT_EXTRA_CLANG_FLAGS[@]} -ne 0 ]]

--- a/tools/xcodeproj_shims/installers/lldb-settings.sh
+++ b/tools/xcodeproj_shims/installers/lldb-settings.sh
@@ -40,6 +40,24 @@ for fsp in $FRAMEWORK_SEARCH_PATHS; do
   # so we can just pass them without any modification
   LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
 done
+# If on the `Debug` config append
+# the `-D DEBUG` flag so the debugger
+# works properly
+#
+# Not that this is connected to the available
+# build configurations and at this time we're
+# creating `Debug` and `Release` by default
+#
+# Once we move away from that approach and start
+# fully mirroring the configs in the `.bazelrc`
+# file this needs to be changed and added to all
+# configs of type `debug`
+#
+# See: https://github.com/bazel-ios/rules_ios/blob/master/rules/xcodeproj.bzl#L828-L837
+if [[ "$CONFIGURATION" = "Debug" ]]
+then
+  LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -D DEBUG")
+fi
 # Set all swift-extra-clang-flags if 'LLDB_SWIFT_EXTRA_CLANG_FLAGS'
 # is not empty
 if [[ ${#LLDB_SWIFT_EXTRA_CLANG_FLAGS[@]} -ne 0 ]]

--- a/tools/xcodeproj_shims/installers/lldb-settings.sh
+++ b/tools/xcodeproj_shims/installers/lldb-settings.sh
@@ -44,7 +44,7 @@ done
 # the `-D DEBUG` flag so the debugger
 # works properly
 #
-# Not that this is connected to the available
+# Note that this is connected to the available
 # build configurations and at this time we're
 # creating `Debug` and `Release` by default
 #


### PR DESCRIPTION
Can be considered a continuation of #218, now that LLDB is aware of the `FRAMEWORK_SEARCH_PATHS` some use cases might have to be handled case-by-case.

This PR is an example, an objc interface was hidden behind a `#if DEBUG` statement and debugging a `.swift` file that depends on it was failing to find it.

With this change we'll respect the `Debug` config and pass the respective flag to LLDB. Moving forward once we evolve how different build configurations are set/handled we have to remember to take that into consideration in how to pass flags to LLDB. Added comments in two different places about this to ensure it's being called out explicitly.