### PR TITLE
Fix trailing doublequote in swiftmodule installer

### DIFF
--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Copy Bazel build `.swiftmodule` files to `DerivedData`. This is used by Xcode
 # and its indexing.
 echo "Start copying swiftmodules at `date`"
-FOUND_SWIFTMODULES=`grep -A 2 primary_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep "\.swiftmodule" | sed "s/uri: \"file:\/\///" || true`
+FOUND_SWIFTMODULES=`grep -A 2 primary_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep "\.swiftmodule" | sed -e "s/uri: \"file:\/\///" -e "s/\"\$//" || true`
 if [[ -z $FOUND_SWIFTMODULES ]]; then 
     echo "No swiftmodules found, finished at `date`"
     exit 0

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Copy Bazel build `.swiftmodule` files to `DerivedData`. This is used by Xcode
 # and its indexing.
 echo "Start copying swiftmodules at `date`"
-FOUND_SWIFTMODULES=`grep -A 2 primary_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep "\.swiftmodule" | sed "s/uri: \"file:\/\///" || true`
+FOUND_SWIFTMODULES=`grep -A 2 primary_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep "\.swiftmodule" | sed -e "s/uri: \"file:\/\///" -e "s/\"\$//" || true`
 if [[ -z $FOUND_SWIFTMODULES ]]; then 
     echo "No swiftmodules found, finished at `date`"
     exit 0

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Copy Bazel build `.swiftmodule` files to `DerivedData`. This is used by Xcode
 # and its indexing.
 echo "Start copying swiftmodules at `date`"
-FOUND_SWIFTMODULES=`grep -A 2 primary_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep "\.swiftmodule" | sed "s/uri: \"file:\/\///" || true`
+FOUND_SWIFTMODULES=`grep -A 2 primary_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep "\.swiftmodule" | sed -e "s/uri: \"file:\/\///" -e "s/\"\$//" || true`
 if [[ -z $FOUND_SWIFTMODULES ]]; then 
     echo "No swiftmodules found, finished at `date`"
     exit 0

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Copy Bazel build `.swiftmodule` files to `DerivedData`. This is used by Xcode
 # and its indexing.
 echo "Start copying swiftmodules at `date`"
-FOUND_SWIFTMODULES=`grep -A 2 primary_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep "\.swiftmodule" | sed "s/uri: \"file:\/\///" || true`
+FOUND_SWIFTMODULES=`grep -A 2 primary_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep "\.swiftmodule" | sed -e "s/uri: \"file:\/\///" -e "s/\"\$//" || true`
 if [[ -z $FOUND_SWIFTMODULES ]]; then 
     echo "No swiftmodules found, finished at `date`"
     exit 0

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Copy Bazel build `.swiftmodule` files to `DerivedData`. This is used by Xcode
 # and its indexing.
 echo "Start copying swiftmodules at `date`"
-FOUND_SWIFTMODULES=`grep -A 2 primary_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep "\.swiftmodule" | sed "s/uri: \"file:\/\///" || true`
+FOUND_SWIFTMODULES=`grep -A 2 primary_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep "\.swiftmodule" | sed -e "s/uri: \"file:\/\///" -e "s/\"\$//" || true`
 if [[ -z $FOUND_SWIFTMODULES ]]; then 
     echo "No swiftmodules found, finished at `date`"
     exit 0

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Copy Bazel build `.swiftmodule` files to `DerivedData`. This is used by Xcode
 # and its indexing.
 echo "Start copying swiftmodules at `date`"
-FOUND_SWIFTMODULES=`grep -A 2 primary_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep "\.swiftmodule" | sed "s/uri: \"file:\/\///" || true`
+FOUND_SWIFTMODULES=`grep -A 2 primary_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep "\.swiftmodule" | sed -e "s/uri: \"file:\/\///" -e "s/\"\$//" || true`
 if [[ -z $FOUND_SWIFTMODULES ]]; then 
     echo "No swiftmodules found, finished at `date`"
     exit 0

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Copy Bazel build `.swiftmodule` files to `DerivedData`. This is used by Xcode
 # and its indexing.
 echo "Start copying swiftmodules at `date`"
-FOUND_SWIFTMODULES=`grep -A 2 primary_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep "\.swiftmodule" | sed "s/uri: \"file:\/\///" || true`
+FOUND_SWIFTMODULES=`grep -A 2 primary_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep "\.swiftmodule" | sed -e "s/uri: \"file:\/\///" -e "s/\"\$//" || true`
 if [[ -z $FOUND_SWIFTMODULES ]]; then 
     echo "No swiftmodules found, finished at `date`"
     exit 0

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Copy Bazel build `.swiftmodule` files to `DerivedData`. This is used by Xcode
 # and its indexing.
 echo "Start copying swiftmodules at `date`"
-FOUND_SWIFTMODULES=`grep -A 2 primary_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep "\.swiftmodule" | sed "s/uri: \"file:\/\///" || true`
+FOUND_SWIFTMODULES=`grep -A 2 primary_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep "\.swiftmodule" | sed -e "s/uri: \"file:\/\///" -e "s/\"\$//" || true`
 if [[ -z $FOUND_SWIFTMODULES ]]; then 
     echo "No swiftmodules found, finished at `date`"
     exit 0

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Copy Bazel build `.swiftmodule` files to `DerivedData`. This is used by Xcode
 # and its indexing.
 echo "Start copying swiftmodules at `date`"
-FOUND_SWIFTMODULES=`grep -A 2 primary_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep "\.swiftmodule" | sed "s/uri: \"file:\/\///" || true`
+FOUND_SWIFTMODULES=`grep -A 2 primary_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep "\.swiftmodule" | sed -e "s/uri: \"file:\/\///" -e "s/\"\$//" || true`
 if [[ -z $FOUND_SWIFTMODULES ]]; then 
     echo "No swiftmodules found, finished at `date`"
     exit 0

--- a/tools/xcodeproj_shims/installers/swiftmodules.sh
+++ b/tools/xcodeproj_shims/installers/swiftmodules.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Copy Bazel build `.swiftmodule` files to `DerivedData`. This is used by Xcode
 # and its indexing.
 echo "Start copying swiftmodules at `date`"
-FOUND_SWIFTMODULES=`grep -A 2 primary_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep "\.swiftmodule" | sed "s/uri: \"file:\/\///" || true`
+FOUND_SWIFTMODULES=`grep -A 2 primary_output "$BAZEL_BUILD_EVENT_TEXT_FILENAME" | grep -w uri | grep "\.swiftmodule" | sed -e "s/uri: \"file:\/\///" -e "s/\"\$//" || true`
 if [[ -z $FOUND_SWIFTMODULES ]]; then 
     echo "No swiftmodules found, finished at `date`"
     exit 0


### PR DESCRIPTION
Small thing I noticed when debugging the diagnostics output while noticing swift modules never seemed to be found/copied.

```bash
Start copying swiftmodules at Mon Jun  7 11:47:49 CDT 2021
Found 0 existing SWIFTMODULES
No SWIFTMODULES found
Finish copying swiftmodules at Mon Jun  7 11:47:49 CDT 2021
```

This removes a trailing double-quote from the BEP parsing. 

i.e.
```
 /private/var/tmp/_bazel_ekerber/dd323d2a4ff53820c11ccc0d5aebe791/execroot/myapp/bazel-out/ios-x86_64-min12.2-applebin_ios-ios_x86_64-dbg-ST-fc18f8f88e01/bin/MyApp.swiftmodule"
```

Which would then fail the -f check in **_swiftmodules.sh**

With this change, swift modules are copied:

```
Start copying swiftmodules at Mon Jun  7 11:56:28 CDT 2021
Found 104 existing SWIFTMODULES
```