### PR TITLE
Fix LLDB internal module compilation error

### DIFF
--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -701,9 +701,12 @@ def _populate_xcodeproj_targets_and_schemes(ctx, targets, src_dot_dots, all_tran
         target_settings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] = " ".join(
             ["\"%s\"" % d for d in defines_without_equal_sign],
         )
-        target_settings["BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS"] = " ".join(
-            ["-D%s" % d for d in target_info.cc_defines.to_list()],
-        )
+        extra_clang_flags = ["-D%s" % d for d in target_info.cc_defines.to_list()]
+
+        if virtualize_frameworks:
+            extra_clang_flags += ["-Xcc %s" % d for d in _objc_copts_for_target(target_name, all_transitive_targets)]
+
+        target_settings["BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS"] = " ".join(extra_clang_flags)
 
         target_settings["BAZEL_LLDB_INIT_FILE"] = lldbinit_file
 

--- a/tests/ios/unit-test/test-imports-app/Header.h
+++ b/tests/ios/unit-test/test-imports-app/Header.h
@@ -2,4 +2,4 @@
 // - Xcode target name
 // - "Module" name
 #import <TestImports-App/Header2.h> // Path from headermap
-#import <TestImports_App/Header2.h> // Actual path
+// #import <TestImports_App/Header2.h> // Actual path

--- a/tests/ios/unit-test/test-imports-app/Header.h
+++ b/tests/ios/unit-test/test-imports-app/Header.h
@@ -1,1 +1,5 @@
-#import <TestImports-App/Header2.h>
+// Note: rules_ios currently supports both of the names.
+// - Xcode target name
+// - "Module" name
+#import <TestImports-App/Header2.h> // Path from headermap
+#import <TestImports_App/Header2.h> // Actual path

--- a/tests/ios/unit-test/test-imports-app/empty.swift
+++ b/tests/ios/unit-test/test-imports-app/empty.swift
@@ -1,5 +1,15 @@
 import Foundation
 import SomeFramework
 
-@objc public class EmptyClass: NSObject {}
+@objc public class EmptyClass: NSObject {
+
+    @objc public static func emptyDescription() -> String {
+        return ""
+    }
+    
+    @objc public func emptyDescription() -> String {
+        return ""
+    }
+
+}
 internal struct EmptyStruct {}

--- a/tests/ios/unit-test/test-imports-app/main.m
+++ b/tests/ios/unit-test/test-imports-app/main.m
@@ -1,5 +1,6 @@
 #import "Header.h"
 #import <TestImports-App/Header.h>
+#import <TestImports-App/TestImports_App-Swift.h>
 
 #ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
 @import UIKit;
@@ -17,7 +18,8 @@
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     self.window.rootViewController = [UIViewController new];
     self.window.rootViewController.view.backgroundColor = UIColor.whiteColor;
-
+    NSAssert([EmptyClass emptyDescription] != nil, @"Empty class description exists");
+    NSAssert([[EmptyClass new] emptyDescription] != nil, @"Empty instance description exists");
     [self.window makeKeyAndVisible];
 
     return YES;


### PR DESCRIPTION
When LLDB compiles swiftmodules during attachment and `po` it is missing
some clang importer arguments. This adds missing copts directly to
LLDB in the lldbinit.

Note that I have also added a _example_ test case for LLDB and clarified some of
the requirments here. For now, it atleast documents this requirment:
```
Xcode project: bazel run tests/ios/xcodeproj:Test-Imports-App-Project
&& open tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/
Scheme: `TestImports-App`
Breakpoints: tests/ios/unit-test/test-imports-app/empty.swift:6
Breakpoints: tests/ios/unit-test/test-imports-app/empty.swift:15
Xcode Version: 12.5.1
```

Longer term, can "Reverse sherlock" some LLDB automation testing from
swift-LLDB to verify debugging of many examples. Testing is further
blocked by getting the debugger working on the examples. As of today,
the examples just don't work on master
https://github.com/bazel-ios/rules_ios/issues/281