### PR TITLE
Virtual hermetic frameworks POC

### DIFF
--- a/rules/framework/BUILD.bazel
+++ b/rules/framework/BUILD.bazel
@@ -5,3 +5,12 @@ py_binary(
     srcs = ["framework_packaging.py"],
     visibility = ["//visibility:public"],
 )
+
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
+
+swift_binary(
+    name = "merge_vfs_overlay",
+    srcs = ["merge_vfs_overlay.swift"],
+    visibility = ["//visibility:public"],
+)
+

--- a/rules/framework/merge_vfs_overlay.swift
+++ b/rules/framework/merge_vfs_overlay.swift
@@ -1,0 +1,94 @@
+
+
+import Foundation
+
+let output = ProcessInfo.processInfo.arguments[1]
+let args = ProcessInfo.processInfo.arguments[2...]
+
+func loadVFS(path: String) -> [String: Any] {
+   do {
+          let data = try Data(contentsOf: URL(fileURLWithPath: path), options: .mappedIfSafe)
+          let jsonResult = try JSONSerialization.jsonObject(with: data, options: .mutableLeaves)
+          return jsonResult as? [String: Any] ?? [:]
+      } catch {
+          print("ERR\(error)")
+          return [:]
+      }
+}
+
+var outputVFS: [String: Any] = [:]
+let VFSJSON = args.reduce(into: outputVFS) {
+    accum, next in
+    let nextVFS = loadVFS(path: next)
+    guard let nextRoots = nextVFS["roots"] as? [Any] else {
+        print("invalid VFS", next, nextVFS["roots"])
+        exit(1)
+        return
+    }
+    if accum.count == 0 {
+        accum = nextVFS
+        return
+    }
+
+    // Naievely add the roots
+    guard let accumRoots = accum["roots"] as? [Any] else {
+        print("NoRoots", accum["roots"])
+        return
+    }
+
+    // This intentionally is an NSMutableDictionary, there's a problem using
+    // NSJSONSerailization with this value. Consider comparing to performance of
+    // codeable.
+    var rootsByName = NSMutableDictionary()
+    for _root in accumRoots {
+
+        guard let root = _root as? [String: Any] else {
+            print("Invalid", _root)
+            continue
+        }
+        let name = root["name"] as! String
+        rootsByName[name] = root
+    }
+
+    for _nextRoot in nextRoots {
+        guard let nextRoot = _nextRoot as? [String: Any] else {
+            print("Invalid", _nextRoot)
+            continue
+        }
+
+        let name = nextRoot["name"] as! String
+        if var prev = rootsByName[name] as? [String: Any] {
+           let contents = nextRoot["contents"] as? [Any] ?? []
+           let prevContents = prev["contents"] as? [Any] ?? []
+           prev["contents"] = prevContents + contents
+
+           let externalContents = nextRoot["external-contents"] as? [Any] ?? []
+           let prevexternalContents = prev["external-contents"] as? [Any] ?? []
+           prev["external-contents"] = prevexternalContents + externalContents
+
+           rootsByName[name] =  prev
+        }
+        rootsByName[name] = nextRoot
+    }
+    accum["roots"] = rootsByName.allValues
+}
+
+let debug = false
+if debug {
+   print("__VFS", output, VFSJSON)
+}
+if let encodedData = try?JSONSerialization.data(withJSONObject: VFSJSON,
+                                                options: .init(rawValue: 0))
+{
+    let pathAsURL = URL(fileURLWithPath: output)
+    do {
+        try encodedData.write(to: pathAsURL)
+        if debug {
+             print("-WROTE", pathAsURL.absoluteString)
+        }
+    } 
+    catch {
+        print("Failed to write JSON data: \(error.localizedDescription)")
+        exit(1)
+    }
+}

--- a/rules/framework/vfs_overlay.bzl
+++ b/rules/framework/vfs_overlay.bzl
@@ -1,9 +1,12 @@
+load("//rules:internal.bzl", "FrameworkInfo")
+
 FRAMEWORK_SEARCH_PATH = "/build_bazel_rules_ios/frameworks"
 
 VFSOverlayInfo = provider(
     doc = "Propagates vfs overlays",
     fields = {
         "files": "depset with overlays",
+        "merged_files": "depset with overlays",
     },
 )
 
@@ -24,17 +27,181 @@ def _vfs_root(root_dir, files, override_name = None):
         ],
     }
 
+def _extra_vfs_root(ctx, framework_name, root_dir, extra_vfs_root, module_map, hdrs, private_hdrs, has_swift):
+    extra_roots = []
+    filtered_hdrs = hdrs
+    if extra_vfs_root:
+        sub_dir = "Headers"
+
+        # Strip the build file path
+        base_path = "/".join(ctx.build_file_path.split("/")[:-1])
+        rooted_path = base_path + "/" + extra_vfs_root + "/" + sub_dir + "/"
+        extra_roots = [
+            {
+                "type": "file",
+                "name": file.path.replace(rooted_path, ""),
+                "external-contents": file.path,
+            }
+            for file in filtered_hdrs
+        ]
+        extra_roots += [
+            {
+                "type": "file",
+                "name": framework_name + "/" + file.path.replace(rooted_path, ""),
+                "external-contents": file.path,
+            }
+            for file in filtered_hdrs
+        ]
+
+    modules_contents = []
+    if len(module_map):
+        modules_contents.append({
+            "type": "file",
+            "name": "module.modulemap",
+            "external-contents": module_map[0].path,
+        })
+
+    modules = []
+    if len(modules_contents):
+        modules = [{
+            "name": "Modules",
+            "type": "directory",
+            "contents": modules_contents,
+            # Note: this is currently not working
+            # [_vfs_swift_module_header_contents(ctx, vfs_name)]
+        }]
+
+    headers = [{
+        "name": "Headers",
+        "type": "directory",
+        "contents": [
+            {
+                "type": "file",
+                "name": file.basename,
+                "external-contents": file.path,
+            }
+            for file in filtered_hdrs
+        ] + extra_roots,
+    }]
+
+    # Note: we shouldn't propagate these private headers - it's happening throuugh merging
+    private_headers_contents = {
+        "name": "PrivateHeaders",
+        "type": "directory",
+        "contents": [
+            {
+                "type": "file",
+                "name": file.basename,
+                "external-contents": file.path,
+            }
+            for file in private_hdrs
+        ],
+    }
+
+    private_headers = []
+    if len(private_hdrs):
+        private_headers = [private_headers_contents]
+
+    ret = [{
+        "name": root_dir,
+        "type": "directory",
+        "contents": headers + private_headers + modules,
+    }]
+    if has_swift:
+        ret += [_vfs_swift_module_header_contents(ctx, framework_name, "/build_bazel_rules_ios/frameworks/")]
+
+    return ret
+
+# CAN REMOVE
+def _vfs_swift_header_contents(ctx, framework_name):
+    bin_dir = ctx.bin_dir.path
+    base_path = "/".join(ctx.build_file_path.split("/")[:-1])
+    fw_name = framework_name
+    rooted_path = bin_dir + "/" + base_path
+    h_name = fw_name + "-Swift.h"
+    external_contents = rooted_path + "/" + h_name
+    return {
+        "type": "file",
+        "name": h_name,
+        "external-contents": external_contents,
+    }
+
+# Consider passing this instead
+def _vfs_swift_module_header_contents(ctx, framework_name, root = ""):
+    fw_name = framework_name
+    bin_dir = ctx.bin_dir.path
+    base_path = "/".join(ctx.build_file_path.split("/")[:-1])
+    rooted_path = bin_dir + "/" + base_path
+    h_name = fw_name + ".swiftmodule"
+    external_contents = rooted_path + "/" + h_name
+
+    # Note: We can put these directly at the root
+    return {
+        "type": "file",
+        "name": root + h_name,
+        "external-contents": external_contents,
+    }
+
+    return {
+        "name": root + h_name,
+        "type": "directory",
+        "contents": [{
+            "type": "file",
+            "name": "x86_64.swiftmodule",
+            "external-contents": external_contents,
+        }],
+    }
+
 def _framework_vfs_overlay_impl(ctx):
+    vfsoverlays = []
+    for dep in ctx.attr.deps:
+        if FrameworkInfo in dep:
+            framework_info = dep[FrameworkInfo]
+            vfsoverlays.append(framework_info.vfsoverlay_infos)
+        if VFSOverlayInfo in dep:
+            vfsoverlays.append(dep[VFSOverlayInfo].files)
+
+    vfs_ret = write_vfs(
+        ctx,
+        hdrs = ctx.files.hdrs,
+        module_map = ctx.files.modulemap,
+        private_hdrs = ctx.files.private_hdrs,
+        has_swift = ctx.attr.has_swift,
+        vfs_providers = [],
+        merge_vfsoverlays = vfsoverlays,
+        vfsoverlay_file = ctx.outputs.vfs_overlay,
+        merge_tool = ctx.attr.merge_tool,
+        extra_vfs_root = ctx.attr.extra_vfs_root,
+    )
+
+    headers = depset([vfs_ret.vfsoverlay_file, vfs_ret.vfsoverlay_file_merged], transitive = vfs_ret.vfsoverlays)
+    cc_info = CcInfo(
+        compilation_context = cc_common.create_compilation_context(
+            headers = headers,
+        ),
+    )
+    return [
+        apple_common.new_objc_provider(),
+        cc_info,
+        VFSOverlayInfo(
+            files = depset([vfs_ret.vfsoverlay_file]),
+            merged_files = depset([vfs_ret.vfsoverlay_file_merged], transitive = vfs_ret.vfsoverlays),
+        ),
+
+        # Mainly a debugging mechanism
+        OutputGroupInfo(
+            vfs = depset([vfs_ret.vfsoverlay_file, vfs_ret.vfsoverlay_file_merged], transitive = vfs_ret.vfsoverlays),
+        ),
+    ]
+
+# Note: maybe we can put swiftmodules in modules...
+def write_vfs(ctx, hdrs, module_map, private_hdrs, has_swift, vfs_providers, vfsoverlay_file, merge_tool, merge_vfsoverlays = [], extra_vfs_root = None):
     framework_path = "{search_path}/{framework_name}.framework".format(
         search_path = FRAMEWORK_SEARCH_PATH,
         framework_name = ctx.attr.framework_name,
     )
-
-    roots = [
-        _vfs_root(root_dir = framework_path + "/Headers", files = ctx.files.hdrs),
-        _vfs_root(root_dir = framework_path + "/PrivateHeaders", files = ctx.files.private_hdrs),
-        _vfs_root(root_dir = framework_path + "/Modules", files = ctx.files.modulemap, override_name = "module.modulemap"),
-    ]
+    root_dir = framework_path
+    roots = _extra_vfs_root(ctx, ctx.attr.framework_name, root_dir, extra_vfs_root, module_map, hdrs, private_hdrs, has_swift)
 
     # These explicit settings ensure that the VFS actually improves search
     # performance.
@@ -46,34 +213,59 @@ def _framework_vfs_overlay_impl(ctx):
         "roots": [root for root in roots if root],
     }
     vfsoverlay_yaml = struct(**vfsoverlay_object).to_json()
-    vfsoverlay_file = ctx.outputs.vfs_overlay
 
     ctx.actions.write(
         content = vfsoverlay_yaml,
         output = vfsoverlay_file,
     )
 
-    files = depset(direct = [vfsoverlay_file])
-    cc_info = CcInfo(
-        compilation_context = cc_common.create_compilation_context(
-            headers = files,
-        ),
-    )
-    return [
-        apple_common.new_objc_provider(),
-        cc_info,
-        VFSOverlayInfo(
-            files = files,
-        ),
-    ]
+    #all_vfs = depset(transitive=merge_vfsoverlays)
+    # NEEDED WHEN:
+    # Frameworks/SquareCartBuilding/Sources/UI/Other/RQAbstractLineItemsViewController.m
+    # all_vfs = depset(transitive=[depset([vfsoverlay_file])] + merge_vfsoverlays)
+    all_vfs = depset(transitive = [depset([vfsoverlay_file])] + merge_vfsoverlays)
+
+    vfs_paths = [f.path for f in all_vfs.to_list()]
+
+    # Note: we don't merge the top level VFS here, so we need to propagate the tuple
+    merged_output = ctx.actions.declare_file(ctx.attr.name + ".yaml.merged")
+
+    if len(vfs_paths) > 0:
+        ctx.actions.run(
+            mnemonic = "MergeVFS",
+            arguments = [merged_output.path] + vfs_paths,
+            inputs = all_vfs,
+            executable = merge_tool.files.to_list()[0],
+            outputs = [merged_output],
+        )
+    else:
+        evfs = {
+            "version": 0,
+            "case-sensitive": True,
+            "overlay-relative": False,
+            "use-external-names": False,
+            "roots": [],
+        }
+        e_vfsoverlay_yaml = struct(**evfs).to_json()
+        ctx.actions.write(
+            content = e_vfsoverlay_yaml,
+            output = merged_output,
+        )
+
+    return struct(vfsoverlay_file_merged = merged_output, vfsoverlay_file = vfsoverlay_file, vfsoverlays = [])
 
 framework_vfs_overlay = rule(
     implementation = _framework_vfs_overlay_impl,
     attrs = {
         "framework_name": attr.string(mandatory = True),
+        #"framework_imports": attr.string_list(default = []),
+        "extra_vfs_root": attr.string(mandatory = False),
+        "has_swift": attr.bool(default = False),
         "modulemap": attr.label(allow_single_file = True),
         "hdrs": attr.label_list(allow_files = True),
         "private_hdrs": attr.label_list(allow_files = True),
+        "deps": attr.label_list(allow_files = True),
+        "merge_tool": attr.label(executable = True, default = Label("//rules/framework:merge_vfs_overlay"), cfg = "host"),
     },
     outputs = {
         "vfs_overlay": "%{name}.yaml",

--- a/rules/internal.bzl
+++ b/rules/internal.bzl
@@ -1,0 +1,15 @@
+FrameworkInfo = provider(
+    fields = {
+        "direct_includes": "",
+        "direct_framework_includes": "",
+        "cc_info": "",
+        "cc_info_merged": "",
+        "unpropagated_cc_infos": "",
+        "headermap_infos": "",
+        "vfsoverlay_infos": "",
+        "swift_infos": "",
+        "framework_headers": "",
+    }
+)
+
+

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -552,7 +552,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
             hdrs = import_headers,
             tags = _MANUAL,
             deps = [],
-            extra_vfs_root = vfs_root,
+            extra_vfs_root = None,
         )
         import_vfsoverlays.append(import_name + "_vfs")
 
@@ -564,7 +564,6 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
         import_module_map = native.glob(
             ["**/*.modulemap"],
         )
-        vfs_root = None
 
         if len(import_module_maps) > 0:
             import_module_map = import_module_maps[0]
@@ -582,7 +581,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
             hdrs = import_headers,
             tags = _MANUAL,
             deps = [],
-            extra_vfs_root = vfs_root,
+            extra_vfs_root = None,
         )
         import_vfsoverlays.append(import_name + "_vfs")
 

--- a/tests/ios/frameworks/strict-deps/a/BUILD.bazel
+++ b/tests/ios/frameworks/strict-deps/a/BUILD.bazel
@@ -4,6 +4,6 @@ apple_framework(
     name = "a",
     srcs = glob(["*.swift"]),
     deps = ["//tests/ios/frameworks/strict-deps/b"],
-    platforms = {"ios": "10.0"},
+    platforms = {"ios": "13.0"},
     visibility = ["//visibility:public"],
 )

--- a/tests/ios/frameworks/strict-deps/a/BUILD.bazel
+++ b/tests/ios/frameworks/strict-deps/a/BUILD.bazel
@@ -1,0 +1,9 @@
+load("//rules:framework.bzl", "apple_framework")
+
+apple_framework(
+    name = "a",
+    srcs = glob(["*.swift"]),
+    deps = ["//tests/ios/frameworks/strict-deps/b"],
+    platforms = {"ios": "10.0"},
+    visibility = ["//visibility:public"],
+)

--- a/tests/ios/frameworks/strict-deps/a/lib.swift
+++ b/tests/ios/frameworks/strict-deps/a/lib.swift
@@ -1,5 +1,6 @@
 import b
 
 struct A {
+    /// BB
     public static func run() { B.run() }
 }

--- a/tests/ios/frameworks/strict-deps/a/lib.swift
+++ b/tests/ios/frameworks/strict-deps/a/lib.swift
@@ -1,0 +1,5 @@
+import b
+
+struct A {
+    public static func run() { B.run() }
+}

--- a/tests/ios/frameworks/strict-deps/b/BUILD.bazel
+++ b/tests/ios/frameworks/strict-deps/b/BUILD.bazel
@@ -2,8 +2,12 @@ load("//rules:framework.bzl", "apple_framework")
 
 apple_framework(
     name = "b",
-    deps = ["//tests/ios/frameworks/strict-deps/c"],
+    deps = [
+            "//tests/ios/frameworks/strict-deps/c",
+            "//tests/ios/frameworks/mixed-source/custom-module-map:CustomModuleMap",
+            "//tests/ios/frameworks/sources-with-prebuilt-binaries:GoogleMobileAds"
+    ],
     srcs = glob(["*.swift"]),
-    platforms = {"ios": "10.0"},
+    platforms = {"ios": "13.0"},
     visibility = ["//visibility:public"],
 )

--- a/tests/ios/frameworks/strict-deps/b/BUILD.bazel
+++ b/tests/ios/frameworks/strict-deps/b/BUILD.bazel
@@ -1,0 +1,9 @@
+load("//rules:framework.bzl", "apple_framework")
+
+apple_framework(
+    name = "b",
+    deps = ["//tests/ios/frameworks/strict-deps/c"],
+    srcs = glob(["*.swift"]),
+    platforms = {"ios": "10.0"},
+    visibility = ["//visibility:public"],
+)

--- a/tests/ios/frameworks/strict-deps/b/lib.swift
+++ b/tests/ios/frameworks/strict-deps/b/lib.swift
@@ -1,4 +1,6 @@
 import c
+import CustomModuleMap
+import GoogleMobileAds
 
 public struct B {
     public static func run() { C.run() }

--- a/tests/ios/frameworks/strict-deps/b/lib.swift
+++ b/tests/ios/frameworks/strict-deps/b/lib.swift
@@ -1,0 +1,5 @@
+import c
+
+public struct B {
+    public static func run() { C.run() }
+}

--- a/tests/ios/frameworks/strict-deps/c/BUILD.bazel
+++ b/tests/ios/frameworks/strict-deps/c/BUILD.bazel
@@ -1,0 +1,8 @@
+load("//rules:framework.bzl", "apple_framework")
+
+apple_framework(
+    name = "c",
+    srcs = glob(["*.swift"]),
+    platforms = {"ios": "10.0"},
+    visibility = ["//visibility:public"],
+)

--- a/tests/ios/frameworks/strict-deps/c/lib.swift
+++ b/tests/ios/frameworks/strict-deps/c/lib.swift
@@ -1,3 +1,4 @@
 public struct C {
     public static func run() { print("runs here") }
+    public static func fun() { print("runs herb") }
 }

--- a/tests/ios/frameworks/strict-deps/c/lib.swift
+++ b/tests/ios/frameworks/strict-deps/c/lib.swift
@@ -1,0 +1,3 @@
+public struct C {
+    public static func run() { print("runs here") }
+}


### PR DESCRIPTION
Add the ability to virtualize the framework structure. swift and clang
compile as frameworks but the files don't move and we load them via VFS.

This is a working POC - for perf benchmarks only and as a reference of
the work.

Hacked this up to see how it impacts build performance in a big app.
Cut clean build time in half in a big hybrid app from rules_ios
baseline. More interestingly, hot top level compiler invocations are
down nearly .5 orders of magnitude.
