### PR TITLE
Enable test action associations in schemes

### DIFF
--- a/rules/additional_scheme_info.bzl
+++ b/rules/additional_scheme_info.bzl
@@ -1,0 +1,54 @@
+""" A rule for adding additional information such as test targets and test environments to a generated scheme """
+
+load("@build_bazel_rules_apple//apple:providers.bzl", "AppleBundleInfo")
+
+AdditionalSchemeInfo = provider(
+    """
+    Information mapping the scheme for a build target with additional information
+    such as test targets to add to a test action.
+    """,
+    fields = {
+        "build_target": "The build target/scheme to add the additional scheme info to.",
+        "test_action_targets": "A list of test actions to add to the scheme for the scheme_build_target.",
+    },
+)
+
+def _additional_scheme_info_impl(ctx):
+    test_action_targets = [
+        struct(
+            name = test_target[AppleBundleInfo].bundle_name,
+            environment_variables = ctx.attr.test_environment,
+        )
+        for test_target in ctx.attr.test_action_targets
+    ]
+
+    return [
+        AdditionalSchemeInfo(
+            build_target = ctx.attr.build_target[AppleBundleInfo].bundle_name,
+            test_action_targets = test_action_targets,
+        ),
+    ]
+
+additional_scheme_info = rule(
+    implementation = _additional_scheme_info_impl,
+    doc = "Pairs a build target with one or more test targets. Returns list of AdditionalSchemeInfo.",
+    attrs = {
+        "build_target": attr.label(
+            mandatory = True,
+            doc = "The build target to attach the additional scheme info to.",
+            providers = [AppleBundleInfo],
+        ),
+        "test_action_targets": attr.label_list(
+            mandatory = False,
+            doc = "A list of test targets that should be appended to the build_target",
+            allow_empty = True,
+            providers = [AppleBundleInfo],
+        ),
+        "test_environment": attr.string_dict(
+            mandatory = False,
+            allow_empty = True,
+            doc = "Extra environment variables to pass during tests",
+            default = {},
+        ),
+    },
+)

--- a/rules/additional_scheme_info.bzl
+++ b/rules/additional_scheme_info.bzl
@@ -40,14 +40,17 @@ additional_scheme_info = rule(
         ),
         "test_action_targets": attr.label_list(
             mandatory = False,
-            doc = "A list of test targets that should be appended to the build_target",
+            doc = "A list of test targets that should be appended to the build_target.",
             allow_empty = True,
             providers = [AppleBundleInfo],
         ),
         "test_environment": attr.string_dict(
             mandatory = False,
             allow_empty = True,
-            doc = "Extra environment variables to pass during tests",
+            doc = """
+Extra environment variables to pass during tests. This will overwrite 
+any value provided in scheme_existing_envvar_overrides.
+            """,
             default = {},
         ),
     },

--- a/tests/ios/xcodeproj/BUILD.bazel
+++ b/tests/ios/xcodeproj/BUILD.bazel
@@ -1,8 +1,12 @@
 load("//rules:xcodeproj.bzl", "xcodeproj")
+load("//rules:additional_scheme_info.bzl", "additional_scheme_info")
 
 xcodeproj(
     name = "Single-Static-Framework-Project",
     testonly = True,
+    additional_scheme_infos = [
+        ":ObjcFrameworkSchemeInfo",
+    ],
     bazel_path = "bazelisk",
     # Not that 'configs' must hold names for configs present in your .bazelrc file
     # in order to build with the respective Xcode build configurations active
@@ -20,6 +24,19 @@ xcodeproj(
         "//tests/ios/frameworks/objc:ObjcFramework",
         "//tests/ios/frameworks/objc:ObjcFrameworkTests",
     ],
+)
+
+additional_scheme_info(
+    name = "ObjcFrameworkSchemeInfo",
+    testonly = True,
+    build_target = "//tests/ios/frameworks/objc:ObjcFramework",
+    test_action_targets = [
+        "//tests/ios/frameworks/objc:ObjcFrameworkTests",
+    ],
+    test_environment = {
+        "ENV1": "/tmp/dir",
+        "ENV2": "🍌",
+    },
 )
 
 xcodeproj(

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/xcshareddata/xcschemes/ObjcFramework.xcscheme
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/xcshareddata/xcschemes/ObjcFramework.xcscheme
@@ -27,8 +27,19 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       onlyGenerateCoverageForSpecifiedTargets = "NO"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "NO"
+      customLLDBInitFile = "$CONFIGURATION_TEMP_DIR/ObjcFramework.lldbinit">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BABD3C372AC007CE85F8D2A5"
+               BuildableName = "ObjcFrameworkTests.xctest"
+               BlueprintName = "ObjcFrameworkTests"
+               ReferencedContainer = "container:Single-Static-Framework-Project.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
@@ -39,6 +50,20 @@
             ReferencedContainer = "container:Single-Static-Framework-Project.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "ENV1"
+            value = "/tmp/dir"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "ENV2"
+            value = "🍌"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/tests/ios/xcodeproj/tests.sh
+++ b/tests/ios/xcodeproj/tests.sh
@@ -9,3 +9,7 @@ export PROJECT_AND_SCHEME="-project Single-Static-Framework-Project.xcodeproj -s
 export SIM_DEVICE_ID=$(xcodebuild $PROJECT_AND_SCHEME -showdestinations -destination "generic/platform=iOS Simulator" | grep "platform:iOS Sim" | head -1 | ruby -e "puts STDIN.read.split(',')[1].split(':').last")
 
 xcodebuild $PROJECT_AND_SCHEME -destination "id=$SIM_DEVICE_ID" -quiet test
+
+# Test running ObjcFrameworkTests using the ObjcFramework scheme
+export PROJECT_AND_NON_TEST_SCHEME="-project Single-Static-Framework-Project.xcodeproj -scheme ObjcFramework"
+xcodebuild $PROJECT_AND_NON_TEST_SCHEME -destination "id=$SIM_DEVICE_ID" -quiet test


### PR DESCRIPTION
A convention many projects utilize is to have test
targets run as a test action for a scheme where the build
target is not itself a test target, including the
default project generated in Xcode.

MyFramework <-- framework
MyFrameworkTests <-- bundle.unittests

This hopes to enable adding test targets and environment
variables to schemes created for any build target.