### PR TITLE
Fixes default swiftmodule include issue

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,7 @@
 # Pull buildifer.mac as an http_file, then depend on the file group to make an
 # executable
 load("@build_bazel_rules_swift//swift/internal:feature_names.bzl", "SWIFT_FEATURE_USE_GLOBAL_INDEX_STORE")
+load("//rules:features.bzl", "feature_names")
 
 sh_binary(
     name = "buildifier",
@@ -11,5 +12,12 @@ config_setting(
     name = "use_global_index_store",
     values = {
         "features": SWIFT_FEATURE_USE_GLOBAL_INDEX_STORE,
+    },
+)
+
+config_setting(
+    name = "virtualize_frameworks",
+    values = {
+        "features": feature_names.virtualize_frameworks,
     },
 )

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -827,7 +827,12 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
             copts = copts_by_build_setting.swift_copts + swift_copts + additional_swift_copts,
             deps = deps + private_deps + lib_names,
             swiftc_inputs = swiftc_inputs,
-            features = ["swift.no_generated_module_map"],
+            features = ["swift.no_generated_module_map"] + select({
+                # rules_swift propagates swiftmodules to includes when they exist as a
+                # dep.
+                "@build_bazel_rules_ios//:virtualize_frameworks": ["swift.vfsoverlay"],
+                "//conditions:default": [],
+            }),
             data = [module_data],
             tags = tags_manual,
             **kwargs


### PR DESCRIPTION
By default `rules_swift` propagates swiftmodules to includes when they
exist as a dep. For now, we need to propagate these as they were.

Additionally, it factors out SwiftInfo building to another function.
This is orthogonal to the change, but something we came up with in the
continued effort to make the framework large framework method a bit
easier to follow than originally.