### PR TITLE
The defines field should be populated from the deps compilation_context

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -282,6 +282,10 @@ def _apple_framework_packaging_impl(ctx):
     _add_to_dict_if_present(compilation_context_fields, "headers", depset(
         direct = header_out + private_header_out + modulemap_out,
     ))
+    _add_to_dict_if_present(compilation_context_fields, "defines", depset(
+        direct = [],
+        transitive = [getattr(dep[CcInfo].compilation_context, "defines") for dep in ctx.attr.deps if CcInfo in dep],
+    ))
     _add_to_dict_if_present(objc_provider_fields, "module_map", depset(
         direct = modulemap_out,
     ))


### PR DESCRIPTION
According to https://github.com/bazelbuild/bazel/issues/10674, the old `define` field on the ObjcProvider is now the `defines` field on CompilationContext.

Related to https://github.com/bazel-ios/rules_ios/pull/199/files