### PR TITLE
Exposes more fields in FrameworkInfo

### DIFF
--- a/rules/providers.bzl
+++ b/rules/providers.bzl
@@ -1,6 +1,11 @@
 FrameworkInfo = provider(
     fields = {
         "vfsoverlay_infos": "Merged VFS overlay infos, present when virtual frameworks enabled",
-        "framework_headers": "Headers part of the framework's public interface",
+        "binary": "The binary of the framework",
+        "headers": "Headers of the framework's public interface",
+        "private_headers": "Private headers of the framework",
+        "modulemap": "The module map of the framework",
+        "swiftmodule": "The swiftmodule",
+        "swiftdoc": " The Swift doc",
     },
 )


### PR DESCRIPTION
Downstream targets can directly read them. A use case is to repackage a static framework into a dynamic framework.