### PR TITLE
Reduce VFS assumptions about swiftmodules

### DIFF
--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -97,7 +97,7 @@ def _make_swift_copts(target, deps, ctx):
     copts = []
     for hmap in hmap_files:
         copts.append("-Xcc")
-        hmap_arg = "-I$BAZEL_WORKSPACE_ROOT/%s" % hmap
+        hmap_arg = "-I$BAZEL_WORKSPACE_ROOT/%s" % hmap.path
         copts.append("\"%s\"" % hmap_arg)
 
     # Include the root


### PR DESCRIPTION
The previous code relied on assumptions about swiftmodules which may be
invalid, depending on the input.

Now:
- It puts the name of the parent in the framework if it's a
  swiftmodule-directory. This handles user provided directory
  swiftmodules. The code now checks if its a `.swiftmodule` because
  previously, it could take _any_ swiftmodule and give it the name of the
  parent: e.g. the build directory.

- It takes the name of the swiftmodule and puts it into the root as
  opposed to computing it.

It can fall back to the code path with assumptions to improve useability
of the rule. There would need to be further refactoring remove this:
Ideally remove this "apple libary only" codepath in the future.