### PR TITLE
Fix no vfs target generated if no .framework present in path

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -280,8 +280,8 @@ def _xcframework_slice(*, xcframework_name, identifier, platform, platform_varia
     else:
         import_module_map = None
 
-    imporated_framework_name = _find_imported_framework_name(import_headers)
-    vfs_framework_name = imporated_framework_name if imporated_framework_name else xcframework_name
+    imported_framework_name = _find_imported_framework_name(import_headers)
+    vfs_framework_name = imported_framework_name if imported_framework_name else xcframework_name
     framework_vfs_overlay(
         name = resolved_target_name_vfs_overlay,
         framework_name = vfs_framework_name,

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -280,17 +280,17 @@ def _xcframework_slice(*, xcframework_name, identifier, platform, platform_varia
     else:
         import_module_map = None
 
-    vfs_imported_framework = _find_imported_framework_name(import_headers)
-    if vfs_imported_framework != None:
-        framework_vfs_overlay(
-            name = resolved_target_name_vfs_overlay,
-            framework_name = vfs_imported_framework,
-            modulemap = import_module_map,
-            swiftmodules = import_swiftmodules,
-            hdrs = import_headers,
-            tags = _MANUAL,
-            extra_search_paths = xcframework_name,
-        )
+    imporated_framework_name = _find_imported_framework_name(import_headers)
+    vfs_framework_name = imporated_framework_name if imporated_framework_name else xcframework_name
+    framework_vfs_overlay(
+        name = resolved_target_name_vfs_overlay,
+        framework_name = vfs_framework_name,
+        modulemap = import_module_map,
+        swiftmodules = import_swiftmodules,
+        hdrs = import_headers,
+        tags = _MANUAL,
+        extra_search_paths = xcframework_name,
+    )
     return (platform, platform_variant, supported_archs, resolved_target_name, resolved_target_name_vfs_overlay)
 
 def _xcframework(*, library_name, name, slices):


### PR DESCRIPTION
This happens for static library where we have .a directly under xcframework. Not having a .framework under .xcframework.
The original logic assumes there is a .framework present and will not create targaet for vfs if not present. 

Fallback to name used for .xcframework, which is consistent with the other place that having the same logic. 

Tests is done against a downstream project target. The full test cases will be estabalished when we roll out VFS fully.