### PR TITLE
Adds ability to use other versions of rules_swift

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ load(
 protobuf_deps()
 ```
 
+### Note about rules_swift
+
+Currently `rules_ios` relies on a cherry picked commit of `rules_swift` found [here](https://github.com/bazelbuild/rules_swift/pull/567). If you do not want to rely on this version of `rules_swift` use the following declaration in your `WORKSPACE` file.
+
+```python
+git_repository(
+    name = "build_bazel_rules_ios",
+    remote = "https://github.com/bazel-ios/rules_ios.git",
+    branch = "master",
+    patch_args = ["-p1"],
+    patches = ["@build_bazel_rules_ios//patches:disable_index_while_building_v2.patch"],
+)
+```
+
 ## Examples
 
 Minimal example:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ protobuf_deps()
 
 ### Note about rules_swift
 
-Currently `rules_ios` relies on a cherry picked commit of `rules_swift` found [here](https://github.com/bazelbuild/rules_swift/pull/567). If you do not want to rely on this version of `rules_swift` use the following declaration in your `WORKSPACE` file.
+Currently `rules_ios` relies on a cherry picked commit of `rules_swift` found [here](https://github.com/bazelbuild/rules_swift/pull/567). If you do not want to rely on this version of `rules_swift` download the patch file [here](patches/disable_index_while_building_v2.patch) and use the following declaration in your `WORKSPACE` file.
 
 ```python
 git_repository(
@@ -87,7 +87,7 @@ git_repository(
     remote = "https://github.com/bazel-ios/rules_ios.git",
     branch = "master",
     patch_args = ["-p1"],
-    patches = ["@build_bazel_rules_ios//patches:disable_index_while_building_v2.patch"],
+    patches = ["@//PATH_TO_DOWNLOADED_PATCH_FILE"],
 )
 ```
 

--- a/patches/disable_index_while_building_v2.patch
+++ b/patches/disable_index_while_building_v2.patch
@@ -1,0 +1,21 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+index ef1ec1c..77d5396 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -1,6 +1,7 @@
+ # Pull buildifer.mac as an http_file, then depend on the file group to make an
+ # executable
+-load("@build_bazel_rules_swift//swift/internal:feature_names.bzl", "SWIFT_FEATURE_INDEX_WHILE_BUILDING_V2")
++# Disabled until SWIFT_FEATURE_INDEX_WHILE_BUILDING_V2 is merged into rules_swift https://github.com/bazelbuild/rules_swift/pull/567
++# load("@build_bazel_rules_swift//swift/internal:feature_names.bzl", "SWIFT_FEATURE_INDEX_WHILE_BUILDING_V2")
+
+ sh_binary(
+     name = "buildifier",
+@@ -10,6 +11,6 @@ sh_binary(
+ config_setting(
+     name = "index_while_building_v2",
+     values = {
+-        "features": SWIFT_FEATURE_INDEX_WHILE_BUILDING_V2,
++        "features": "swift.FORCE_SWIFT_FEATURE_INDEX_WHILE_BUILDING_V2",
+     },
+ )


### PR DESCRIPTION
Adds a patch file and a note in the readme that allows developers to use
other versions of rules swift than
https://github.com/bazelbuild/rules_swift/pull/567.