### PR TITLE
[virtual-frameworks] fix transitive swiftmodule bug

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -458,6 +458,8 @@ def _apple_framework_packaging_impl(ctx):
     virtualize_frameworks = feature_names.virtualize_frameworks in ctx.features
     if virtualize_frameworks:
         framework_info = _get_virtual_framework_info(ctx, framework_files, compilation_context_fields)
+        if outputs.swiftmodule:
+            swift_info_fields["modules"] = _copy_swiftmodule(ctx, framework_files)
     else:
         framework_info = FrameworkInfo(
             headers = outputs.headers,

--- a/tests/ios/frameworks/strict-deps/BUILD.bazel
+++ b/tests/ios/frameworks/strict-deps/BUILD.bazel
@@ -1,0 +1,13 @@
+load("//rules:app.bzl", "ios_application")
+
+ios_application(
+    name = "App",
+    srcs = ["App/main.swift"],
+    bundle_id = "com.example.app",
+    minimum_os_version = "10.0",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tests/ios/frameworks/mixed-source/only-source:SwiftLibrary",
+        "//tests/ios/frameworks/strict-deps/a",
+    ],
+)

--- a/tests/ios/frameworks/strict-deps/a/BUILD.bazel
+++ b/tests/ios/frameworks/strict-deps/a/BUILD.bazel
@@ -1,0 +1,9 @@
+load("//rules:framework.bzl", "apple_framework")
+
+apple_framework(
+    name = "a",
+    srcs = glob(["*.swift"]),
+    platforms = {"ios": "10.0"},
+    visibility = ["//visibility:public"],
+    deps = ["//tests/ios/frameworks/strict-deps/b"],
+)

--- a/tests/ios/frameworks/strict-deps/a/lib.swift
+++ b/tests/ios/frameworks/strict-deps/a/lib.swift
@@ -1,0 +1,5 @@
+import b
+
+struct A {
+    public static func run() { B.run() }
+}

--- a/tests/ios/frameworks/strict-deps/b/BUILD.bazel
+++ b/tests/ios/frameworks/strict-deps/b/BUILD.bazel
@@ -1,0 +1,9 @@
+load("//rules:framework.bzl", "apple_framework")
+
+apple_framework(
+    name = "b",
+    srcs = glob(["*.swift"]),
+    platforms = {"ios": "10.0"},
+    visibility = ["//visibility:public"],
+    deps = ["//tests/ios/frameworks/strict-deps/c"],
+)

--- a/tests/ios/frameworks/strict-deps/b/lib.swift
+++ b/tests/ios/frameworks/strict-deps/b/lib.swift
@@ -1,0 +1,5 @@
+import c
+
+public struct B {
+    public static func run() { C.run() }
+}

--- a/tests/ios/frameworks/strict-deps/c/BUILD.bazel
+++ b/tests/ios/frameworks/strict-deps/c/BUILD.bazel
@@ -1,0 +1,8 @@
+load("//rules:framework.bzl", "apple_framework")
+
+apple_framework(
+    name = "c",
+    srcs = glob(["*.swift"]),
+    platforms = {"ios": "10.0"},
+    visibility = ["//visibility:public"],
+)

--- a/tests/ios/frameworks/strict-deps/c/lib.swift
+++ b/tests/ios/frameworks/strict-deps/c/lib.swift
@@ -1,0 +1,3 @@
+public struct C {
+    public static func run() { print("runs here") }
+}


### PR DESCRIPTION
If the swiftmodule isn't propagated upwards, it will cause issues when
re-compiling and re-linking in the case of a remote cache or when the
local cache is primed with existing state.

This an example serial chain of swiftdeps to showcase the situation
```
a->b->c
```