### PR TITLE
Add ability to specify pre/post actions for build/run/...

### DIFF
--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -683,12 +683,10 @@ def _add_pre_post_actions(target_name, scheme, key, actions):
         scheme: target scheme to update for
         key: one of preActions or postActions
         actions: original attribute passed in from ctx.attr.additional_pre_actions or ctx.attr.additional_post_actions
-    Returns:
-        nothing, scheme will be updated a the end
     """
-    supproted_keys = ["preActions", "postActions"]
-    if key not in supproted_keys:
-        fail("Key must be one of %s" % supproted_keys)
+    supported_keys = ["preActions", "postActions"]
+    if key not in supported_keys:
+        fail("Key must be one of %s" % supported_keys)
     for action_type in actions:
         if action_type not in scheme:
             break
@@ -939,8 +937,16 @@ https://www.rubydoc.info/github/CocoaPods/Xcodeproj/Xcodeproj/Constants
         "additional_files": attr.label_list(allow_files = True, allow_empty = True, default = [], mandatory = False),
         "additional_prebuild_script": attr.string(default = "", mandatory = False),  # Note this script will run BEFORE Bazel build script
         "additional_bazel_build_options": attr.string_list(default = [], mandatory = False),
-        "additional_pre_actions": attr.string_list_dict(default = {}, mandatory = False, doc = "Configure a list of pre-actions for build/run etc. For each entry the key is one of build/test/run and value is a list of scripts"),
-        "additional_post_actions": attr.string_list_dict(default = {}, mandatory = False, doc = "Configure a list of post-actions, see additional_pre_actions for details"),
+        "additional_pre_actions": attr.string_list_dict(default = {}, mandatory = False, doc = """
+Configure a list of pre-actions for build/run/test in each scheme generated. 
+For each entry the key is one of build/test/run and value is a list of scripts.
+And it will not surface any error or output through build log.
+        """),
+        "additional_post_actions": attr.string_list_dict(default = {}, mandatory = False, doc = """
+Configure a list of post-actions for build/run/test in each scheme generated. 
+For each entry the key is one of build/test/run and value is a list of scripts.
+And it will not surface any error or output through build log.
+        """),
         "bazel_execution_log_enabled": attr.bool(default = False, mandatory = False),
         "bazel_profile_enabled": attr.bool(default = False, mandatory = False),
     },

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -670,15 +670,16 @@ def _populate_xcodeproj_targets_and_schemes(ctx, targets, src_dot_dots, all_tran
             }
 
         pre_actions_attr = ctx.attr.additional_pre_actions
-        _add_pre_post_actions(xcodeproj_schemes_by_name[target_name], "preActions", pre_actions_attr)
+        _add_pre_post_actions(target_name, xcodeproj_schemes_by_name[target_name], "preActions", pre_actions_attr)
         post_actions_attr = ctx.attr.additional_post_actions
-        _add_pre_post_actions(xcodeproj_schemes_by_name[target_name], "postActions", post_actions_attr)
+        _add_pre_post_actions(target_name, xcodeproj_schemes_by_name[target_name], "postActions", post_actions_attr)
     return (xcodeproj_targets_by_name, xcodeproj_schemes_by_name)
 
-def _add_pre_post_actions(scheme, key, actions):
+def _add_pre_post_actions(target_name, scheme, key, actions):
     """Helper method to populate passed in scheme with pre/post actions. Note their output won't show up in build log.
 
     Args:
+        target_name: Target the scheme is aiming at
         scheme: target scheme to update for
         key: one of preActions or postActions
         actions: original attribute passed in from ctx.attr.additional_pre_actions or ctx.attr.additional_post_actions
@@ -695,7 +696,7 @@ def _add_pre_post_actions(scheme, key, actions):
         payload = scheme[action_type]
         list = []
         for action in actions_to_add:
-            list.append({"script": action})
+            list.append({"script": action, "settingsTarget": target_name})
         payload[key] = list
 
 def _xcodeproj_impl(ctx):

--- a/tests/ios/xcodeproj/BUILD.bazel
+++ b/tests/ios/xcodeproj/BUILD.bazel
@@ -50,6 +50,12 @@ xcodeproj(
         "//tests/ios/unit-test/test-imports-app:TestImports-App_framework_unlinked",
         "//tests/ios/unit-test/test-imports-app:TestImports-Unit-Tests",
     ],
+    additional_pre_actions = {
+        "build": ["echo 'pre_build_action_1'", "echo 'pre_build_action_2'"],
+    },
+    additional_post_actions = {
+        "build": ["echo 'post_build_action_1'", "echo 'post_build_action_2'"],
+    }
 )
 
 xcodeproj(

--- a/tests/ios/xcodeproj/BUILD.bazel
+++ b/tests/ios/xcodeproj/BUILD.bazel
@@ -42,6 +42,18 @@ additional_scheme_info(
 xcodeproj(
     name = "Test-Imports-App-Project",
     testonly = True,
+    additional_post_actions = {
+        "build": [
+            "echo 'post_build_action_1'",
+            "echo 'post_build_action_2'",
+        ],
+    },
+    additional_pre_actions = {
+        "build": [
+            "echo 'pre_build_action_1'",
+            "echo 'pre_build_action_2'",
+        ],
+    },
     bazel_path = "bazelisk",
     generate_schemes_for_product_types = ["application"],
     include_transitive_targets = False,
@@ -50,12 +62,6 @@ xcodeproj(
         "//tests/ios/unit-test/test-imports-app:TestImports-App_framework_unlinked",
         "//tests/ios/unit-test/test-imports-app:TestImports-Unit-Tests",
     ],
-    additional_pre_actions = {
-        "build": ["echo 'pre_build_action_1'", "echo 'pre_build_action_2'"],
-    },
-    additional_post_actions = {
-        "build": ["echo 'post_build_action_1'", "echo 'post_build_action_2'"],
-    }
 )
 
 xcodeproj(

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/xcshareddata/xcschemes/TestImports-App.xcscheme
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/xcshareddata/xcschemes/TestImports-App.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1200"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"
       buildImplicitDependencies = "NO">
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "echo &apos;pre_build_action_1&apos;&#10;">
+               scriptText = "echo &apos;pre_build_action_1&apos;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
@@ -26,7 +26,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "echo &apos;pre_build_action_2&apos;&#10;">
+               scriptText = "echo &apos;pre_build_action_2&apos;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
@@ -44,7 +44,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "echo &apos;post_build_action_1&apos;&#10;">
+               scriptText = "echo &apos;post_build_action_1&apos;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
@@ -60,7 +60,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "echo &apos;post_build_action_2&apos;&#10;">
+               scriptText = "echo &apos;post_build_action_2&apos;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
@@ -94,7 +94,10 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -104,20 +107,18 @@
             ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <Testables>
-      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      customLLDBInitFile = "$CONFIGURATION_TEMP_DIR/TestImports-App.lldbinit"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES">
+      allowLocationSimulation = "YES"
+      customLLDBInitFile = "$CONFIGURATION_TEMP_DIR/TestImports-App.lldbinit">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference
@@ -128,6 +129,8 @@
             ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/xcshareddata/xcschemes/TestImports-App.xcscheme
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/xcshareddata/xcschemes/TestImports-App.xcscheme
@@ -1,10 +1,78 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1200"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "NO"
       buildImplicitDependencies = "NO">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "echo &apos;pre_build_action_1&apos;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "BAE883963A69FF9CDA89E73E"
+                     BuildableName = "TestImports-App.app"
+                     BlueprintName = "TestImports-App"
+                     ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "echo &apos;pre_build_action_2&apos;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "BAE883963A69FF9CDA89E73E"
+                     BuildableName = "TestImports-App.app"
+                     BlueprintName = "TestImports-App"
+                     ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "echo &apos;post_build_action_1&apos;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "BAE883963A69FF9CDA89E73E"
+                     BuildableName = "TestImports-App.app"
+                     BlueprintName = "TestImports-App"
+                     ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "echo &apos;post_build_action_2&apos;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "BAE883963A69FF9CDA89E73E"
+                     BuildableName = "TestImports-App.app"
+                     BlueprintName = "TestImports-App"
+                     ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -50,38 +118,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <PreActions>
-         <ExecutionAction
-            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
-            <ActionContent
-               title = "Run Script"
-               scriptText = "echo &apos;pre_build_action_1&apos;&#10;cat &apos;test&apos; &gt; ~/Downloads/temp.log&#10;">
-            </ActionContent>
-         </ExecutionAction>
-         <ExecutionAction
-            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
-            <ActionContent
-               title = "Run Script"
-               scriptText = "echo &apos;pre_build_action_2&apos;&#10;">
-            </ActionContent>
-         </ExecutionAction>
-      </PreActions>
-      <PostActions>
-         <ExecutionAction
-            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
-            <ActionContent
-               title = "Run Script"
-               scriptText = "echo &apos;post_build_action_1&apos;&#10;">
-            </ActionContent>
-         </ExecutionAction>
-         <ExecutionAction
-            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
-            <ActionContent
-               title = "Run Script"
-               scriptText = "echo &apos;post_build_action_2&apos;&#10;">
-            </ActionContent>
-         </ExecutionAction>
-      </PostActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/xcshareddata/xcschemes/TestImports-App.xcscheme
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/xcshareddata/xcschemes/TestImports-App.xcscheme
@@ -26,10 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      onlyGenerateCoverageForSpecifiedTargets = "NO"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -39,18 +36,52 @@
             ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$CONFIGURATION_TEMP_DIR/TestImports-App.lldbinit"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES"
-      customLLDBInitFile = "$CONFIGURATION_TEMP_DIR/TestImports-App.lldbinit">
+      allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "echo &apos;pre_build_action_1&apos;&#10;cat &apos;test&apos; &gt; ~/Downloads/temp.log&#10;">
+            </ActionContent>
+         </ExecutionAction>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "echo &apos;pre_build_action_2&apos;&#10;">
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "echo &apos;post_build_action_1&apos;&#10;">
+            </ActionContent>
+         </ExecutionAction>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "echo &apos;post_build_action_2&apos;&#10;">
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference
@@ -61,8 +92,6 @@
             ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
This change gives xcodeproj two more attributes for specifying pre/post actions against build/test etc.
It will run before and after build/test/run and will not spit output to build log, so any additional script ran there should be fast and shall not hang.

In terms of the data structure to pass here, three considerations are given here based on this [discussion](https://github.com/bazelbuild/bazel/blob/e2c91cc330179b638e3b88b2fd5ba4db63e0e1ce/src/main/java/com/google/devtools/build/lib/packages/Type.java#L58-L80) regarding why we should not have a `json style` compliticated data structure as a type for `attr`. One point strikes me is that having a complicated data structure as a type for `attr` makes `query` filtering `attr` a very difficult job. 

Comparison of three types here:
1. `string_list`
Pros: straight forward, it can be a list of scripts but tied to `build` and `pre-action`
Cons:, to extend the feature, in worse case we will need 6+ attr for `pre/post * build/test/run`, right now we can do `pre/post * build` which is 2 attr.

2. `string_dict`
Pros: can be very specific, such as `{type: build, name: 'script name', script: 'some script'}
Cons: Each attribute can only host one script for either pre/post. Note that we cannot put `list` in the dict here or we run into a `json style` data structure (DS).

3. `string_list_dict` (base is a dict and each key is string and value is a list of string)
Pros: most complicated DS we can get, so it gives the ability to specify at least the type and its scripts:
`{'build': [script1, script2, script3...], "run":[script1, script2, script3]}` for pre/post (2 attr). 
Cons: limited to key value means that we cannot specify name for script unless the string array itself has some special format within it. We cannot specify other fields such as [settingsTarget](https://github.com/yonaskolb/XcodeGen/blob/master/Docs/ProjectSpec.md#execution-action) . 

Given above, I am choosing `string_list_dict` here and follow the sample DS listed above. We are using this already in codebase and it is at least better than `additional_prebuild_script` where it only accepts a single script string

 
TODO 
- [ ] Fix specs