### PR TITLE
[xcodeproj] Fix double analysis phase

### DIFF
--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -822,6 +822,7 @@ def _xcodeproj_impl(ctx):
     )
     installer_runfile_paths = [i.short_path for i in ctx.attr.installer[DefaultInfo].default_runfiles.files.to_list()]
     build_wrapper_runfile_paths = [i.short_path for i in ctx.attr.build_wrapper[DefaultInfo].default_runfiles.files.to_list()]
+
     # In order to be runnable, the print_json_leaf_nodes script needs to live
     # next to a print_json_leaf_nodes.runfiles directory that contains its runfiles.
     # The print_json_leaf_nodes_runfiles array will be populated with the subdirectories

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -821,7 +821,7 @@ def _xcodeproj_impl(ctx):
         "%s-install-xcodeproj.sh" % ctx.attr.name,
     )
     installer_runfile_paths = [i.short_path for i in ctx.attr.installer[DefaultInfo].default_runfiles.files.to_list()]
-
+    build_wrapper_runfile_paths = [i.short_path for i in ctx.attr.build_wrapper[DefaultInfo].default_runfiles.files.to_list()]
     # In order to be runnable, the print_json_leaf_nodes script needs to live
     # next to a print_json_leaf_nodes.runfiles directory that contains its runfiles.
     # The print_json_leaf_nodes_runfiles array will be populated with the subdirectories
@@ -850,6 +850,7 @@ def _xcodeproj_impl(ctx):
             "$(print_json_leaf_nodes_path)": ctx.executable.print_json_leaf_nodes.short_path,
             "$(print_json_leaf_nodes_runfiles)": " ".join(print_json_leaf_nodes_runfiles),
             "$(build_wrapper_path)": ctx.executable.build_wrapper.short_path,
+            "$(build_wrapper_runfile_short_paths)": " ".join(build_wrapper_runfile_paths),
             "$(infoplist_stub)": ctx.file.infoplist_stub.short_path,
             "$(output_processor_path)": ctx.file.output_processor.short_path,
             "$(workspacesettings_xcsettings_short_path)": ctx.file._workspace_xcsettings.short_path,
@@ -875,6 +876,7 @@ def _xcodeproj_impl(ctx):
                          ctx.files._workspace_checks +
                          ctx.files.output_processor,
                 transitive = [
+                    ctx.attr.build_wrapper[DefaultInfo].default_runfiles.files,
                     ctx.attr.installer[DefaultInfo].default_runfiles.files,
                     ctx.attr.print_json_leaf_nodes[DefaultInfo].default_runfiles.files,
                 ],

--- a/tools/xcode_version_computation/BUILD.bazel
+++ b/tools/xcode_version_computation/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
+
+swift_binary(
+    name = "xcode_version_computation",
+    srcs = ["main.swift"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/xcode_version_computation/main.swift
+++ b/tools/xcode_version_computation/main.swift
@@ -33,10 +33,10 @@ func GetFullBazelXcodeVersion(developerDir: String) throws -> String {
         options: [], format: &plistFormat)
     let plist = plistData as? [String: AnyObject] ?? [:]
     guard let shortVersion = plist["CFBundleShortVersionString"] as? String else {
-        throw LoadError.error("Missing Xcode short version")
+        throw LoadError.error("Missing Xcode CFBundleShortVersionString in version.plist")
     }
     guard let buildVersion = plist["ProductBuildVersion"] as? String else {
-        throw LoadError.error("Missing Xcode build version")
+        throw LoadError.error("Missing Xcode ProductBuildVersion in version.plist")
     }
     return ExpandVersion(version: shortVersion) + "." + buildVersion
 }

--- a/tools/xcode_version_computation/main.swift
+++ b/tools/xcode_version_computation/main.swift
@@ -1,0 +1,54 @@
+/// This program writes a full Xcode version based on how Bazel will set this
+/// version for the DEVELOPER_DIR
+/// https://github.com/bazelbuild/bazel/blob/master/tools/osx/xcode_locator.m
+import Foundation
+
+func ExpandVersion(version: String) -> String {
+    let components = version.components(separatedBy:".")
+    var appendage: String?
+    if (components.count == 2) {
+        appendage = ".0";
+    } else if (components.count == 1) {
+        appendage = ".0.0"
+    }
+    if let appendage = appendage {
+        return version + appendage
+    }
+    return version;
+}
+
+enum LoadError: Error {
+    case error(_ value: String)
+}
+
+func GetFullBazelXcodeVersion(developerDir: String) throws -> String {
+    let url = URL(fileURLWithPath: developerDir)
+    var plistFormat = PropertyListSerialization.PropertyListFormat.xml
+    let bundleURL = url.deletingLastPathComponent().appendingPathComponent("version.plist")
+    guard let plistXML = FileManager.default.contents(atPath: bundleURL.path) else {
+        throw LoadError.error("Cant load" + bundleURL.path)
+    }
+
+    let plistData = try PropertyListSerialization.propertyList(from: plistXML,
+        options: [], format: &plistFormat)
+    let plist = plistData as? [String: AnyObject] ?? [:]
+    guard let shortVersion = plist["CFBundleShortVersionString"] as? String else {
+        throw LoadError.error("Missing Xcode short version")
+    }
+    guard let buildVersion = plist["ProductBuildVersion"] as? String else {
+        throw LoadError.error("Missing Xcode build version")
+    }
+    return ExpandVersion(version: shortVersion) + "." + buildVersion
+}
+
+let _ = {
+    do {
+        guard let developerDir = ProcessInfo.processInfo.environment["DEVELOPER_DIR"] else {
+            throw LoadError.error("Missing DEVELOPER_DIR")
+        }
+        let version = try GetFullBazelXcodeVersion(developerDir: developerDir)
+        print(version)
+    } catch {
+        fatalError("\(error)")
+    }
+}()

--- a/tools/xcodeproj_shims/BUILD.bazel
+++ b/tools/xcodeproj_shims/BUILD.bazel
@@ -39,11 +39,17 @@ sh_binary(
     visibility = STUB_VISIBILITY,
 )
 
+sh_library(
+    name = "build-wrapper-deps",
+    srcs = ["//tools/xcode_version_computation"],
+)
+
 sh_binary(
     name = "build-wrapper",
     srcs = [
         "build-wrapper.sh",
     ],
+    data = ["build-wrapper-deps"],
     visibility = STUB_VISIBILITY,
 )
 

--- a/tools/xcodeproj_shims/build-wrapper.sh
+++ b/tools/xcodeproj_shims/build-wrapper.sh
@@ -6,16 +6,9 @@ declare -a BAZEL_BUILD_OPTIONS=(
     "--build_event_publish_all_actions"
     "--nobuild_event_text_file_path_conversion"
     "--use_top_level_targets_for_symlinks"
+    "--xcode_version=$($(dirname $0)/xcode_version_computation)"
 )
 
-# HACK: only needed until we can presume https://github.com/bazelbuild/bazel/pull/12563
-xcode_version="$($BAZEL_PATH query 'attr("name", "version.+_'"${XCODE_PRODUCT_BUILD_VERSION}"'", kind(xcode_version, @local_config_xcode//:*))')"
-if [ -n "$xcode_version" ]; then
-    xcode_version="$(echo "${xcode_version#*:version*}" | tr _ .)"
-    BAZEL_BUILD_OPTIONS+=("--xcode_version=$xcode_version")
-else
-    echo "warning: Falling back on default xcode for execution, bazel did not find $XCODE_PRODUCT_BUILD_VERSION in @local_config_xcode"
-fi
 
 if [ $BAZEL_EXECUTION_LOG_ENABLED -gt 0 ]; then
     BAZEL_BUILD_OPTIONS+=("--experimental_execution_log_file=$BAZEL_BUILD_EXECUTION_LOG_FILENAME")

--- a/tools/xcodeproj_shims/xcodeproj-installer.sh
+++ b/tools/xcodeproj_shims/xcodeproj-installer.sh
@@ -22,6 +22,8 @@ mkdir -p "${installers_dir}"
 readonly print_json_installers_dir="${stubs_dir}/print_json_leaf_nodes.runfiles/"
 mkdir -p "${print_json_installers_dir}"
 
+# Project runfile installation: these scripts install various runfiles into the
+# project
 for PRINT_INSTALLER_PATH in $(print_json_leaf_nodes_runfiles)
 do
   mkdir -p "${print_json_installers_dir}/$(dirname $PRINT_INSTALLER_PATH)"

--- a/tools/xcodeproj_shims/xcodeproj-installer.sh
+++ b/tools/xcodeproj_shims/xcodeproj-installer.sh
@@ -34,6 +34,12 @@ do
 done
 cp "$(installer_short_path)" "${installers_dir}/"
 
+build_wrapper_runfile_short_paths="$(build_wrapper_runfile_short_paths)"
+for BUILD_WRAPPER_PATH in $build_wrapper_runfile_short_paths
+do
+  cp -r "$BUILD_WRAPPER_PATH" "${stubs_dir}/"
+done
+
 cp "$(clang_stub_short_path)" "${stubs_dir}/clang-stub"
 cp "$(clang_stub_ld_path)" "${stubs_dir}/ld-stub"
 cp "$(clang_stub_swiftc_path)" "${stubs_dir}/swiftc-stub"


### PR DESCRIPTION
When running under Xcode, `rules_ios`'s "build wrapper" currently
overrides the Xcode flag to the parent process's version.  Previously it
ran Bazel query and caused the analysis phase to happen 2x on each
build.

The Bazel Xcode version reader program writes a full Xcode version based
on how Bazel will set this version for the `DEVELOPER_DIR`.