### PR TITLE
Wrap ios_application dependencies in framework

### DIFF
--- a/tests/ios/app/BUILD.bazel
+++ b/tests/ios/app/BUILD.bazel
@@ -52,6 +52,7 @@ ios_application(
     srcs = ["App/main.m"],
     bundle_id = "com.example.app",
     minimum_os_version = "10.0",
+    use_apple_framework = True,
     visibility = ["//visibility:public"],
     deps = [
         ":FW",


### PR DESCRIPTION
Currently when using this rule set with an application organized around
`apple_framework_packaging` the rules_ios transition is missing from the
app sources. Source files picked up in the `ios_application`a globs are
sent through `apple_library`. This defaults to wrapping the code
apple_framework_packaging to apply the transition.

Alternatives considered: it may be ideal to just remove the "library"
feature from this macro to simplify the implementation and eliminate the
need to partition out kwargs. That may be ideal longer term but will
require changes in other repos.