### PR TITLE
Filter out DerivedData paths before passing FRAMEWORK_SEARCH_PATHS to LLDB

### DIFF
--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -35,10 +35,16 @@ fi
 # See original approach to fix this for more details
 # https://github.com/bazel-ios/rules_ios/pull/213
 for fsp in $FRAMEWORK_SEARCH_PATHS; do
-  # Note that these paths will come quoted
-  # and with the Xcode env vars already resolved
-  # so we can just pass them without any modification
-  LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
+  # We don't want LLDB so look for things under DerivedData
+  # given the fact that all relevant paths are being created
+  # under 'bazel-out'
+  if [[ "$fsp" != *"$BUILT_PRODUCTS_DIR"* ]]
+  then
+    # Note that these paths will come quoted
+    # and with the Xcode env vars already resolved
+    # so we can just pass them without any modification
+    LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
+  fi
 done
 # If on the `Debug` config append
 # the `-D DEBUG` flag so the debugger

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -35,10 +35,16 @@ fi
 # See original approach to fix this for more details
 # https://github.com/bazel-ios/rules_ios/pull/213
 for fsp in $FRAMEWORK_SEARCH_PATHS; do
-  # Note that these paths will come quoted
-  # and with the Xcode env vars already resolved
-  # so we can just pass them without any modification
-  LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
+  # We don't want LLDB so look for things under DerivedData
+  # given the fact that all relevant paths are being created
+  # under 'bazel-out'
+  if [[ "$fsp" != *"$BUILT_PRODUCTS_DIR"* ]]
+  then
+    # Note that these paths will come quoted
+    # and with the Xcode env vars already resolved
+    # so we can just pass them without any modification
+    LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
+  fi
 done
 # If on the `Debug` config append
 # the `-D DEBUG` flag so the debugger

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -35,10 +35,16 @@ fi
 # See original approach to fix this for more details
 # https://github.com/bazel-ios/rules_ios/pull/213
 for fsp in $FRAMEWORK_SEARCH_PATHS; do
-  # Note that these paths will come quoted
-  # and with the Xcode env vars already resolved
-  # so we can just pass them without any modification
-  LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
+  # We don't want LLDB so look for things under DerivedData
+  # given the fact that all relevant paths are being created
+  # under 'bazel-out'
+  if [[ "$fsp" != *"$BUILT_PRODUCTS_DIR"* ]]
+  then
+    # Note that these paths will come quoted
+    # and with the Xcode env vars already resolved
+    # so we can just pass them without any modification
+    LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
+  fi
 done
 # If on the `Debug` config append
 # the `-D DEBUG` flag so the debugger

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -35,10 +35,16 @@ fi
 # See original approach to fix this for more details
 # https://github.com/bazel-ios/rules_ios/pull/213
 for fsp in $FRAMEWORK_SEARCH_PATHS; do
-  # Note that these paths will come quoted
-  # and with the Xcode env vars already resolved
-  # so we can just pass them without any modification
-  LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
+  # We don't want LLDB so look for things under DerivedData
+  # given the fact that all relevant paths are being created
+  # under 'bazel-out'
+  if [[ "$fsp" != *"$BUILT_PRODUCTS_DIR"* ]]
+  then
+    # Note that these paths will come quoted
+    # and with the Xcode env vars already resolved
+    # so we can just pass them without any modification
+    LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
+  fi
 done
 # If on the `Debug` config append
 # the `-D DEBUG` flag so the debugger

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -35,10 +35,16 @@ fi
 # See original approach to fix this for more details
 # https://github.com/bazel-ios/rules_ios/pull/213
 for fsp in $FRAMEWORK_SEARCH_PATHS; do
-  # Note that these paths will come quoted
-  # and with the Xcode env vars already resolved
-  # so we can just pass them without any modification
-  LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
+  # We don't want LLDB so look for things under DerivedData
+  # given the fact that all relevant paths are being created
+  # under 'bazel-out'
+  if [[ "$fsp" != *"$BUILT_PRODUCTS_DIR"* ]]
+  then
+    # Note that these paths will come quoted
+    # and with the Xcode env vars already resolved
+    # so we can just pass them without any modification
+    LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
+  fi
 done
 # If on the `Debug` config append
 # the `-D DEBUG` flag so the debugger

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -35,10 +35,16 @@ fi
 # See original approach to fix this for more details
 # https://github.com/bazel-ios/rules_ios/pull/213
 for fsp in $FRAMEWORK_SEARCH_PATHS; do
-  # Note that these paths will come quoted
-  # and with the Xcode env vars already resolved
-  # so we can just pass them without any modification
-  LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
+  # We don't want LLDB so look for things under DerivedData
+  # given the fact that all relevant paths are being created
+  # under 'bazel-out'
+  if [[ "$fsp" != *"$BUILT_PRODUCTS_DIR"* ]]
+  then
+    # Note that these paths will come quoted
+    # and with the Xcode env vars already resolved
+    # so we can just pass them without any modification
+    LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
+  fi
 done
 # If on the `Debug` config append
 # the `-D DEBUG` flag so the debugger

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -35,10 +35,16 @@ fi
 # See original approach to fix this for more details
 # https://github.com/bazel-ios/rules_ios/pull/213
 for fsp in $FRAMEWORK_SEARCH_PATHS; do
-  # Note that these paths will come quoted
-  # and with the Xcode env vars already resolved
-  # so we can just pass them without any modification
-  LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
+  # We don't want LLDB so look for things under DerivedData
+  # given the fact that all relevant paths are being created
+  # under 'bazel-out'
+  if [[ "$fsp" != *"$BUILT_PRODUCTS_DIR"* ]]
+  then
+    # Note that these paths will come quoted
+    # and with the Xcode env vars already resolved
+    # so we can just pass them without any modification
+    LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
+  fi
 done
 # If on the `Debug` config append
 # the `-D DEBUG` flag so the debugger

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -35,10 +35,16 @@ fi
 # See original approach to fix this for more details
 # https://github.com/bazel-ios/rules_ios/pull/213
 for fsp in $FRAMEWORK_SEARCH_PATHS; do
-  # Note that these paths will come quoted
-  # and with the Xcode env vars already resolved
-  # so we can just pass them without any modification
-  LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
+  # We don't want LLDB so look for things under DerivedData
+  # given the fact that all relevant paths are being created
+  # under 'bazel-out'
+  if [[ "$fsp" != *"$BUILT_PRODUCTS_DIR"* ]]
+  then
+    # Note that these paths will come quoted
+    # and with the Xcode env vars already resolved
+    # so we can just pass them without any modification
+    LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
+  fi
 done
 # If on the `Debug` config append
 # the `-D DEBUG` flag so the debugger

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -35,10 +35,16 @@ fi
 # See original approach to fix this for more details
 # https://github.com/bazel-ios/rules_ios/pull/213
 for fsp in $FRAMEWORK_SEARCH_PATHS; do
-  # Note that these paths will come quoted
-  # and with the Xcode env vars already resolved
-  # so we can just pass them without any modification
-  LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
+  # We don't want LLDB so look for things under DerivedData
+  # given the fact that all relevant paths are being created
+  # under 'bazel-out'
+  if [[ "$fsp" != *"$BUILT_PRODUCTS_DIR"* ]]
+  then
+    # Note that these paths will come quoted
+    # and with the Xcode env vars already resolved
+    # so we can just pass them without any modification
+    LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
+  fi
 done
 # If on the `Debug` config append
 # the `-D DEBUG` flag so the debugger

--- a/tools/xcodeproj_shims/installers/lldb-settings.sh
+++ b/tools/xcodeproj_shims/installers/lldb-settings.sh
@@ -35,10 +35,16 @@ fi
 # See original approach to fix this for more details
 # https://github.com/bazel-ios/rules_ios/pull/213
 for fsp in $FRAMEWORK_SEARCH_PATHS; do
-  # Note that these paths will come quoted
-  # and with the Xcode env vars already resolved
-  # so we can just pass them without any modification
-  LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
+  # We don't want LLDB so look for things under DerivedData
+  # given the fact that all relevant paths are being created
+  # under 'bazel-out'
+  if [[ "$fsp" != *"$BUILT_PRODUCTS_DIR"* ]]
+  then
+    # Note that these paths will come quoted
+    # and with the Xcode env vars already resolved
+    # so we can just pass them without any modification
+    LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
+  fi
 done
 # If on the `Debug` config append
 # the `-D DEBUG` flag so the debugger


### PR DESCRIPTION
Continuation of the debugger fixes.

After generating an Xcode project using the `xcodeproj` rule, if different targets are manually built in Xcode it will create paths under DerivedData that can cause LLDB to fail to load it's ASTs since the correct headers and symlinks are being created under `bazel-out` instead. 

If DerivedData is one of the framework search paths for LLDB it will search there and fail before finding the correct paths under `bazel-out` so this PR is explicitly filtering out those paths only for the `target.swift-extra-clang-flags` lldb flag. 