### PR TITLE
Scaffolding for Xcode configuration repo rule

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -82,3 +82,10 @@ http_file(
     # .bazelversion uses 4.0
     urls = ["https://github.com/bazelbuild/buildtools/releases/download/3.5.0/buildifier.mac"],
 )
+
+load(
+    "//rules/xcode_autoconf:xcode_configure.bzl",
+    "xcode_autoconf",
+)
+
+xcode_autoconf(name = "rules_ios_local_config_xcode")

--- a/rules/xcode_autoconf/.gitignore
+++ b/rules/xcode_autoconf/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/

--- a/rules/xcode_autoconf/BUILD.bazel
+++ b/rules/xcode_autoconf/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(glob(["**/*.swift"])

--- a/rules/xcode_autoconf/BUILD.bazel
+++ b/rules/xcode_autoconf/BUILD.bazel
@@ -1,1 +1,1 @@
-exports_files(glob(["**/*.swift"])
+exports_files(glob(["**/*.swift"]))

--- a/rules/xcode_autoconf/Package.swift
+++ b/rules/xcode_autoconf/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "XcodeAutoConfigure",
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "XcodeAutoConfigure",
+            dependencies: []),
+        .testTarget(
+            name: "XcodeAutoConfigureTests",
+            dependencies: ["XcodeAutoConfigure"]),
+    ]
+)

--- a/rules/xcode_autoconf/Package.swift
+++ b/rules/xcode_autoconf/Package.swift
@@ -1,17 +1,11 @@
-// swift-tools-version:5.3
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
+// swift-tools-version:5.1
 import PackageDescription
 
 let package = Package(
     name: "XcodeAutoConfigure",
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "XcodeAutoConfigure",
             dependencies: []),

--- a/rules/xcode_autoconf/Sources/XcodeAutoConfigure/main.swift
+++ b/rules/xcode_autoconf/Sources/XcodeAutoConfigure/main.swift
@@ -1,0 +1,14 @@
+import Foundation
+// TODO:
+// Determines selected Xcode based on env: intelligent noop here
+
+// TODO:
+// Otherwise, dump the JSON SDKS to starlark if it's changed. Note: This needs
+// a dep on the DEVELOPER_DIR and env.
+// ( "xcrun", "xcodebuild", "-version", "-sdk" )
+
+// TODO:
+// Write a BUILD file for the current executing Xcode
+
+let buildFileContents = "#HELLO WORLD"
+try buildFileContents.write(toFile: "BUILD.bazel", atomically: true, encoding: .utf8)

--- a/rules/xcode_autoconf/Tests/XcodeAutoConfigureTests/XcodeAutoConfigureTests.swift
+++ b/rules/xcode_autoconf/Tests/XcodeAutoConfigureTests/XcodeAutoConfigureTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+import class Foundation.Bundle
+
+final class XcodeAutoConfigureTests: XCTestCase {
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+
+        // Some of the APIs that we use below are available in macOS 10.13 and above.
+        guard #available(macOS 10.13, *) else {
+            return
+        }
+
+        let fooBinary = productsDirectory.appendingPathComponent("XcodeAutoConfigure")
+
+        let process = Process()
+        process.executableURL = fooBinary
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8)
+
+        XCTAssertEqual(output, "Hello, world!\n")
+    }
+
+    /// Returns path to the built products directory.
+    var productsDirectory: URL {
+      #if os(macOS)
+        for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+            return bundle.bundleURL.deletingLastPathComponent()
+        }
+        fatalError("couldn't find the products directory")
+      #else
+        return Bundle.main.bundleURL
+      #endif
+    }
+
+    static var allTests = [
+        ("testExample", testExample),
+    ]
+}

--- a/rules/xcode_autoconf/xcode_configure.bzl
+++ b/rules/xcode_autoconf/xcode_configure.bzl
@@ -1,0 +1,56 @@
+# This rule _must_ be fast as it's a `local` rule. `xcrun swift`
+# is ~100-200ms
+def _run_darwin_xcode_configure(repository_ctx):
+    execute_timeout = 10
+    xcrun_result = repository_ctx.execute([
+        "xcrun",
+        "swift",
+        "run",
+
+        # Swift run needs a build path to compile sources. Set it adjacent to
+        # this directory, so we don't re-recompile it everytime.
+        "--build-path",
+        "../xcode_autoconf_build_dir",
+        "--configuration",
+        "release",
+
+        # Set this directory to the directory of package file
+        "--package-path",
+        repository_ctx.path(repository_ctx.attr.package_files[0]).dirname,
+        "XcodeAutoConfigure",
+    ], execute_timeout)
+
+    if xcrun_result.return_code != 0:
+        fail("Failed to auto_configure", xcrun_result.stdout, xcrun_result.stderr)
+
+def _impl(repository_ctx):
+    """Implementation for the local_config_xcode repository rule.
+
+    Generates a BUILD file containing a root xcode_config target named 'host_xcodes',
+    which points to an xcode_version target for each version of xcode installed on
+    the local host machine. If no versions of xcode are present on the machine
+    (for instance, if this is a non-darwin OS), creates a stub target.
+    """
+    os_name = repository_ctx.os.name.lower()
+    if (os_name.startswith("mac os")):
+        _run_darwin_xcode_configure(repository_ctx)
+    else:
+        build_contents = """
+        package(default_visibility = ['//visibility:public'])
+        xcode_config(name = 'host_xcodes')
+        """
+        repository_ctx.file("BUILD.bazel", build_contents)
+
+xcode_autoconf = repository_rule(
+    implementation = _impl,
+    local = True,
+    attrs = {
+        # This remote xcode needs to be handled when remote caching is enabled
+        "remote_xcode": attr.string(),
+        "package_files": attr.label_list(default = [
+            # Take a dependency on source files of the xcode configurator
+            "@build_bazel_rules_ios//rules/xcode_autoconf:Package.swift",
+            "@build_bazel_rules_ios//rules/xcode_autoconf:Sources/XcodeAutoConfigure/main.swift",
+        ]),
+    },
+)

--- a/rules/xcode_autoconf/xcode_configure.bzl
+++ b/rules/xcode_autoconf/xcode_configure.bzl
@@ -43,7 +43,8 @@ def _impl(repository_ctx):
 
 xcode_autoconf = repository_rule(
     implementation = _impl,
-    local = True,
+    local = False,
+    environ = ["DEVELOPER_DIR"],
     attrs = {
         # This remote xcode needs to be handled when remote caching is enabled
         "remote_xcode": attr.string(),


### PR DESCRIPTION
Sets up the scaffolding to address https://github.com/bazel-ios/rules_ios/issues/269

Provide a fast way to configure Xcode and set versions. Bazel currently
contains an Xcode auto configure mechanism that doesn't work so well
with `rules_ios` and resulted in performance issues when used with
Xcode's GUI and the CLI.

Bazel requires a user to set the Xcode version flag. Today an Xcode
project generator or wrapper must interact with the `xcode_version` flag
and make assumptions about how it works: e.g.
`rules_ios` currently triggers re-analysis because it runs Bazel query (
https://github.com/bazel-ios/rules_ios/issues/269 ).

All of this is replaced by a configuration program based on SPM / `swift
run`.

The program will manage both Bazel's Xcode version flag and the
overall BUILD file. It uses `swift run` / SPM for incremental speed and simplicity
as we can't Bazel build a that's an input to a repo rule. For now, the
basic logic of what it will do is written in a comment and all of this
is scaffolding, so it doesn't do anything yet.