### PR TITLE
Virtual hermetic frameworks

### DIFF
--- a/docs/framework_doc.md
+++ b/docs/framework_doc.md
@@ -7,7 +7,7 @@
 <pre>
 apple_framework_packaging(<a href="#apple_framework_packaging-name">name</a>, <a href="#apple_framework_packaging-bundle_extension">bundle_extension</a>, <a href="#apple_framework_packaging-bundle_id">bundle_id</a>, <a href="#apple_framework_packaging-deps">deps</a>, <a href="#apple_framework_packaging-framework_name">framework_name</a>,
                           <a href="#apple_framework_packaging-minimum_os_version">minimum_os_version</a>, <a href="#apple_framework_packaging-platform_type">platform_type</a>, <a href="#apple_framework_packaging-platforms">platforms</a>, <a href="#apple_framework_packaging-skip_packaging">skip_packaging</a>,
-                          <a href="#apple_framework_packaging-transitive_deps">transitive_deps</a>)
+                          <a href="#apple_framework_packaging-transitive_deps">transitive_deps</a>, <a href="#apple_framework_packaging-vfs">vfs</a>)
 </pre>
 
 Packages compiled code into an Apple .framework package
@@ -27,6 +27,7 @@ Packages compiled code into an Apple .framework package
 | <a id="apple_framework_packaging-platforms"></a>platforms |  A dictionary of platform names to minimum deployment targets. If not given, the framework will be built for the platform it inherits from the target that uses the framework as a dependency.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="apple_framework_packaging-skip_packaging"></a>skip_packaging |  Parts of the framework packaging process to be skipped. Valid values are: - "binary" - "modulemap" - "header" - "private_header" - "swiftmodule" - "swiftdoc"   | List of strings | optional | [] |
 | <a id="apple_framework_packaging-transitive_deps"></a>transitive_deps |  Deps of the deps   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
+| <a id="apple_framework_packaging-vfs"></a>vfs |  Additional VFS for the framework to export   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
 <a id="#apple_framework"></a>

--- a/rules/features.bzl
+++ b/rules/features.bzl
@@ -1,0 +1,4 @@
+feature_names = struct(
+    # Virtualize means that swift,clang read from llvm's in-memory file system
+    virtualize_frameworks = "apple.virtualize_frameworks",
+)

--- a/rules/framework/vfs_overlay.bzl
+++ b/rules/framework/vfs_overlay.bzl
@@ -156,10 +156,7 @@ def _framework_vfs_overlay_impl(ctx):
 
 def _merge_vfs_infos(base, vfs_infos):
     for vfs_info in vfs_infos:
-        for key in vfs_info:
-            if key in base:
-                continue
-            base[key] = vfs_info[key]
+        base.update(vfs_info)
     return base
 
 # Internally the "vfs obj" is represented as a dictionary, which is keyed on

--- a/rules/framework/vfs_overlay.bzl
+++ b/rules/framework/vfs_overlay.bzl
@@ -1,40 +1,191 @@
+load("//rules:providers.bzl", "FrameworkInfo")
+load("//rules:features.bzl", "feature_names")
+
 FRAMEWORK_SEARCH_PATH = "/build_bazel_rules_ios/frameworks"
 
 VFSOverlayInfo = provider(
     doc = "Propagates vfs overlays",
     fields = {
         "files": "depset with overlays",
+        "vfs_info": "intneral obj",
     },
 )
 
-def _vfs_root(root_dir, files, override_name = None):
-    if not files:
-        return
+# Make roots for a given framework. For now this is done in starlark for speed
+# and incrementality. For imported frameworks, there is additional search paths
+# enabled
+def _make_root(ctx, framework_name, root_dir, extra_search_paths, module_map, hdrs, private_hdrs, has_swift):
+    extra_roots = []
+    if extra_search_paths:
+        sub_dir = "Headers"
 
-    return {
-        "name": root_dir,
+        # Strip the build file path
+        base_path = "/".join(ctx.build_file_path.split("/")[:-1])
+        rooted_path = base_path + "/" + extra_search_paths + "/" + sub_dir + "/"
+
+        extra_roots = [{
+            "type": "file",
+            "name": file.path.replace(rooted_path, ""),
+            "external-contents": file.path,
+        } for file in hdrs]
+
+        extra_roots += [{
+            "type": "file",
+            "name": framework_name + "/" + file.path.replace(rooted_path, ""),
+            "external-contents": file.path,
+        } for file in hdrs]
+
+    modules_contents = []
+    if len(module_map):
+        modules_contents.append({
+            "type": "file",
+            "name": "module.modulemap",
+            "external-contents": module_map[0].path,
+        })
+
+    modules = []
+    if len(modules_contents):
+        modules = [{
+            "name": "Modules",
+            "type": "directory",
+            "contents": modules_contents,
+        }]
+
+    headers_contents = extra_roots
+    headers_contents.extend([
+        {
+            "type": "file",
+            "name": file.basename,
+            "external-contents": file.path,
+        }
+        for file in hdrs
+    ])
+
+    headers = []
+    if len(headers_contents):
+        headers = [{
+            "name": "Headers",
+            "type": "directory",
+            "contents": headers_contents,
+        }]
+
+    private_headers_contents = {
+        "name": "PrivateHeaders",
         "type": "directory",
         "contents": [
             {
                 "type": "file",
-                "name": override_name or file.basename,
+                "name": file.basename,
                 "external-contents": file.path,
             }
-            for file in files
+            for file in private_hdrs
         ],
     }
 
+    private_headers = []
+    if len(private_hdrs):
+        private_headers = [private_headers_contents]
+
+    roots = []
+    if len(headers) or len(private_headers) or len(modules):
+        .append({
+            "name": root_dir,
+            "type": "directory",
+            "contents": headers + private_headers + modules,
+        })
+    if has_swift:
+        roots.append(_vfs_swift_module_contents(ctx, framework_name, FRAMEWORK_SEARCH_PATH))
+
+    return roots
+
+def _vfs_swift_module_contents(ctx, framework_name, root_dir):
+    # Forumlate the framework's swiftmodule - don't have the swiftmodule when
+    # creating with apple_library. Consider removing that codepath to make this
+    # and other situations easier
+    base_path = "/".join(ctx.build_file_path.split("/")[:-1])
+    bin_dir = ctx.bin_dir.path
+    rooted_path = bin_dir + "/" + base_path
+
+    # Note: Swift translates the input framework name to this because - is an
+    # invalid character in module name
+    name = framework_name.replace("-", "_") + ".swiftmodule"
+    external_contents = rooted_path + "/" + name
+    return {
+        "type": "file",
+        "name": root_dir + "/" + name,
+        "external-contents": external_contents,
+    }
+
 def _framework_vfs_overlay_impl(ctx):
-    framework_path = "{search_path}/{framework_name}.framework".format(
-        search_path = FRAMEWORK_SEARCH_PATH,
-        framework_name = ctx.attr.framework_name,
+    vfsoverlays = []
+
+    # Conditionally collect and pass in the VFS overlay here.
+    virtualize_frameworks = feature_names.virtualize_frameworks in ctx.features
+    if virtualize_frameworks:
+        for dep in ctx.attr.deps:
+            if FrameworkInfo in dep:
+                vfsoverlays.extend(dep[FrameworkInfo].vfsoverlay_infos)
+            if VFSOverlayInfo in dep:
+                vfsoverlays.append(dep[VFSOverlayInfo].vfs_info)
+
+    vfs = make_vfsoverlay(
+        ctx,
+        hdrs = ctx.files.hdrs,
+        module_map = ctx.files.modulemap,
+        private_hdrs = ctx.files.private_hdrs,
+        has_swift = ctx.attr.has_swift,
+        merge_vfsoverlays = vfsoverlays,
+        output = ctx.outputs.vfsoverlay_file,
+        extra_search_paths = ctx.attr.extra_search_paths,
     )
 
-    roots = [
-        _vfs_root(root_dir = framework_path + "/Headers", files = ctx.files.hdrs),
-        _vfs_root(root_dir = framework_path + "/PrivateHeaders", files = ctx.files.private_hdrs),
-        _vfs_root(root_dir = framework_path + "/Modules", files = ctx.files.modulemap, override_name = "module.modulemap"),
+    headers = depset([vfs.vfsoverlay_file])
+    cc_info = CcInfo(
+        compilation_context = cc_common.create_compilation_context(
+            headers = headers,
+        ),
+    )
+    return [
+        apple_common.new_objc_provider(),
+        cc_info,
+        VFSOverlayInfo(
+            files = depset([vfs.vfsoverlay_file]),
+            vfs_info = vfs.vfs_info,
+        ),
     ]
+
+def _merge_vfs_infos(base, vfs_infos):
+    for vfs_info in vfs_infos:
+        for key in vfs_info:
+            if key in base:
+                continue
+            base[key] = vfs_info[key]
+    return base
+
+# Internally the "vfs obj" is represented as a dictionary, which is keyed on
+# the name of the root. This is an opaque value to consumers
+def _make_vfs_info(roots):
+    keys = {}
+    for root in roots:
+        name = root["name"]
+        keys[name] = root
+    return keys
+
+def make_vfsoverlay(ctx, hdrs, module_map, private_hdrs, has_swift, merge_vfsoverlays = [], extra_search_paths = None, output = None):
+    framework_name = ctx.attr.framework_name
+    framework_path = "{search_path}/{framework_name}.framework".format(
+        search_path = FRAMEWORK_SEARCH_PATH,
+        framework_name = framework_name,
+    )
+
+    roots = _make_root(ctx, framework_name, framework_path, extra_search_paths, module_map, hdrs, private_hdrs, has_swift)
+    vfs_info = _make_vfs_info(roots)
+    if len(merge_vfsoverlays) > 0:
+        vfs_info = _merge_vfs_infos(vfs_info, merge_vfsoverlays)
+        roots = vfs_info.values()
+
+    if output == None:
+        return struct(vfsoverlay_file = None, vfs_info = vfs_info)
 
     # These explicit settings ensure that the VFS actually improves search
     # performance.
@@ -43,39 +194,28 @@ def _framework_vfs_overlay_impl(ctx):
         "case-sensitive": True,
         "overlay-relative": False,
         "use-external-names": False,
-        "roots": [root for root in roots if root],
+        "roots": roots,
     }
     vfsoverlay_yaml = struct(**vfsoverlay_object).to_json()
-    vfsoverlay_file = ctx.outputs.vfs_overlay
-
     ctx.actions.write(
         content = vfsoverlay_yaml,
-        output = vfsoverlay_file,
+        output = output,
     )
 
-    files = depset(direct = [vfsoverlay_file])
-    cc_info = CcInfo(
-        compilation_context = cc_common.create_compilation_context(
-            headers = files,
-        ),
-    )
-    return [
-        apple_common.new_objc_provider(),
-        cc_info,
-        VFSOverlayInfo(
-            files = files,
-        ),
-    ]
+    return struct(vfsoverlay_file = output, vfs_info = vfs_info)
 
 framework_vfs_overlay = rule(
     implementation = _framework_vfs_overlay_impl,
     attrs = {
         "framework_name": attr.string(mandatory = True),
+        "extra_search_paths": attr.string(mandatory = False),
+        "has_swift": attr.bool(default = False),
         "modulemap": attr.label(allow_single_file = True),
         "hdrs": attr.label_list(allow_files = True),
-        "private_hdrs": attr.label_list(allow_files = True),
+        "private_hdrs": attr.label_list(allow_files = True, default = []),
+        "deps": attr.label_list(allow_files = True, default = []),
     },
     outputs = {
-        "vfs_overlay": "%{name}.yaml",
+        "vfsoverlay_file": "%{name}.yaml",
     },
 )

--- a/rules/framework/vfs_overlay.bzl
+++ b/rules/framework/vfs_overlay.bzl
@@ -88,7 +88,7 @@ def _make_root(ctx, framework_name, root_dir, extra_search_paths, module_map, hd
 
     roots = []
     if len(headers) or len(private_headers) or len(modules):
-        .append({
+        roots.append({
             "name": root_dir,
             "type": "directory",
             "contents": headers + private_headers + modules,

--- a/rules/providers.bzl
+++ b/rules/providers.bzl
@@ -1,0 +1,6 @@
+FrameworkInfo = provider(
+    fields = {
+        "vfsoverlay_infos": "Merged VFS overlay infos, present when virtual frameworks enabled",
+        "framework_headers": "Headers part of the framework's public interface",
+    },
+)


### PR DESCRIPTION
Add the ability to virtualize the framework structure. swift and clang
compile as frameworks but the files don't move and we load them via VFS.
The VFS is llvm's in-memory file system declared by JSON. VFS is already
in use but this uses it in a very different way.

This fixes many issues:
1. we don't hit O(n) deps includes - removing thousands of framework
search paths
2. we don't have to "clean" frameworks. This feature added quite a bit
of overhead and isn't necesary since it's declarative
3. imports are fully again. traditionally a build system uses -F on a
build directory. This causes problems with reproducible builds.

It cut clean build time in half in a big hybrid app from rules_ios
baseline. More interestingly, hot top level compiler invocations are
down nearly .5 orders of magnitude.

Remaining tasks:
- address xcodeproj integration
- duplicate test suite to run with this on/off
- address xcframework imports ( right now we're using -F )

Relates to: #211