### PR TITLE
Copy swiftmodules to both Xcode 12/13+ locations

### DIFF
--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/_swiftmodule.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/_swiftmodule.sh
@@ -2,18 +2,31 @@
 
 set -euo pipefail
 
-for module in "$@"; do
-    doc="${module%.swiftmodule}.swiftdoc"
-    module_name=$(basename "$module")
-    module_bundle="$BUILT_PRODUCTS_DIR/$module_name"
-    mkdir -p "$module_bundle"
+# Xcode 12 and under stored index information in /DerivedData/<project>/Build/Products
+readonly xcode_12_index_dir="$BUILT_PRODUCTS_DIR"
 
-    cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule"
-    cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc"
+# Xcode 13 and later store index information in /DerivedData/<project>/Index/Build/Products
+readonly xcode_13_index_dir="${BUILT_PRODUCTS_DIR/\/Build\/Products\///Index/Build/Products/}"
 
-    ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
-    cp "$module" "$module_bundle/$ios_module_name.swiftmodule"
-    cp "$doc" "$module_bundle/$ios_module_name.swiftdoc"
+readonly dirs=(
+  "$xcode_12_index_dir"
+  "$xcode_13_index_dir"
+)
 
-    chmod -R +w "$module_bundle"
+for index_dir in "${dirs[@]}"; do
+    for module in "$@"; do
+        doc="${module%.swiftmodule}.swiftdoc"
+        module_name=$(basename "$module")
+        module_bundle="$index_dir/$module_name"
+        mkdir -p "$module_bundle"
+
+        cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule" || true
+        cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc" || true
+
+        ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
+        cp "$module" "$module_bundle/$ios_module_name.swiftmodule" || true
+        cp "$doc" "$module_bundle/$ios_module_name.swiftdoc" || true
+
+        chmod -R +w "$module_bundle"
+    done
 done

--- a/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/_swiftmodule.sh
+++ b/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/_swiftmodule.sh
@@ -2,18 +2,31 @@
 
 set -euo pipefail
 
-for module in "$@"; do
-    doc="${module%.swiftmodule}.swiftdoc"
-    module_name=$(basename "$module")
-    module_bundle="$BUILT_PRODUCTS_DIR/$module_name"
-    mkdir -p "$module_bundle"
+# Xcode 12 and under stored index information in /DerivedData/<project>/Build/Products
+readonly xcode_12_index_dir="$BUILT_PRODUCTS_DIR"
 
-    cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule"
-    cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc"
+# Xcode 13 and later store index information in /DerivedData/<project>/Index/Build/Products
+readonly xcode_13_index_dir="${BUILT_PRODUCTS_DIR/\/Build\/Products\///Index/Build/Products/}"
 
-    ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
-    cp "$module" "$module_bundle/$ios_module_name.swiftmodule"
-    cp "$doc" "$module_bundle/$ios_module_name.swiftdoc"
+readonly dirs=(
+  "$xcode_12_index_dir"
+  "$xcode_13_index_dir"
+)
 
-    chmod -R +w "$module_bundle"
+for index_dir in "${dirs[@]}"; do
+    for module in "$@"; do
+        doc="${module%.swiftmodule}.swiftdoc"
+        module_name=$(basename "$module")
+        module_bundle="$index_dir/$module_name"
+        mkdir -p "$module_bundle"
+
+        cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule" || true
+        cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc" || true
+
+        ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
+        cp "$module" "$module_bundle/$ios_module_name.swiftmodule" || true
+        cp "$doc" "$module_bundle/$ios_module_name.swiftdoc" || true
+
+        chmod -R +w "$module_bundle"
+    done
 done

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/_swiftmodule.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/_swiftmodule.sh
@@ -2,18 +2,31 @@
 
 set -euo pipefail
 
-for module in "$@"; do
-    doc="${module%.swiftmodule}.swiftdoc"
-    module_name=$(basename "$module")
-    module_bundle="$BUILT_PRODUCTS_DIR/$module_name"
-    mkdir -p "$module_bundle"
+# Xcode 12 and under stored index information in /DerivedData/<project>/Build/Products
+readonly xcode_12_index_dir="$BUILT_PRODUCTS_DIR"
 
-    cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule"
-    cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc"
+# Xcode 13 and later store index information in /DerivedData/<project>/Index/Build/Products
+readonly xcode_13_index_dir="${BUILT_PRODUCTS_DIR/\/Build\/Products\///Index/Build/Products/}"
 
-    ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
-    cp "$module" "$module_bundle/$ios_module_name.swiftmodule"
-    cp "$doc" "$module_bundle/$ios_module_name.swiftdoc"
+readonly dirs=(
+  "$xcode_12_index_dir"
+  "$xcode_13_index_dir"
+)
 
-    chmod -R +w "$module_bundle"
+for index_dir in "${dirs[@]}"; do
+    for module in "$@"; do
+        doc="${module%.swiftmodule}.swiftdoc"
+        module_name=$(basename "$module")
+        module_bundle="$index_dir/$module_name"
+        mkdir -p "$module_bundle"
+
+        cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule" || true
+        cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc" || true
+
+        ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
+        cp "$module" "$module_bundle/$ios_module_name.swiftmodule" || true
+        cp "$doc" "$module_bundle/$ios_module_name.swiftdoc" || true
+
+        chmod -R +w "$module_bundle"
+    done
 done

--- a/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_swiftmodule.sh
+++ b/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_swiftmodule.sh
@@ -2,18 +2,31 @@
 
 set -euo pipefail
 
-for module in "$@"; do
-    doc="${module%.swiftmodule}.swiftdoc"
-    module_name=$(basename "$module")
-    module_bundle="$BUILT_PRODUCTS_DIR/$module_name"
-    mkdir -p "$module_bundle"
+# Xcode 12 and under stored index information in /DerivedData/<project>/Build/Products
+readonly xcode_12_index_dir="$BUILT_PRODUCTS_DIR"
 
-    cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule"
-    cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc"
+# Xcode 13 and later store index information in /DerivedData/<project>/Index/Build/Products
+readonly xcode_13_index_dir="${BUILT_PRODUCTS_DIR/\/Build\/Products\///Index/Build/Products/}"
 
-    ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
-    cp "$module" "$module_bundle/$ios_module_name.swiftmodule"
-    cp "$doc" "$module_bundle/$ios_module_name.swiftdoc"
+readonly dirs=(
+  "$xcode_12_index_dir"
+  "$xcode_13_index_dir"
+)
 
-    chmod -R +w "$module_bundle"
+for index_dir in "${dirs[@]}"; do
+    for module in "$@"; do
+        doc="${module%.swiftmodule}.swiftdoc"
+        module_name=$(basename "$module")
+        module_bundle="$index_dir/$module_name"
+        mkdir -p "$module_bundle"
+
+        cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule" || true
+        cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc" || true
+
+        ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
+        cp "$module" "$module_bundle/$ios_module_name.swiftmodule" || true
+        cp "$doc" "$module_bundle/$ios_module_name.swiftdoc" || true
+
+        chmod -R +w "$module_bundle"
+    done
 done

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/_swiftmodule.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/_swiftmodule.sh
@@ -2,18 +2,31 @@
 
 set -euo pipefail
 
-for module in "$@"; do
-    doc="${module%.swiftmodule}.swiftdoc"
-    module_name=$(basename "$module")
-    module_bundle="$BUILT_PRODUCTS_DIR/$module_name"
-    mkdir -p "$module_bundle"
+# Xcode 12 and under stored index information in /DerivedData/<project>/Build/Products
+readonly xcode_12_index_dir="$BUILT_PRODUCTS_DIR"
 
-    cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule"
-    cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc"
+# Xcode 13 and later store index information in /DerivedData/<project>/Index/Build/Products
+readonly xcode_13_index_dir="${BUILT_PRODUCTS_DIR/\/Build\/Products\///Index/Build/Products/}"
 
-    ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
-    cp "$module" "$module_bundle/$ios_module_name.swiftmodule"
-    cp "$doc" "$module_bundle/$ios_module_name.swiftdoc"
+readonly dirs=(
+  "$xcode_12_index_dir"
+  "$xcode_13_index_dir"
+)
 
-    chmod -R +w "$module_bundle"
+for index_dir in "${dirs[@]}"; do
+    for module in "$@"; do
+        doc="${module%.swiftmodule}.swiftdoc"
+        module_name=$(basename "$module")
+        module_bundle="$index_dir/$module_name"
+        mkdir -p "$module_bundle"
+
+        cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule" || true
+        cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc" || true
+
+        ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
+        cp "$module" "$module_bundle/$ios_module_name.swiftmodule" || true
+        cp "$doc" "$module_bundle/$ios_module_name.swiftdoc" || true
+
+        chmod -R +w "$module_bundle"
+    done
 done

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/_swiftmodule.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/_swiftmodule.sh
@@ -2,18 +2,31 @@
 
 set -euo pipefail
 
-for module in "$@"; do
-    doc="${module%.swiftmodule}.swiftdoc"
-    module_name=$(basename "$module")
-    module_bundle="$BUILT_PRODUCTS_DIR/$module_name"
-    mkdir -p "$module_bundle"
+# Xcode 12 and under stored index information in /DerivedData/<project>/Build/Products
+readonly xcode_12_index_dir="$BUILT_PRODUCTS_DIR"
 
-    cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule"
-    cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc"
+# Xcode 13 and later store index information in /DerivedData/<project>/Index/Build/Products
+readonly xcode_13_index_dir="${BUILT_PRODUCTS_DIR/\/Build\/Products\///Index/Build/Products/}"
 
-    ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
-    cp "$module" "$module_bundle/$ios_module_name.swiftmodule"
-    cp "$doc" "$module_bundle/$ios_module_name.swiftdoc"
+readonly dirs=(
+  "$xcode_12_index_dir"
+  "$xcode_13_index_dir"
+)
 
-    chmod -R +w "$module_bundle"
+for index_dir in "${dirs[@]}"; do
+    for module in "$@"; do
+        doc="${module%.swiftmodule}.swiftdoc"
+        module_name=$(basename "$module")
+        module_bundle="$index_dir/$module_name"
+        mkdir -p "$module_bundle"
+
+        cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule" || true
+        cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc" || true
+
+        ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
+        cp "$module" "$module_bundle/$ios_module_name.swiftmodule" || true
+        cp "$doc" "$module_bundle/$ios_module_name.swiftdoc" || true
+
+        chmod -R +w "$module_bundle"
+    done
 done

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/_swiftmodule.sh
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/_swiftmodule.sh
@@ -2,18 +2,31 @@
 
 set -euo pipefail
 
-for module in "$@"; do
-    doc="${module%.swiftmodule}.swiftdoc"
-    module_name=$(basename "$module")
-    module_bundle="$BUILT_PRODUCTS_DIR/$module_name"
-    mkdir -p "$module_bundle"
+# Xcode 12 and under stored index information in /DerivedData/<project>/Build/Products
+readonly xcode_12_index_dir="$BUILT_PRODUCTS_DIR"
 
-    cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule"
-    cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc"
+# Xcode 13 and later store index information in /DerivedData/<project>/Index/Build/Products
+readonly xcode_13_index_dir="${BUILT_PRODUCTS_DIR/\/Build\/Products\///Index/Build/Products/}"
 
-    ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
-    cp "$module" "$module_bundle/$ios_module_name.swiftmodule"
-    cp "$doc" "$module_bundle/$ios_module_name.swiftdoc"
+readonly dirs=(
+  "$xcode_12_index_dir"
+  "$xcode_13_index_dir"
+)
 
-    chmod -R +w "$module_bundle"
+for index_dir in "${dirs[@]}"; do
+    for module in "$@"; do
+        doc="${module%.swiftmodule}.swiftdoc"
+        module_name=$(basename "$module")
+        module_bundle="$index_dir/$module_name"
+        mkdir -p "$module_bundle"
+
+        cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule" || true
+        cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc" || true
+
+        ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
+        cp "$module" "$module_bundle/$ios_module_name.swiftmodule" || true
+        cp "$doc" "$module_bundle/$ios_module_name.swiftdoc" || true
+
+        chmod -R +w "$module_bundle"
+    done
 done

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/_swiftmodule.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/_swiftmodule.sh
@@ -2,18 +2,31 @@
 
 set -euo pipefail
 
-for module in "$@"; do
-    doc="${module%.swiftmodule}.swiftdoc"
-    module_name=$(basename "$module")
-    module_bundle="$BUILT_PRODUCTS_DIR/$module_name"
-    mkdir -p "$module_bundle"
+# Xcode 12 and under stored index information in /DerivedData/<project>/Build/Products
+readonly xcode_12_index_dir="$BUILT_PRODUCTS_DIR"
 
-    cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule"
-    cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc"
+# Xcode 13 and later store index information in /DerivedData/<project>/Index/Build/Products
+readonly xcode_13_index_dir="${BUILT_PRODUCTS_DIR/\/Build\/Products\///Index/Build/Products/}"
 
-    ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
-    cp "$module" "$module_bundle/$ios_module_name.swiftmodule"
-    cp "$doc" "$module_bundle/$ios_module_name.swiftdoc"
+readonly dirs=(
+  "$xcode_12_index_dir"
+  "$xcode_13_index_dir"
+)
 
-    chmod -R +w "$module_bundle"
+for index_dir in "${dirs[@]}"; do
+    for module in "$@"; do
+        doc="${module%.swiftmodule}.swiftdoc"
+        module_name=$(basename "$module")
+        module_bundle="$index_dir/$module_name"
+        mkdir -p "$module_bundle"
+
+        cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule" || true
+        cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc" || true
+
+        ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
+        cp "$module" "$module_bundle/$ios_module_name.swiftmodule" || true
+        cp "$doc" "$module_bundle/$ios_module_name.swiftdoc" || true
+
+        chmod -R +w "$module_bundle"
+    done
 done

--- a/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_swiftmodule.sh
+++ b/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_swiftmodule.sh
@@ -2,18 +2,31 @@
 
 set -euo pipefail
 
-for module in "$@"; do
-    doc="${module%.swiftmodule}.swiftdoc"
-    module_name=$(basename "$module")
-    module_bundle="$BUILT_PRODUCTS_DIR/$module_name"
-    mkdir -p "$module_bundle"
+# Xcode 12 and under stored index information in /DerivedData/<project>/Build/Products
+readonly xcode_12_index_dir="$BUILT_PRODUCTS_DIR"
 
-    cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule"
-    cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc"
+# Xcode 13 and later store index information in /DerivedData/<project>/Index/Build/Products
+readonly xcode_13_index_dir="${BUILT_PRODUCTS_DIR/\/Build\/Products\///Index/Build/Products/}"
 
-    ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
-    cp "$module" "$module_bundle/$ios_module_name.swiftmodule"
-    cp "$doc" "$module_bundle/$ios_module_name.swiftdoc"
+readonly dirs=(
+  "$xcode_12_index_dir"
+  "$xcode_13_index_dir"
+)
 
-    chmod -R +w "$module_bundle"
+for index_dir in "${dirs[@]}"; do
+    for module in "$@"; do
+        doc="${module%.swiftmodule}.swiftdoc"
+        module_name=$(basename "$module")
+        module_bundle="$index_dir/$module_name"
+        mkdir -p "$module_bundle"
+
+        cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule" || true
+        cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc" || true
+
+        ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
+        cp "$module" "$module_bundle/$ios_module_name.swiftmodule" || true
+        cp "$doc" "$module_bundle/$ios_module_name.swiftdoc" || true
+
+        chmod -R +w "$module_bundle"
+    done
 done

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/_swiftmodule.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/_swiftmodule.sh
@@ -2,18 +2,31 @@
 
 set -euo pipefail
 
-for module in "$@"; do
-    doc="${module%.swiftmodule}.swiftdoc"
-    module_name=$(basename "$module")
-    module_bundle="$BUILT_PRODUCTS_DIR/$module_name"
-    mkdir -p "$module_bundle"
+# Xcode 12 and under stored index information in /DerivedData/<project>/Build/Products
+readonly xcode_12_index_dir="$BUILT_PRODUCTS_DIR"
 
-    cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule"
-    cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc"
+# Xcode 13 and later store index information in /DerivedData/<project>/Index/Build/Products
+readonly xcode_13_index_dir="${BUILT_PRODUCTS_DIR/\/Build\/Products\///Index/Build/Products/}"
 
-    ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
-    cp "$module" "$module_bundle/$ios_module_name.swiftmodule"
-    cp "$doc" "$module_bundle/$ios_module_name.swiftdoc"
+readonly dirs=(
+  "$xcode_12_index_dir"
+  "$xcode_13_index_dir"
+)
 
-    chmod -R +w "$module_bundle"
+for index_dir in "${dirs[@]}"; do
+    for module in "$@"; do
+        doc="${module%.swiftmodule}.swiftdoc"
+        module_name=$(basename "$module")
+        module_bundle="$index_dir/$module_name"
+        mkdir -p "$module_bundle"
+
+        cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule" || true
+        cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc" || true
+
+        ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
+        cp "$module" "$module_bundle/$ios_module_name.swiftmodule" || true
+        cp "$doc" "$module_bundle/$ios_module_name.swiftdoc" || true
+
+        chmod -R +w "$module_bundle"
+    done
 done

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/_swiftmodule.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/_swiftmodule.sh
@@ -2,18 +2,31 @@
 
 set -euo pipefail
 
-for module in "$@"; do
-    doc="${module%.swiftmodule}.swiftdoc"
-    module_name=$(basename "$module")
-    module_bundle="$BUILT_PRODUCTS_DIR/$module_name"
-    mkdir -p "$module_bundle"
+# Xcode 12 and under stored index information in /DerivedData/<project>/Build/Products
+readonly xcode_12_index_dir="$BUILT_PRODUCTS_DIR"
 
-    cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule"
-    cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc"
+# Xcode 13 and later store index information in /DerivedData/<project>/Index/Build/Products
+readonly xcode_13_index_dir="${BUILT_PRODUCTS_DIR/\/Build\/Products\///Index/Build/Products/}"
 
-    ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
-    cp "$module" "$module_bundle/$ios_module_name.swiftmodule"
-    cp "$doc" "$module_bundle/$ios_module_name.swiftdoc"
+readonly dirs=(
+  "$xcode_12_index_dir"
+  "$xcode_13_index_dir"
+)
 
-    chmod -R +w "$module_bundle"
+for index_dir in "${dirs[@]}"; do
+    for module in "$@"; do
+        doc="${module%.swiftmodule}.swiftdoc"
+        module_name=$(basename "$module")
+        module_bundle="$index_dir/$module_name"
+        mkdir -p "$module_bundle"
+
+        cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule" || true
+        cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc" || true
+
+        ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
+        cp "$module" "$module_bundle/$ios_module_name.swiftmodule" || true
+        cp "$doc" "$module_bundle/$ios_module_name.swiftdoc" || true
+
+        chmod -R +w "$module_bundle"
+    done
 done

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/_swiftmodule.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/_swiftmodule.sh
@@ -2,18 +2,31 @@
 
 set -euo pipefail
 
-for module in "$@"; do
-    doc="${module%.swiftmodule}.swiftdoc"
-    module_name=$(basename "$module")
-    module_bundle="$BUILT_PRODUCTS_DIR/$module_name"
-    mkdir -p "$module_bundle"
+# Xcode 12 and under stored index information in /DerivedData/<project>/Build/Products
+readonly xcode_12_index_dir="$BUILT_PRODUCTS_DIR"
 
-    cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule"
-    cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc"
+# Xcode 13 and later store index information in /DerivedData/<project>/Index/Build/Products
+readonly xcode_13_index_dir="${BUILT_PRODUCTS_DIR/\/Build\/Products\///Index/Build/Products/}"
 
-    ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
-    cp "$module" "$module_bundle/$ios_module_name.swiftmodule"
-    cp "$doc" "$module_bundle/$ios_module_name.swiftdoc"
+readonly dirs=(
+  "$xcode_12_index_dir"
+  "$xcode_13_index_dir"
+)
 
-    chmod -R +w "$module_bundle"
+for index_dir in "${dirs[@]}"; do
+    for module in "$@"; do
+        doc="${module%.swiftmodule}.swiftdoc"
+        module_name=$(basename "$module")
+        module_bundle="$index_dir/$module_name"
+        mkdir -p "$module_bundle"
+
+        cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule" || true
+        cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc" || true
+
+        ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
+        cp "$module" "$module_bundle/$ios_module_name.swiftmodule" || true
+        cp "$doc" "$module_bundle/$ios_module_name.swiftdoc" || true
+
+        chmod -R +w "$module_bundle"
+    done
 done

--- a/tools/xcodeproj_shims/installers/_swiftmodule.sh
+++ b/tools/xcodeproj_shims/installers/_swiftmodule.sh
@@ -2,18 +2,31 @@
 
 set -euo pipefail
 
-for module in "$@"; do
-    doc="${module%.swiftmodule}.swiftdoc"
-    module_name=$(basename "$module")
-    module_bundle="$BUILT_PRODUCTS_DIR/$module_name"
-    mkdir -p "$module_bundle"
+# Xcode 12 and under stored index information in /DerivedData/<project>/Build/Products
+readonly xcode_12_index_dir="$BUILT_PRODUCTS_DIR"
 
-    cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule"
-    cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc"
+# Xcode 13 and later store index information in /DerivedData/<project>/Index/Build/Products
+readonly xcode_13_index_dir="${BUILT_PRODUCTS_DIR/\/Build\/Products\///Index/Build/Products/}"
 
-    ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
-    cp "$module" "$module_bundle/$ios_module_name.swiftmodule"
-    cp "$doc" "$module_bundle/$ios_module_name.swiftdoc"
+readonly dirs=(
+  "$xcode_12_index_dir"
+  "$xcode_13_index_dir"
+)
 
-    chmod -R +w "$module_bundle"
+for index_dir in "${dirs[@]}"; do
+    for module in "$@"; do
+        doc="${module%.swiftmodule}.swiftdoc"
+        module_name=$(basename "$module")
+        module_bundle="$index_dir/$module_name"
+        mkdir -p "$module_bundle"
+
+        cp "$module" "$module_bundle/$CURRENT_ARCH.swiftmodule" || true
+        cp "$doc" "$module_bundle/$CURRENT_ARCH.swiftdoc" || true
+
+        ios_module_name="$CURRENT_ARCH-$LLVM_TARGET_TRIPLE_VENDOR-$SWIFT_PLATFORM_TARGET_PREFIX$LLVM_TARGET_TRIPLE_SUFFIX"
+        cp "$module" "$module_bundle/$ios_module_name.swiftmodule" || true
+        cp "$doc" "$module_bundle/$ios_module_name.swiftdoc" || true
+
+        chmod -R +w "$module_bundle"
+    done
 done


### PR DESCRIPTION
Resolves #306 

Xcode 13 now stores swiftmodule index information the `Index` directory in derived data. This modifies the swiftmodule installer to copy to both locations.

(Credit @brentleyjones in **iOS-dev-at-scale**: https://ios-dev-at-scale.slack.com/archives/CJDFFEN4S/p1631798553000500)