### PR TITLE
minimum_deployment_os_version / `-target` stopgap

### DIFF
--- a/data/xcspecs.bzl
+++ b/data/xcspecs.bzl
@@ -27,6 +27,26 @@ SETTINGS = {
         "Name": "Apple Clang",
         "OptionConditionFlavors": ["arch", "sdk"],
         "Options": {
+            "CLANG_TARGET_TRIPLE_ARCHS": {
+                "CommandLineArgs": [
+                    "-target",
+                    "$(value)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(LLVM_TARGET_TRIPLE_OS_VERSION)$(LLVM_TARGET_TRIPLE_SUFFIX)",
+                ],
+                "Condition": "com_apple_compilers_llvm_clang_1_0__CLANG_TARGET_TRIPLE_ARCHS__Condition",
+                "DefaultValue": "com_apple_compilers_llvm_clang_1_0__CLANG_TARGET_TRIPLE_ARCHS__DefaultValue",
+                "Type": "StringList",
+            },
+            "CLANG_TARGET_TRIPLE_VARIANTS": {
+                "CommandLineFlag": "-target-variant",
+                "Condition": "com_apple_compilers_llvm_clang_1_0__CLANG_TARGET_TRIPLE_VARIANTS__Condition",
+                "ConditionFlavors": ["arch"],
+                "Type": "StringList",
+            },
+            "arch": {
+                "CommandLineFlag": "-arch",
+                "Condition": "com_apple_compilers_llvm_clang_1_0__arch__Condition",
+                "Type": "String",
+            },
             "CLANG_TOOLCHAIN_FLAGS": {"CommandLineArgs": ["$(value)"], "Type": "StringList"},
             "diagnostic_message_length": {
                 "CommandLinePrefixFlag": "-fmessage-length=",
@@ -2044,6 +2064,21 @@ SETTINGS = {
         "IsAbstract": "Yes",
         "Name": "Ld",
         "Options": {
+            "LD_TARGET_TRIPLE_ARCHS": {
+                "CommandLineArgs": [
+                    "-target",
+                    "$(value)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(LLVM_TARGET_TRIPLE_OS_VERSION)$(LLVM_TARGET_TRIPLE_SUFFIX)",
+                ],
+                "Condition": "com_apple_pbx_linkers_ld__LD_TARGET_TRIPLE_ARCHS__Condition",
+                "DefaultValue": "com_apple_pbx_linkers_ld__LD_TARGET_TRIPLE_ARCHS__DefaultValue",
+                "Type": "StringList",
+            },
+            "LD_TARGET_TRIPLE_VARIANTS": {
+                "CommandLineFlag": "-target-variant",
+                "Condition": "com_apple_pbx_linkers_ld__LD_TARGET_TRIPLE_VARIANTS__Condition",
+                "ConditionFlavors": ["arch"],
+                "Type": "StringList",
+            },
             "LD_ADDITIONAL_DEPLOYMENT_TARGET_FLAGS": {
                 "CommandLineArgs": "$(value)",
                 "ConditionFlavors": ["arch"],
@@ -2732,6 +2767,20 @@ SETTINGS = {
                 "Description": "A list of additional flags to pass to the Swift " +
                                "compiler.",
                 "DisplayName": "Other Swift Flags",
+                "Type": "StringList",
+            },
+            "SWIFT_DEPLOYMENT_TARGET": {
+                "DefaultValue": "com_apple_xcode_tools_swift_compiler__SWIFT_DEPLOYMENT_TARGET__DefaultValue",
+                "Type": "String",
+            },
+            "SWIFT_TARGET_TRIPLE": {
+                "CommandLineFlag": "-target",
+                "DefaultValue": "com_apple_xcode_tools_swift_compiler__SWIFT_TARGET_TRIPLE__DefaultValue",
+                "Type": "String",
+            },
+            "SWIFT_TARGET_TRIPLE_VARIANTS": {
+                "CommandLineFlag": "-target-variant",
+                "ConditionFlavors": ["arch"],
                 "Type": "StringList",
             },
             "SWIFT_VERSION": {

--- a/data/xcspecs.bzl
+++ b/data/xcspecs.bzl
@@ -27,26 +27,6 @@ SETTINGS = {
         "Name": "Apple Clang",
         "OptionConditionFlavors": ["arch", "sdk"],
         "Options": {
-            "CLANG_TARGET_TRIPLE_ARCHS": {
-                "CommandLineArgs": [
-                    "-target",
-                    "$(value)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(LLVM_TARGET_TRIPLE_OS_VERSION)$(LLVM_TARGET_TRIPLE_SUFFIX)",
-                ],
-                "Condition": "com_apple_compilers_llvm_clang_1_0__CLANG_TARGET_TRIPLE_ARCHS__Condition",
-                "DefaultValue": "com_apple_compilers_llvm_clang_1_0__CLANG_TARGET_TRIPLE_ARCHS__DefaultValue",
-                "Type": "StringList",
-            },
-            "CLANG_TARGET_TRIPLE_VARIANTS": {
-                "CommandLineFlag": "-target-variant",
-                "Condition": "com_apple_compilers_llvm_clang_1_0__CLANG_TARGET_TRIPLE_VARIANTS__Condition",
-                "ConditionFlavors": ["arch"],
-                "Type": "StringList",
-            },
-            "arch": {
-                "CommandLineFlag": "-arch",
-                "Condition": "com_apple_compilers_llvm_clang_1_0__arch__Condition",
-                "Type": "String",
-            },
             "CLANG_TOOLCHAIN_FLAGS": {"CommandLineArgs": ["$(value)"], "Type": "StringList"},
             "diagnostic_message_length": {
                 "CommandLinePrefixFlag": "-fmessage-length=",
@@ -2064,21 +2044,6 @@ SETTINGS = {
         "IsAbstract": "Yes",
         "Name": "Ld",
         "Options": {
-            "LD_TARGET_TRIPLE_ARCHS": {
-                "CommandLineArgs": [
-                    "-target",
-                    "$(value)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(LLVM_TARGET_TRIPLE_OS_VERSION)$(LLVM_TARGET_TRIPLE_SUFFIX)",
-                ],
-                "Condition": "com_apple_pbx_linkers_ld__LD_TARGET_TRIPLE_ARCHS__Condition",
-                "DefaultValue": "com_apple_pbx_linkers_ld__LD_TARGET_TRIPLE_ARCHS__DefaultValue",
-                "Type": "StringList",
-            },
-            "LD_TARGET_TRIPLE_VARIANTS": {
-                "CommandLineFlag": "-target-variant",
-                "Condition": "com_apple_pbx_linkers_ld__LD_TARGET_TRIPLE_VARIANTS__Condition",
-                "ConditionFlavors": ["arch"],
-                "Type": "StringList",
-            },
             "LD_ADDITIONAL_DEPLOYMENT_TARGET_FLAGS": {
                 "CommandLineArgs": "$(value)",
                 "ConditionFlavors": ["arch"],
@@ -2767,20 +2732,6 @@ SETTINGS = {
                 "Description": "A list of additional flags to pass to the Swift " +
                                "compiler.",
                 "DisplayName": "Other Swift Flags",
-                "Type": "StringList",
-            },
-            "SWIFT_DEPLOYMENT_TARGET": {
-                "DefaultValue": "com_apple_xcode_tools_swift_compiler__SWIFT_DEPLOYMENT_TARGET__DefaultValue",
-                "Type": "String",
-            },
-            "SWIFT_TARGET_TRIPLE": {
-                "CommandLineFlag": "-target",
-                "DefaultValue": "com_apple_xcode_tools_swift_compiler__SWIFT_TARGET_TRIPLE__DefaultValue",
-                "Type": "String",
-            },
-            "SWIFT_TARGET_TRIPLE_VARIANTS": {
-                "CommandLineFlag": "-target-variant",
-                "ConditionFlavors": ["arch"],
                 "Type": "StringList",
             },
             "SWIFT_VERSION": {

--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -21,6 +21,7 @@ _IOS_APPLICATION_KWARGS = [
     "strings",
     "alternate_icons",
     "settings_bundle",
+    "minimum_deployment_os_version",
 ]
 
 def ios_application(name, apple_library = apple_library, infoplists_by_build_setting = {}, **kwargs):

--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -2,6 +2,12 @@ load("@build_bazel_rules_apple//apple:ios.bzl", rules_apple_ios_application = "i
 load("//rules:library.bzl", "apple_library")
 load("//rules:plists.bzl", "info_plists_by_setting")
 
+# We need to try and partition out arguments for obj_library / swift_library
+# from ios_application since this creates source file libs internally.
+#
+# The docs for ios_application are at rules_apple
+# https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-ios.md#ios_application
+# - Perhaps we can just remove this wrapper longer term.
 _IOS_APPLICATION_KWARGS = [
     "bundle_id",
     "infoplists",

--- a/rules/library/xcconfig.bzl
+++ b/rules/library/xcconfig.bzl
@@ -207,6 +207,16 @@ def copts_from_xcconfig(xcconfig):
         "CLANG_BITCODE_GENERATION_MODE",  # handled by `--apple_bitcode` flag on Bazel side
         "SWIFT_BITCODE_GENERATION_MODE",  # handled by `--apple_bitcode` flag on Bazel side
         "LD_BITCODE_GENERATION_MODE",  # handled by `--apple_bitcode` flag on Bazel side
+
+        # Bazel platform / target specific attributes - handled by toolchains
+        "SWIFT_TARGET_TRIPLE_VARIANTS",
+        "SWIFT_TARGET_TRIPLE",
+        "SWIFT_DEPLOYMENT_TARGET",
+        "LD_TARGET_TRIPLE_VARIANT",
+        "LD_TARGET_TRIPLE_ARCHS",
+        "CLANG_TARGET_TRIPLE_ARCHS",
+        "CLANG_TARGET_TRIPLE_VARIANTS",
+        "arch",
     )
 
     identifiers = [

--- a/rules/precompiled_apple_resource_bundle.bzl
+++ b/rules/precompiled_apple_resource_bundle.bzl
@@ -59,6 +59,7 @@ def _precompiled_apple_resource_bundle_impl(ctx):
             config_vars = ctx.var,
             device_families = ["iphone", "ipad"],
             explicit_minimum_os = None,
+            explicit_minimum_deployment_os = None,
             objc_fragment = None,
             platform_type_string = platform_type,
             uses_swift = False,

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -47,10 +47,10 @@ def rules_ios_dependencies():
     _maybe(
         github_repo,
         name = "build_bazel_rules_apple",
-        ref = "c99b0fd9f58a75ecc5324b073bc1e901d9e0e55b",
+        ref = "3baff5b829177f8007619d1f16971761d68a64e1",
         project = "bazelbuild",
         repo = "rules_apple",
-        sha256 = "7ab9af8529aea6d347b136140132d558ee164eb62367637f568321a941b0ddba",
+        sha256 = "2d4b0b1616cb7a7fe5d35dfbd1c813c5ae216169ff34c7a81f7a85f1b99a9cf2",
     )
 
     _maybe(


### PR DESCRIPTION
It adds the ability to set `minimum_deployment_os_version` and pulls in
the latest sha of `rules_apple`.

It stopgaps target specific evaluation xcconfig issues. When I tried to
build an app with target specifc xcconfigs with settings like
`SWIFT_PLATFORM_TARGET_PREFIX`, I end up getting invalid `-target` flags
in compiler invocations which were incomplete. `rules_ios`'s xcconfig
evaluator is not a full implementation of xcconfig and conflicts with
Bazel's settings here. It doesn't currently evaluate on a per architecture
basis but aligning the 2 may be a longer term exercise.

This PR is related to #225 : making it a bit easier to align with what Xcode is doing