### PR TITLE
Pass HEADER_SEARCH_PATHS to LLDB

### DIFF
--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -46,6 +46,23 @@ for fsp in $FRAMEWORK_SEARCH_PATHS; do
     LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
   fi
 done
+# So LLDB is aware of all headers that are not visible
+# from $FRAMEWORK_SEARCH_PATHS above
+#
+# Fox example, test hosts that depend on objc -> swift
+# bridging headers that only exists in .hmap files
+for hdr in $HEADER_SEARCH_PATHS; do
+  # We don't want LLDB so look for things under DerivedData
+  # given the fact that all relevant paths are being created
+  # under 'bazel-out'
+  if [[ "$hdr" != *"$BUILT_PRODUCTS_DIR"* ]]
+  then
+    # Note that these paths will come quoted
+    # and with the Xcode env vars already resolved
+    # so we can just pass them without any modification
+    LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -I$hdr")
+  fi
+done
 # If on the `Debug` config append
 # the `-D DEBUG` flag so the debugger
 # works properly

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -46,6 +46,23 @@ for fsp in $FRAMEWORK_SEARCH_PATHS; do
     LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
   fi
 done
+# So LLDB is aware of all headers that are not visible
+# from $FRAMEWORK_SEARCH_PATHS above
+#
+# Fox example, test hosts that depend on objc -> swift
+# bridging headers that only exists in .hmap files
+for hdr in $HEADER_SEARCH_PATHS; do
+  # We don't want LLDB so look for things under DerivedData
+  # given the fact that all relevant paths are being created
+  # under 'bazel-out'
+  if [[ "$hdr" != *"$BUILT_PRODUCTS_DIR"* ]]
+  then
+    # Note that these paths will come quoted
+    # and with the Xcode env vars already resolved
+    # so we can just pass them without any modification
+    LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -I$hdr")
+  fi
+done
 # If on the `Debug` config append
 # the `-D DEBUG` flag so the debugger
 # works properly

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -46,6 +46,23 @@ for fsp in $FRAMEWORK_SEARCH_PATHS; do
     LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
   fi
 done
+# So LLDB is aware of all headers that are not visible
+# from $FRAMEWORK_SEARCH_PATHS above
+#
+# Fox example, test hosts that depend on objc -> swift
+# bridging headers that only exists in .hmap files
+for hdr in $HEADER_SEARCH_PATHS; do
+  # We don't want LLDB so look for things under DerivedData
+  # given the fact that all relevant paths are being created
+  # under 'bazel-out'
+  if [[ "$hdr" != *"$BUILT_PRODUCTS_DIR"* ]]
+  then
+    # Note that these paths will come quoted
+    # and with the Xcode env vars already resolved
+    # so we can just pass them without any modification
+    LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -I$hdr")
+  fi
+done
 # If on the `Debug` config append
 # the `-D DEBUG` flag so the debugger
 # works properly

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -46,6 +46,23 @@ for fsp in $FRAMEWORK_SEARCH_PATHS; do
     LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
   fi
 done
+# So LLDB is aware of all headers that are not visible
+# from $FRAMEWORK_SEARCH_PATHS above
+#
+# Fox example, test hosts that depend on objc -> swift
+# bridging headers that only exists in .hmap files
+for hdr in $HEADER_SEARCH_PATHS; do
+  # We don't want LLDB so look for things under DerivedData
+  # given the fact that all relevant paths are being created
+  # under 'bazel-out'
+  if [[ "$hdr" != *"$BUILT_PRODUCTS_DIR"* ]]
+  then
+    # Note that these paths will come quoted
+    # and with the Xcode env vars already resolved
+    # so we can just pass them without any modification
+    LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -I$hdr")
+  fi
+done
 # If on the `Debug` config append
 # the `-D DEBUG` flag so the debugger
 # works properly

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -46,6 +46,23 @@ for fsp in $FRAMEWORK_SEARCH_PATHS; do
     LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
   fi
 done
+# So LLDB is aware of all headers that are not visible
+# from $FRAMEWORK_SEARCH_PATHS above
+#
+# Fox example, test hosts that depend on objc -> swift
+# bridging headers that only exists in .hmap files
+for hdr in $HEADER_SEARCH_PATHS; do
+  # We don't want LLDB so look for things under DerivedData
+  # given the fact that all relevant paths are being created
+  # under 'bazel-out'
+  if [[ "$hdr" != *"$BUILT_PRODUCTS_DIR"* ]]
+  then
+    # Note that these paths will come quoted
+    # and with the Xcode env vars already resolved
+    # so we can just pass them without any modification
+    LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -I$hdr")
+  fi
+done
 # If on the `Debug` config append
 # the `-D DEBUG` flag so the debugger
 # works properly

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -46,6 +46,23 @@ for fsp in $FRAMEWORK_SEARCH_PATHS; do
     LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
   fi
 done
+# So LLDB is aware of all headers that are not visible
+# from $FRAMEWORK_SEARCH_PATHS above
+#
+# Fox example, test hosts that depend on objc -> swift
+# bridging headers that only exists in .hmap files
+for hdr in $HEADER_SEARCH_PATHS; do
+  # We don't want LLDB so look for things under DerivedData
+  # given the fact that all relevant paths are being created
+  # under 'bazel-out'
+  if [[ "$hdr" != *"$BUILT_PRODUCTS_DIR"* ]]
+  then
+    # Note that these paths will come quoted
+    # and with the Xcode env vars already resolved
+    # so we can just pass them without any modification
+    LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -I$hdr")
+  fi
+done
 # If on the `Debug` config append
 # the `-D DEBUG` flag so the debugger
 # works properly

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -46,6 +46,23 @@ for fsp in $FRAMEWORK_SEARCH_PATHS; do
     LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
   fi
 done
+# So LLDB is aware of all headers that are not visible
+# from $FRAMEWORK_SEARCH_PATHS above
+#
+# Fox example, test hosts that depend on objc -> swift
+# bridging headers that only exists in .hmap files
+for hdr in $HEADER_SEARCH_PATHS; do
+  # We don't want LLDB so look for things under DerivedData
+  # given the fact that all relevant paths are being created
+  # under 'bazel-out'
+  if [[ "$hdr" != *"$BUILT_PRODUCTS_DIR"* ]]
+  then
+    # Note that these paths will come quoted
+    # and with the Xcode env vars already resolved
+    # so we can just pass them without any modification
+    LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -I$hdr")
+  fi
+done
 # If on the `Debug` config append
 # the `-D DEBUG` flag so the debugger
 # works properly

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -46,6 +46,23 @@ for fsp in $FRAMEWORK_SEARCH_PATHS; do
     LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
   fi
 done
+# So LLDB is aware of all headers that are not visible
+# from $FRAMEWORK_SEARCH_PATHS above
+#
+# Fox example, test hosts that depend on objc -> swift
+# bridging headers that only exists in .hmap files
+for hdr in $HEADER_SEARCH_PATHS; do
+  # We don't want LLDB so look for things under DerivedData
+  # given the fact that all relevant paths are being created
+  # under 'bazel-out'
+  if [[ "$hdr" != *"$BUILT_PRODUCTS_DIR"* ]]
+  then
+    # Note that these paths will come quoted
+    # and with the Xcode env vars already resolved
+    # so we can just pass them without any modification
+    LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -I$hdr")
+  fi
+done
 # If on the `Debug` config append
 # the `-D DEBUG` flag so the debugger
 # works properly

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -46,6 +46,23 @@ for fsp in $FRAMEWORK_SEARCH_PATHS; do
     LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
   fi
 done
+# So LLDB is aware of all headers that are not visible
+# from $FRAMEWORK_SEARCH_PATHS above
+#
+# Fox example, test hosts that depend on objc -> swift
+# bridging headers that only exists in .hmap files
+for hdr in $HEADER_SEARCH_PATHS; do
+  # We don't want LLDB so look for things under DerivedData
+  # given the fact that all relevant paths are being created
+  # under 'bazel-out'
+  if [[ "$hdr" != *"$BUILT_PRODUCTS_DIR"* ]]
+  then
+    # Note that these paths will come quoted
+    # and with the Xcode env vars already resolved
+    # so we can just pass them without any modification
+    LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -I$hdr")
+  fi
+done
 # If on the `Debug` config append
 # the `-D DEBUG` flag so the debugger
 # works properly

--- a/tools/xcodeproj_shims/installers/lldb-settings.sh
+++ b/tools/xcodeproj_shims/installers/lldb-settings.sh
@@ -46,6 +46,23 @@ for fsp in $FRAMEWORK_SEARCH_PATHS; do
     LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -F$fsp")
   fi
 done
+# So LLDB is aware of all headers that are not visible
+# from $FRAMEWORK_SEARCH_PATHS above
+#
+# Fox example, test hosts that depend on objc -> swift
+# bridging headers that only exists in .hmap files
+for hdr in $HEADER_SEARCH_PATHS; do
+  # We don't want LLDB so look for things under DerivedData
+  # given the fact that all relevant paths are being created
+  # under 'bazel-out'
+  if [[ "$hdr" != *"$BUILT_PRODUCTS_DIR"* ]]
+  then
+    # Note that these paths will come quoted
+    # and with the Xcode env vars already resolved
+    # so we can just pass them without any modification
+    LLDB_SWIFT_EXTRA_CLANG_FLAGS+=(" -I$hdr")
+  fi
+done
 # If on the `Debug` config append
 # the `-D DEBUG` flag so the debugger
 # works properly


### PR DESCRIPTION
Can be seen as a continuation of https://github.com/bazel-ios/rules_ios/pull/213

Realized that we also need to include the `HEADER_SEARCH_PATHS` otherwise LLDB won't find the `.hmap` files created in `rules_ios`.

One use case that is broken because of this is debugging a `.swift` file in a test host app that depends on a bridging header (`SWIFT_OBJC_BRIDGING_HEADER ` Xcode setting) and that is `#import`-ing some other headers. Those headers will be added to an `.hmap` file and linked in Xcode's `HEADER_SEARCH_PATHS` setting but as of now LLDB is not aware of it.