### PR TITLE
Allow test_host_app app rules to receive custom attributes

### DIFF
--- a/rules/test_host_app/BUILD.bazel
+++ b/rules/test_host_app/BUILD.bazel
@@ -4,6 +4,7 @@ exports_files([
     "Info.plist",
     "ios.entitlements",
     "LaunchScreen.storyboard",
+    "main.m",
 ])
 
 generate_test_host_apps()

--- a/rules/test_host_app/BUILD.bazel
+++ b/rules/test_host_app/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//rules:app.bzl", "ios_application")
+load("//rules/test_host_app:test_host_app.bzl", "generate_test_host_apps")
 
 exports_files([
     "Info.plist",
@@ -6,33 +6,4 @@ exports_files([
     "LaunchScreen.storyboard",
 ])
 
-[
-    ios_application(
-        name = "iOS-{}-AppHost".format(version),
-        srcs = ["main.m"],
-        bundle_id = "com.example.ios-app-host-{}".format(version),
-        entitlements = "ios.entitlements",
-        families = [
-            "iphone",
-            "ipad",
-        ],
-        launch_storyboard = "LaunchScreen.storyboard",
-        minimum_os_version = version,
-        visibility = ["//visibility:public"],
-    )
-    for version in [
-        "9.3",
-        "10.0",
-        "11.0",
-        "12.0",
-        "12.2",
-        "12.4",
-        "13.0",
-        "13.2",
-        "13.6",
-        "14.0",
-        "14.1",
-        "14.2",
-        "14.3",
-    ]
-]
+generate_test_host_apps()

--- a/rules/test_host_app/test_host_app.bzl
+++ b/rules/test_host_app/test_host_app.bzl
@@ -1,0 +1,40 @@
+"""
+Generates test host ios_application targets for each supported version
+
+A consumer of `rules_ios` can optionally load the `generate_test_host_apps` symbol
+and pass in additional attributes to be set in all `ios_application` rules
+"""
+
+load("//rules:app.bzl", "ios_application")
+
+def generate_test_host_apps(**kwargs):
+    versions = [
+        "9.3",
+        "10.0",
+        "11.0",
+        "12.0",
+        "12.2",
+        "12.4",
+        "13.0",
+        "13.2",
+        "13.6",
+        "14.0",
+        "14.1",
+        "14.2",
+        "14.3",
+    ]
+    for version in versions:
+        ios_application(
+            name = "iOS-{}-AppHost".format(version),
+            srcs = ["main.m"],
+            bundle_id = "com.example.ios-app-host-{}".format(version),
+            entitlements = "ios.entitlements",
+            families = [
+                "iphone",
+                "ipad",
+            ],
+            launch_storyboard = "LaunchScreen.storyboard",
+            minimum_os_version = version,
+            visibility = ["//visibility:public"],
+            **kwargs
+        )

--- a/rules/test_host_app/test_host_app.bzl
+++ b/rules/test_host_app/test_host_app.bzl
@@ -26,14 +26,14 @@ def generate_test_host_apps(**kwargs):
     for version in versions:
         ios_application(
             name = "iOS-{}-AppHost".format(version),
-            srcs = ["main.m"],
+            srcs = ["@build_bazel_rules_ios//rules/test_host_app:main.m"],
             bundle_id = "com.example.ios-app-host-{}".format(version),
-            entitlements = "ios.entitlements",
+            entitlements = "@build_bazel_rules_ios//rules/test_host_app:ios.entitlements",
             families = [
                 "iphone",
                 "ipad",
             ],
-            launch_storyboard = "LaunchScreen.storyboard",
+            launch_storyboard = "@build_bazel_rules_ios//rules/test_host_app:LaunchScreen.storyboard",
             minimum_os_version = version,
             visibility = ["//visibility:public"],
             **kwargs


### PR DESCRIPTION
So a consumer of `rules_ios` can optionally initialize the default test host apps with additional attributes.

One example of a use case enabled by this PR is wanting to `bazel run` a [xcodeproj](https://github.com/bazel-ios/rules_ios/blob/master/rules/xcodeproj.bzl#L857) target with the `--ios_multi_cpus=arm64` flag set so the generated Xcode project has `arm64` paths under `bazel-out` for `HEADER_SEARCH_PATHS` and `FRAMEWORK_SEARCH_PATHS` [allowing one to debug .swift sources in mixed projects on device](https://github.com/bazel-ios/rules_ios/blob/master/tools/xcodeproj_shims/installers/lldb-settings.sh#L37-L55).

At this time the above is not possible because `--ios_multi_cpus=arm64` requires a `provisioning_profile` attribute in `ios_application` so it's not possible to use the current default test host apps for that since it would throw an error re missing `provisioning_profile` attribute. 

The changes in this PR allow a consumer to load the `generate_test_host_apps` symbol and pass in additional attributes without losing all the existing configuration in `rules_ios`.