### PR TITLE
Point Xcode at LD stub

### DIFF
--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -671,7 +671,7 @@ def _xcodeproj_impl(ctx):
         "BAZEL_CONFIGS": ctx.attr.configs,
     })
 
-    # Stubbding main executable used by xcode so no actual building happening on Xcode side
+    # Stubbing compiler, linker executables used by xcode so no actual building happening on Xcode side
     proj_settings_base.update({
         "CC": "$BAZEL_STUBS_DIR/clang-stub",
         "CXX": "$CC",
@@ -679,6 +679,8 @@ def _xcodeproj_impl(ctx):
         "LD": "$BAZEL_STUBS_DIR/ld-stub",
         "LIBTOOL": "/usr/bin/true",
         "SWIFT_EXEC": "$BAZEL_STUBS_DIR/swiftc-stub",
+        # LD isn't used for all use cases - direct it to use this LD
+        "OTHER_LDFLAGS": "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub",
     })
 
     # Change of settings to help params used for compiling individual files to match closer to Bazel

--- a/tests/ios/app/test_true.mm
+++ b/tests/ios/app/test_true.mm
@@ -1,0 +1,13 @@
+@import XCTest;
+
+@interface EmptyTestsObjCPP : XCTestCase
+
+@end
+
+@implementation EmptyTestsObjCPP
+
+- (void)testTrue {
+   XCTAssertTrue(YES);
+}
+
+@end

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
@@ -425,6 +425,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
+				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
@@ -501,6 +502,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
+				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
@@ -555,6 +557,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
+				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
@@ -608,6 +611,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
+				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.pbxproj
@@ -313,6 +313,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
+				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
@@ -343,6 +344,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
+				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/project.pbxproj
@@ -447,6 +447,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
+				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
@@ -593,6 +594,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
+				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/project.pbxproj
@@ -375,6 +375,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
+				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
@@ -427,6 +428,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
+				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/project.pbxproj
@@ -525,6 +525,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
+				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
@@ -602,6 +603,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
+				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.pbxproj
@@ -269,6 +269,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
+				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
@@ -349,6 +350,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
+				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
@@ -371,6 +371,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
+				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
@@ -401,6 +402,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
+				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
@@ -343,6 +343,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
+				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
@@ -446,6 +447,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
+				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
@@ -561,6 +561,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
+				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
@@ -641,6 +642,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
 				LIBTOOL = /usr/bin/true;
+				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";


### PR DESCRIPTION
When building a C++ file, setting LD in Xcode doesn't stub out the
linker, it's a different codepath.

This is a simple way to point at the stub by relying on a public clang
flag `-fuse-ld` Ideally we can replace the full build system without
stubbing out tools e.g. with something like XCBuildKit longer term.

Fixes #228