### PR TITLE
Bumps rules_apple and rules_swift

### DIFF
--- a/rules/precompiled_apple_resource_bundle.bzl
+++ b/rules/precompiled_apple_resource_bundle.bzl
@@ -12,6 +12,7 @@ load("@build_bazel_rules_apple//apple/internal:apple_product_type.bzl", "apple_p
 load("@build_bazel_rules_apple//apple/internal:intermediates.bzl", "intermediates")
 load("@build_bazel_rules_apple//apple/internal:partials.bzl", "partials")
 load("@build_bazel_rules_apple//apple/internal:platform_support.bzl", "platform_support")
+load("@build_bazel_rules_apple//apple/internal:resources.bzl", "resources")
 load("@build_bazel_rules_apple//apple/internal:resource_actions.bzl", "resource_actions")
 load("@build_bazel_rules_apple//apple/internal:rule_factory.bzl", "rule_factory")
 load("//rules:transition_support.bzl", "transition_support")
@@ -73,14 +74,22 @@ def _precompiled_apple_resource_bundle_impl(ctx):
             product_type = _FAKE_BUNDLE_PRODUCT_TYPE_BY_PLATFORM_TYPE.get(platform_type, ctx.attr._product_type),
         ),
         rule_label = fake_rule_label,
+        version = None,
     )
 
     apple_toolchain_info = ctx.attr._toolchain[AppleSupportToolchainInfo]
     partial_output = partial.call(
         partials.resources_partial(
-            rule_attrs = ctx.attr,
-            top_level_attrs = ["resources"],
             apple_toolchain_info = apple_toolchain_info,
+            resource_deps = ctx.attr.resources,
+            top_level_infoplists = resources.collect(
+                attr = ctx.attr,
+                res_attrs = ["infoplists"],
+            ),
+            top_level_resources = resources.collect(
+                attr = ctx.attr,
+                res_attrs = ["resources"],
+            ),
             **partials_args
         ),
     )
@@ -98,7 +107,6 @@ def _precompiled_apple_resource_bundle_impl(ctx):
         output_pkginfo = None,
         output_plist = output_plist,
         resolved_plisttool = apple_toolchain_info.resolved_plisttool,
-        version = None,
         **partials_args
     )
 

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -47,23 +47,10 @@ def rules_ios_dependencies():
     _maybe(
         github_repo,
         name = "build_bazel_rules_apple",
-        ref = "fe15e1cc5cd47708d76c8cfe77fbddd0371b3166",
+        ref = "c99b0fd9f58a75ecc5324b073bc1e901d9e0e55b",
         project = "bazelbuild",
         repo = "rules_apple",
-        sha256 = "6d6ad776b9b161ec099b61577bd9cbc4d975fbba04537ae603903609bf54c23b",
-    )
-
-    # Note: this omits recent refactoring as it has broken rules_apple.
-    # someone needs to go in and handle the integration work there.
-    # see thread here https://github.com/bazelbuild/rules_swift/pull/646
-    # running on the tag: rules-ios/4.1.0
-    _maybe(
-        github_repo,
-        name = "build_bazel_rules_swift",
-        ref = "093299e8f5c7aecd2e4d7689327648690d38ca54",
-        project = "bazel-ios",
-        repo = "rules_swift",
-        sha256 = "df806dfdffd0447841a550fff5355be750837ea1b402c8be828afbf0ef89fc47",
+        sha256 = "7ab9af8529aea6d347b136140132d558ee164eb62367637f568321a941b0ddba",
     )
 
     _maybe(


### PR DESCRIPTION
Pickes the fix for propagating swift linker flags in rules_apple: https://github.com/bazelbuild/rules_apple/pull/1186/files
Removes the rules_swift override since the global index store cache is in 0.23.0 now.