### PR TITLE
Fixes a frozen dict error in xcconfig logic

### DIFF
--- a/rules/library/xcconfig.bzl
+++ b/rules/library/xcconfig.bzl
@@ -278,7 +278,7 @@ def copts_by_build_setting_with_defaults(xcconfig = {}, fetch_default_xcconfig =
     Returns:
         Struct with different copts behind 'select()' statements
     """
-    xcconfig_with_defaults = xcconfig
+    xcconfig_with_defaults = dict(xcconfig)
 
     # Adding default values if necessary
     for (xc_build_setting, value) in fetch_default_xcconfig.items():


### PR DESCRIPTION
If we do not copy this array the user will see the following
error when they use `fetch_default_xcconfig`

```terminal
ERROR: Traceback (most recent call last):
        File “Something/BUILD", line 242, column 16, in <toplevel>
                apple_framework(
        File "/private/var/tmp/_bazel_maxwellelliott/db37ab0e01ac1d9a8e5ea282dd04a720/external/build_bazel_rules_ios/rules/framework.bzl", line 26, column 28, in apple_framework
                library = apple_library(name = name, **kwargs)
        File "/private/var/tmp/_bazel_maxwellelliott/db37ab0e01ac1d9a8e5ea282dd04a720/external/build_bazel_rules_ios/rules/library.bzl", line 401, column 66, in apple_library
                copts_by_build_setting = copts_by_build_setting_with_defaults(xcconfig, fetch_default_xcconfig, xcconfig_by_build_setting)
        File "/private/var/tmp/_bazel_maxwellelliott/db37ab0e01ac1d9a8e5ea282dd04a720/external/build_bazel_rules_ios/rules/library/xcconfig.bzl", line 286, column 54, in copts_by_build_setting_with_defaults
                xcconfig_with_defaults[xc_build_setting] = value
Error: trying to mutate a frozen dict value
```