### PR TITLE
Copy dSYMs for Profile/Instruments support

### DIFF
--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/dsyms.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/dsyms.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Start copying dSYMs at `date`"
+
+# Typicaly dSYMs would only be copied when profiling (and are required by Instruments).
+# In this case, we aren't sure what confiuration is used for profiling,
+# so just copy them over if they exist.
+
+readonly dsym_input="bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}.dSYM"
+readonly dsym_output="$TARGET_BUILD_DIR"
+
+if [[ -z $dsym_input ]]; then
+  echo "No dsyms found, finished at `date`"
+  exit 0
+fi
+
+echo "Found ${#dsym_input[@]} DSYMS"
+
+rsync \
+  --recursive --chmod=u+w --delete -i \
+  "$dsym_input" "$dsym_output"
+
+echo "Finish copying dsyms at `date`"

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/install.sh
@@ -106,3 +106,4 @@ fi
 # which XCode will use for indexing. Let's keep those.
 "$BAZEL_INSTALLERS_DIR"/swiftmodules.sh >"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
 "$BAZEL_INSTALLERS_DIR"/indexstores.sh >"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/dsyms.sh >"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stderr-"$DATE_SUFFIX".log &

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/installer
@@ -106,3 +106,4 @@ fi
 # which XCode will use for indexing. Let's keep those.
 "$BAZEL_INSTALLERS_DIR"/swiftmodules.sh >"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
 "$BAZEL_INSTALLERS_DIR"/indexstores.sh >"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/dsyms.sh >"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stderr-"$DATE_SUFFIX".log &

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/dsyms.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/dsyms.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Start copying dSYMs at `date`"
+
+# Typicaly dSYMs would only be copied when profiling (and are required by Instruments).
+# In this case, we aren't sure what confiuration is used for profiling,
+# so just copy them over if they exist.
+
+readonly dsym_input="bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}.dSYM"
+readonly dsym_output="$TARGET_BUILD_DIR"
+
+if [[ -z $dsym_input ]]; then
+  echo "No dsyms found, finished at `date`"
+  exit 0
+fi
+
+echo "Found ${#dsym_input[@]} DSYMS"
+
+rsync \
+  --recursive --chmod=u+w --delete -i \
+  "$dsym_input" "$dsym_output"
+
+echo "Finish copying dsyms at `date`"

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/install.sh
@@ -106,3 +106,4 @@ fi
 # which XCode will use for indexing. Let's keep those.
 "$BAZEL_INSTALLERS_DIR"/swiftmodules.sh >"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
 "$BAZEL_INSTALLERS_DIR"/indexstores.sh >"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/dsyms.sh >"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stderr-"$DATE_SUFFIX".log &

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/installer
@@ -106,3 +106,4 @@ fi
 # which XCode will use for indexing. Let's keep those.
 "$BAZEL_INSTALLERS_DIR"/swiftmodules.sh >"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
 "$BAZEL_INSTALLERS_DIR"/indexstores.sh >"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/dsyms.sh >"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stderr-"$DATE_SUFFIX".log &

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/dsyms.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/dsyms.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Start copying dSYMs at `date`"
+
+# Typicaly dSYMs would only be copied when profiling (and are required by Instruments).
+# In this case, we aren't sure what confiuration is used for profiling,
+# so just copy them over if they exist.
+
+readonly dsym_input="bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}.dSYM"
+readonly dsym_output="$TARGET_BUILD_DIR"
+
+if [[ -z $dsym_input ]]; then
+  echo "No dsyms found, finished at `date`"
+  exit 0
+fi
+
+echo "Found ${#dsym_input[@]} DSYMS"
+
+rsync \
+  --recursive --chmod=u+w --delete -i \
+  "$dsym_input" "$dsym_output"
+
+echo "Finish copying dsyms at `date`"

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/install.sh
@@ -106,3 +106,4 @@ fi
 # which XCode will use for indexing. Let's keep those.
 "$BAZEL_INSTALLERS_DIR"/swiftmodules.sh >"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
 "$BAZEL_INSTALLERS_DIR"/indexstores.sh >"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/dsyms.sh >"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stderr-"$DATE_SUFFIX".log &

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/installer
@@ -106,3 +106,4 @@ fi
 # which XCode will use for indexing. Let's keep those.
 "$BAZEL_INSTALLERS_DIR"/swiftmodules.sh >"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
 "$BAZEL_INSTALLERS_DIR"/indexstores.sh >"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/dsyms.sh >"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stderr-"$DATE_SUFFIX".log &

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/dsyms.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/dsyms.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Start copying dSYMs at `date`"
+
+# Typicaly dSYMs would only be copied when profiling (and are required by Instruments).
+# In this case, we aren't sure what confiuration is used for profiling,
+# so just copy them over if they exist.
+
+readonly dsym_input="bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}.dSYM"
+readonly dsym_output="$TARGET_BUILD_DIR"
+
+if [[ -z $dsym_input ]]; then
+  echo "No dsyms found, finished at `date`"
+  exit 0
+fi
+
+echo "Found ${#dsym_input[@]} DSYMS"
+
+rsync \
+  --recursive --chmod=u+w --delete -i \
+  "$dsym_input" "$dsym_output"
+
+echo "Finish copying dsyms at `date`"

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/install.sh
@@ -106,3 +106,4 @@ fi
 # which XCode will use for indexing. Let's keep those.
 "$BAZEL_INSTALLERS_DIR"/swiftmodules.sh >"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
 "$BAZEL_INSTALLERS_DIR"/indexstores.sh >"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/dsyms.sh >"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stderr-"$DATE_SUFFIX".log &

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/installer
@@ -106,3 +106,4 @@ fi
 # which XCode will use for indexing. Let's keep those.
 "$BAZEL_INSTALLERS_DIR"/swiftmodules.sh >"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
 "$BAZEL_INSTALLERS_DIR"/indexstores.sh >"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/dsyms.sh >"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stderr-"$DATE_SUFFIX".log &

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/dsyms.sh
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/dsyms.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Start copying dSYMs at `date`"
+
+# Typicaly dSYMs would only be copied when profiling (and are required by Instruments).
+# In this case, we aren't sure what confiuration is used for profiling,
+# so just copy them over if they exist.
+
+readonly dsym_input="bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}.dSYM"
+readonly dsym_output="$TARGET_BUILD_DIR"
+
+if [[ -z $dsym_input ]]; then
+  echo "No dsyms found, finished at `date`"
+  exit 0
+fi
+
+echo "Found ${#dsym_input[@]} DSYMS"
+
+rsync \
+  --recursive --chmod=u+w --delete -i \
+  "$dsym_input" "$dsym_output"
+
+echo "Finish copying dsyms at `date`"

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/install.sh
@@ -106,3 +106,4 @@ fi
 # which XCode will use for indexing. Let's keep those.
 "$BAZEL_INSTALLERS_DIR"/swiftmodules.sh >"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
 "$BAZEL_INSTALLERS_DIR"/indexstores.sh >"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/dsyms.sh >"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stderr-"$DATE_SUFFIX".log &

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/installer
@@ -106,3 +106,4 @@ fi
 # which XCode will use for indexing. Let's keep those.
 "$BAZEL_INSTALLERS_DIR"/swiftmodules.sh >"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
 "$BAZEL_INSTALLERS_DIR"/indexstores.sh >"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/dsyms.sh >"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stderr-"$DATE_SUFFIX".log &

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/dsyms.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/dsyms.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Start copying dSYMs at `date`"
+
+# Typicaly dSYMs would only be copied when profiling (and are required by Instruments).
+# In this case, we aren't sure what confiuration is used for profiling,
+# so just copy them over if they exist.
+
+readonly dsym_input="bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}.dSYM"
+readonly dsym_output="$TARGET_BUILD_DIR"
+
+if [[ -z $dsym_input ]]; then
+  echo "No dsyms found, finished at `date`"
+  exit 0
+fi
+
+echo "Found ${#dsym_input[@]} DSYMS"
+
+rsync \
+  --recursive --chmod=u+w --delete -i \
+  "$dsym_input" "$dsym_output"
+
+echo "Finish copying dsyms at `date`"

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/install.sh
@@ -106,3 +106,4 @@ fi
 # which XCode will use for indexing. Let's keep those.
 "$BAZEL_INSTALLERS_DIR"/swiftmodules.sh >"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
 "$BAZEL_INSTALLERS_DIR"/indexstores.sh >"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/dsyms.sh >"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stderr-"$DATE_SUFFIX".log &

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/installer
@@ -106,3 +106,4 @@ fi
 # which XCode will use for indexing. Let's keep those.
 "$BAZEL_INSTALLERS_DIR"/swiftmodules.sh >"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
 "$BAZEL_INSTALLERS_DIR"/indexstores.sh >"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/dsyms.sh >"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stderr-"$DATE_SUFFIX".log &

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/dsyms.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/dsyms.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Start copying dSYMs at `date`"
+
+# Typicaly dSYMs would only be copied when profiling (and are required by Instruments).
+# In this case, we aren't sure what confiuration is used for profiling,
+# so just copy them over if they exist.
+
+readonly dsym_input="bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}.dSYM"
+readonly dsym_output="$TARGET_BUILD_DIR"
+
+if [[ -z $dsym_input ]]; then
+  echo "No dsyms found, finished at `date`"
+  exit 0
+fi
+
+echo "Found ${#dsym_input[@]} DSYMS"
+
+rsync \
+  --recursive --chmod=u+w --delete -i \
+  "$dsym_input" "$dsym_output"
+
+echo "Finish copying dsyms at `date`"

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/install.sh
@@ -106,3 +106,4 @@ fi
 # which XCode will use for indexing. Let's keep those.
 "$BAZEL_INSTALLERS_DIR"/swiftmodules.sh >"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
 "$BAZEL_INSTALLERS_DIR"/indexstores.sh >"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/dsyms.sh >"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stderr-"$DATE_SUFFIX".log &

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/installer
@@ -106,3 +106,4 @@ fi
 # which XCode will use for indexing. Let's keep those.
 "$BAZEL_INSTALLERS_DIR"/swiftmodules.sh >"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
 "$BAZEL_INSTALLERS_DIR"/indexstores.sh >"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/dsyms.sh >"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stderr-"$DATE_SUFFIX".log &

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/dsyms.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/dsyms.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Start copying dSYMs at `date`"
+
+# Typicaly dSYMs would only be copied when profiling (and are required by Instruments).
+# In this case, we aren't sure what confiuration is used for profiling,
+# so just copy them over if they exist.
+
+readonly dsym_input="bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}.dSYM"
+readonly dsym_output="$TARGET_BUILD_DIR"
+
+if [[ -z $dsym_input ]]; then
+  echo "No dsyms found, finished at `date`"
+  exit 0
+fi
+
+echo "Found ${#dsym_input[@]} DSYMS"
+
+rsync \
+  --recursive --chmod=u+w --delete -i \
+  "$dsym_input" "$dsym_output"
+
+echo "Finish copying dsyms at `date`"

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/install.sh
@@ -106,3 +106,4 @@ fi
 # which XCode will use for indexing. Let's keep those.
 "$BAZEL_INSTALLERS_DIR"/swiftmodules.sh >"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
 "$BAZEL_INSTALLERS_DIR"/indexstores.sh >"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/dsyms.sh >"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stderr-"$DATE_SUFFIX".log &

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/installer
@@ -106,3 +106,4 @@ fi
 # which XCode will use for indexing. Let's keep those.
 "$BAZEL_INSTALLERS_DIR"/swiftmodules.sh >"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
 "$BAZEL_INSTALLERS_DIR"/indexstores.sh >"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/dsyms.sh >"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stderr-"$DATE_SUFFIX".log &

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/dsyms.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/dsyms.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Start copying dSYMs at `date`"
+
+# Typicaly dSYMs would only be copied when profiling (and are required by Instruments).
+# In this case, we aren't sure what confiuration is used for profiling,
+# so just copy them over if they exist.
+
+readonly dsym_input="bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}.dSYM"
+readonly dsym_output="$TARGET_BUILD_DIR"
+
+if [[ -z $dsym_input ]]; then
+  echo "No dsyms found, finished at `date`"
+  exit 0
+fi
+
+echo "Found ${#dsym_input[@]} DSYMS"
+
+rsync \
+  --recursive --chmod=u+w --delete -i \
+  "$dsym_input" "$dsym_output"
+
+echo "Finish copying dsyms at `date`"

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/install.sh
@@ -106,3 +106,4 @@ fi
 # which XCode will use for indexing. Let's keep those.
 "$BAZEL_INSTALLERS_DIR"/swiftmodules.sh >"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
 "$BAZEL_INSTALLERS_DIR"/indexstores.sh >"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/dsyms.sh >"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stderr-"$DATE_SUFFIX".log &

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/installer
@@ -106,3 +106,4 @@ fi
 # which XCode will use for indexing. Let's keep those.
 "$BAZEL_INSTALLERS_DIR"/swiftmodules.sh >"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
 "$BAZEL_INSTALLERS_DIR"/indexstores.sh >"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/dsyms.sh >"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stderr-"$DATE_SUFFIX".log &

--- a/tools/xcodeproj_shims/install.sh
+++ b/tools/xcodeproj_shims/install.sh
@@ -106,3 +106,4 @@ fi
 # which XCode will use for indexing. Let's keep those.
 "$BAZEL_INSTALLERS_DIR"/swiftmodules.sh >"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/swiftmodules-stderr-"$DATE_SUFFIX".log &
 "$BAZEL_INSTALLERS_DIR"/indexstores.sh >"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/indexstores-stderr-"$DATE_SUFFIX".log &
+"$BAZEL_INSTALLERS_DIR"/dsyms.sh >"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/dsyms-stderr-"$DATE_SUFFIX".log &

--- a/tools/xcodeproj_shims/installers/dsyms.sh
+++ b/tools/xcodeproj_shims/installers/dsyms.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Start copying dSYMs at `date`"
+
+# Typicaly dSYMs would only be copied when profiling (and are required by Instruments).
+# In this case, we aren't sure what confiuration is used for profiling,
+# so just copy them over if they exist.
+
+readonly dsym_input="bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}.dSYM"
+readonly dsym_output="$TARGET_BUILD_DIR"
+
+if [[ -z $dsym_input ]]; then
+  echo "No dsyms found, finished at `date`"
+  exit 0
+fi
+
+echo "Found ${#dsym_input[@]} DSYMS"
+
+rsync \
+  --recursive --chmod=u+w --delete -i \
+  "$dsym_input" "$dsym_output"
+
+echo "Finish copying dsyms at `date`"

--- a/tools/xcodeproj_shims/installers/dsyms.sh
+++ b/tools/xcodeproj_shims/installers/dsyms.sh
@@ -8,7 +8,7 @@ echo "Start copying dSYMs at `date`"
 # In this case, we aren't sure what confiuration is used for profiling,
 # so just copy them over if they exist.
 
-readonly dsym_input="bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}.dSYM"
+readonly dsym_input=`find bazel-bin/$BAZEL_BIN_SUBDIR/ -name "*.dSYM"`
 readonly dsym_output="$TARGET_BUILD_DIR"
 
 if [[ -z $dsym_input ]]; then


### PR DESCRIPTION
Context via iOS-dev-at-scale: https://ios-dev-at-scale.slack.com/archives/CRPRV58UF/p1622743928003000

`xcodeproj/rules_ios` won't copy generated dSYM artifacts to derived data, which are used by Instruments to symbolicate various profiling tools.

This adds a straight-forward find/rsync strategy that will move any dsyms, if they exist, over to Derived Data. For this to have any effect, the user will have to use a build configuration that _generates_ dsyms

i.e.
```
build:xcode_profile --compilation_mode=opt
build:xcode_profile --apple_generate_dsym
```

With this approach, I did not use the same BEP/grep approach used in swiftmodules.sh and indexstores.sh. I found that it created a problem if the app was built outside of Xcode as not all artifacts would appear in the BEP file on all builds – but would love to discuss with somebody if there is something I'm missing.