### PR TITLE
Remove pre/post action having references to build target (xcode crush if build target is at large scale)

### DIFF
--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -693,6 +693,9 @@ def _add_pre_post_actions(target_name, scheme, key, actions):
         actions_to_add = actions[action_type]
         payload = scheme[action_type]
         list = []
+
+        # Note `settingsTarget` is explicitly omitted because
+        # for a target with lots of env vars we might exceed Xcode arg_max limit
         for action in actions_to_add:
             list.append({"script": action})
         payload[key] = list

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -694,7 +694,7 @@ def _add_pre_post_actions(target_name, scheme, key, actions):
         payload = scheme[action_type]
         list = []
         for action in actions_to_add:
-            list.append({"script": action, "settingsTarget": target_name})
+            list.append({"script": action})
         payload[key] = list
 
 def _xcodeproj_impl(ctx):

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/xcshareddata/xcschemes/TestImports-App.xcscheme
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/xcshareddata/xcschemes/TestImports-App.xcscheme
@@ -11,15 +11,6 @@
             <ActionContent
                title = "Run Script"
                scriptText = "echo &apos;pre_build_action_1&apos;">
-               <EnvironmentBuildable>
-                  <BuildableReference
-                     BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "BAE883963A69FF9CDA89E73E"
-                     BuildableName = "TestImports-App.app"
-                     BlueprintName = "TestImports-App"
-                     ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
-                  </BuildableReference>
-               </EnvironmentBuildable>
             </ActionContent>
          </ExecutionAction>
          <ExecutionAction
@@ -45,15 +36,6 @@
             <ActionContent
                title = "Run Script"
                scriptText = "echo &apos;post_build_action_1&apos;">
-               <EnvironmentBuildable>
-                  <BuildableReference
-                     BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "BAE883963A69FF9CDA89E73E"
-                     BuildableName = "TestImports-App.app"
-                     BlueprintName = "TestImports-App"
-                     ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
-                  </BuildableReference>
-               </EnvironmentBuildable>
             </ActionContent>
          </ExecutionAction>
          <ExecutionAction

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/xcshareddata/xcschemes/TestImports-App.xcscheme
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/xcshareddata/xcschemes/TestImports-App.xcscheme
@@ -18,15 +18,6 @@
             <ActionContent
                title = "Run Script"
                scriptText = "echo &apos;pre_build_action_2&apos;">
-               <EnvironmentBuildable>
-                  <BuildableReference
-                     BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "BAE883963A69FF9CDA89E73E"
-                     BuildableName = "TestImports-App.app"
-                     BlueprintName = "TestImports-App"
-                     ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
-                  </BuildableReference>
-               </EnvironmentBuildable>
             </ActionContent>
          </ExecutionAction>
       </PreActions>
@@ -43,15 +34,6 @@
             <ActionContent
                title = "Run Script"
                scriptText = "echo &apos;post_build_action_2&apos;">
-               <EnvironmentBuildable>
-                  <BuildableReference
-                     BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "BAE883963A69FF9CDA89E73E"
-                     BuildableName = "TestImports-App.app"
-                     BlueprintName = "TestImports-App"
-                     ReferencedContainer = "container:Test-Imports-App-Project.xcodeproj">
-                  </BuildableReference>
-               </EnvironmentBuildable>
             </ActionContent>
          </ExecutionAction>
       </PostActions>


### PR DESCRIPTION
since projects usually have a large scale, the env vars an target can have might be a very large list that exceed xcode arg max limit (256 kb) This is resolved in MacOS 11 but for now we should not add the reference to the target so that xcode won't crash.

For use cases where we have to add it back, we can add a new flag for it or consider it when we refactor xcodeproj fule