### PR TITLE
Fix external VFS paths

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -82,3 +82,10 @@ http_file(
     # .bazelversion uses 4.0
     urls = ["https://github.com/bazelbuild/buildtools/releases/download/3.5.0/buildifier.mac"],
 )
+
+load(
+    "//tests/ios/frameworks/external-dependency:external_dependency.bzl",
+    "load_external_test_dependency",
+)
+
+load_external_test_dependency()

--- a/rules/framework/vfs_overlay.bzl
+++ b/rules/framework/vfs_overlay.bzl
@@ -28,7 +28,13 @@ def _get_external_contents(prefix, path_str):
     return prefix + path_str
 
 def _get_vfs_parent(ctx):
-    return (ctx.bin_dir.path + "/" + ctx.build_file_path)
+    root_path = ctx.bin_dir.path + "/"
+
+    # For an external package, the BUILD file will be rooted relative to the
+    # workspace_root, account for this
+    if len(ctx.label.workspace_root):
+        root_path += ctx.label.workspace_root + "/"
+    return root_path + ctx.build_file_path
 
 def _find_top_swiftmodule_file(swiftmodules):
     for file in swiftmodules:

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -17,7 +17,7 @@ def _maybe(repo_rule, name, **kwargs):
     if not native.existing_rule(name):
         repo_rule(name = name, **kwargs)
 
-def github_repo(name, project, repo, ref, sha256 = None):
+def github_repo(name, project, repo, ref, sha256 = None, **kwargs):
     """Downloads a repository from GitHub as a tarball.
 
     Args:
@@ -26,6 +26,7 @@ def github_repo(name, project, repo, ref, sha256 = None):
         repo: The name of the repository on GitHub.
         ref: The reference to be downloaded. Can be any named ref, e.g. a commit, branch, or tag.
         sha256: The sha256 of the downloaded tarball.
+        **kwargs: additional keyword arguments for http_archive.
     """
 
     github_url = "https://github.com/{project}/{repo}/archive/{ref}.zip".format(
@@ -39,6 +40,7 @@ def github_repo(name, project, repo, ref, sha256 = None):
         url = github_url,
         sha256 = sha256,
         canonical_id = github_url,
+        **kwargs
     )
 
 def rules_ios_dependencies():

--- a/tests/ios/frameworks/external-dependency/BUILD.bazel
+++ b/tests/ios/frameworks/external-dependency/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+build_test(
+    name = "swift_collections_build_test",
+    targets = [
+        "@com_github_apple_swiftcollections//:DequeModule",
+        "@com_github_apple_swiftcollections//:OrderedCollections",
+    ],
+)

--- a/tests/ios/frameworks/external-dependency/BUILD.com_github_apple_swiftcollections
+++ b/tests/ios/frameworks/external-dependency/BUILD.com_github_apple_swiftcollections
@@ -1,0 +1,17 @@
+load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
+
+_platforms = {"ios": "13.3"}
+
+apple_framework(
+    name = "DequeModule",
+    srcs = glob(["Sources/DequeModule/**/*.swift"]),
+    platforms = _platforms,
+    visibility = ["//visibility:public"],
+)
+
+apple_framework(
+    name = "OrderedCollections",
+    srcs = glob(["Sources/OrderedCollections/**/*.swift"]),
+    platforms = _platforms,
+    visibility = ["//visibility:public"],
+)

--- a/tests/ios/frameworks/external-dependency/external_dependency.bzl
+++ b/tests/ios/frameworks/external-dependency/external_dependency.bzl
@@ -1,0 +1,11 @@
+load("//rules:repositories.bzl", "github_repo")
+
+def load_external_test_dependency():
+    github_repo(
+        name = "com_github_apple_swiftcollections",
+        build_file = "@//tests/ios/frameworks/external-dependency:BUILD.com_github_apple_swiftcollections",
+        project = "apple",
+        ref = "0.0.3",
+        repo = "swift-collections",
+        sha256 = "e6f36a1f9bb163437b4e9bc8da641a6129f16af7799eb8418c4a35749ceb1ef7",
+    )


### PR DESCRIPTION
Fix external VFS paths

Currently, the VFS rule formulates a path relative to the BUILD file
path, to replicate the "exec path" in the java rules. Now this path
formulation include the repository name for external repos. Of course,
it isn't returned by `build_file_path`. We didn't have a test case and
thanks to @jschear, it's now up and running

Fixes #307
