### PR TITLE
Supports Info.plist in framework

### DIFF
--- a/docs/framework_doc.md
+++ b/docs/framework_doc.md
@@ -5,9 +5,9 @@
 ## apple_framework_packaging
 
 <pre>
-apple_framework_packaging(<a href="#apple_framework_packaging-name">name</a>, <a href="#apple_framework_packaging-bundle_extension">bundle_extension</a>, <a href="#apple_framework_packaging-bundle_id">bundle_id</a>, <a href="#apple_framework_packaging-deps">deps</a>, <a href="#apple_framework_packaging-framework_name">framework_name</a>,
-                          <a href="#apple_framework_packaging-minimum_os_version">minimum_os_version</a>, <a href="#apple_framework_packaging-platform_type">platform_type</a>, <a href="#apple_framework_packaging-platforms">platforms</a>, <a href="#apple_framework_packaging-skip_packaging">skip_packaging</a>,
-                          <a href="#apple_framework_packaging-transitive_deps">transitive_deps</a>, <a href="#apple_framework_packaging-vfs">vfs</a>)
+apple_framework_packaging(<a href="#apple_framework_packaging-name">name</a>, <a href="#apple_framework_packaging-bundle_extension">bundle_extension</a>, <a href="#apple_framework_packaging-bundle_id">bundle_id</a>, <a href="#apple_framework_packaging-deps">deps</a>, <a href="#apple_framework_packaging-environment_plist">environment_plist</a>,
+                          <a href="#apple_framework_packaging-framework_name">framework_name</a>, <a href="#apple_framework_packaging-infoplists">infoplists</a>, <a href="#apple_framework_packaging-minimum_os_version">minimum_os_version</a>, <a href="#apple_framework_packaging-platform_type">platform_type</a>, <a href="#apple_framework_packaging-platforms">platforms</a>,
+                          <a href="#apple_framework_packaging-skip_packaging">skip_packaging</a>, <a href="#apple_framework_packaging-transitive_deps">transitive_deps</a>, <a href="#apple_framework_packaging-vfs">vfs</a>)
 </pre>
 
 Packages compiled code into an Apple .framework package
@@ -21,7 +21,9 @@ Packages compiled code into an Apple .framework package
 | <a id="apple_framework_packaging-bundle_extension"></a>bundle_extension |  The extension of the bundle, defaults to "framework".   | String | optional | "framework" |
 | <a id="apple_framework_packaging-bundle_id"></a>bundle_id |  The bundle identifier of the framework. Currently unused.   | String | optional | "" |
 | <a id="apple_framework_packaging-deps"></a>deps |  Objc or Swift rules to be packed by the framework rule   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
+| <a id="apple_framework_packaging-environment_plist"></a>environment_plist |  An executable file referencing the environment_plist tool. Used to merge infoplists. See https://github.com/bazelbuild/rules_apple/blob/master/apple/internal/environment_plist.bzl#L69   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="apple_framework_packaging-framework_name"></a>framework_name |  Name of the framework, usually the same as the module name   | String | required |  |
+| <a id="apple_framework_packaging-infoplists"></a>infoplists |  The infoplists for the framework   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="apple_framework_packaging-minimum_os_version"></a>minimum_os_version |  Internal - currently rules_ios the dict <code>platforms</code>   | String | optional | "" |
 | <a id="apple_framework_packaging-platform_type"></a>platform_type |  Internal - currently rules_ios uses the dict <code>platforms</code>   | String | optional | "" |
 | <a id="apple_framework_packaging-platforms"></a>platforms |  A dictionary of platform names to minimum deployment targets. If not given, the framework will be built for the platform it inherits from the target that uses the framework as a dependency.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |

--- a/tests/ios/frameworks/strict-deps/a/BUILD.bazel
+++ b/tests/ios/frameworks/strict-deps/a/BUILD.bazel
@@ -3,6 +3,7 @@ load("//rules:framework.bzl", "apple_framework")
 apple_framework(
     name = "a",
     srcs = glob(["*.swift"]),
+    infoplists = ["//rules/test_host_app:Info.plist"],
     platforms = {"ios": "10.0"},
     visibility = ["//visibility:public"],
     deps = ["//tests/ios/frameworks/strict-deps/b"],


### PR DESCRIPTION
When distributing a framework to third-party developers, we will want to include a Info.plist file into the framework.
This PR uses rules_apple's resource_actions.merge_root_infoplists to merge info.plists and converts them into binary.