### PR TITLE
Conditionally compile with transitive VFS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,24 @@ jobs:
         with:
           name: bazel-testlogs
           path: bazel-testlogs
+  build_virtual_frameworks:
+    # Build the entire tree with this feature enabled. Longer term, we'll likely
+    # consider merging this feature into the default behavior and can re-align
+    # the CI job
+    name: Build ( Virutal Frameworks )
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Select Xcode 12.2
+        run: sudo xcode-select -s /Applications/Xcode_12.2.app
+      - name: Build and Test
+        run: |
+          bazelisk build //... --features apple.virtualize_frameworks
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: bazel-testlogs
+          path: bazel-testlogs
   buildifier:
     name: Check Starlark and Docs
     runs-on: macos-latest

--- a/rules/framework/vfs_overlay.bzl
+++ b/rules/framework/vfs_overlay.bzl
@@ -210,9 +210,6 @@ def _make_root(vfs_parent, bin_dir_path, build_file_path, framework_name, swiftm
         contents = _provided_vfs_swift_module_contents(swiftmodules, vfs_prefix)
         if contents:
             roots.append(contents)
-    elif has_swift:
-        roots.append(_assumed_vfs_swift_module_contents(bin_dir_path, build_file_path, vfs_prefix, framework_name))
-
     return roots
 
 def _provided_vfs_swift_module_contents(swiftmodules, vfs_prefix):
@@ -228,23 +225,6 @@ def _provided_vfs_swift_module_contents(swiftmodules, vfs_prefix):
         "type": "file",
         "name": swiftmodule_file.basename,
         "external-contents": _get_external_contents(vfs_prefix, swiftmodule_file.path),
-    }
-
-def _assumed_vfs_swift_module_contents(bin_dir_path, build_file_path, vfs_prefix, framework_name):
-    # Forumlate the framework's swiftmodule - don't have the swiftmodule when
-    # creating with apple_library. Consider removing that codepath to make this
-    # and other situations easier
-    base_path = "/".join(build_file_path.split("/")[:-1])
-    rooted_path = bin_dir_path + "/" + base_path
-
-    # Note: Swift translates the input framework name to this because - is an
-    # invalid character in module name
-    name = framework_name.replace("-", "_") + ".swiftmodule"
-    external_contents = rooted_path + "/" + name
-    return {
-        "type": "file",
-        "name": name,
-        "external-contents": _get_external_contents(vfs_prefix, external_contents),
     }
 
 def _framework_vfs_overlay_impl(ctx):

--- a/tests/ios/unit-test/test-imports-app/BUILD.bazel
+++ b/tests/ios/unit-test/test-imports-app/BUILD.bazel
@@ -77,9 +77,11 @@ ios_unit_test(
     deps = [
         ":TestImports-App_framework_unlinked",
     ] + select({
-        # Note: without using apple_framework, it won't set enable_framework_vfs
-        # imported it won't actually be seen
-        "@build_bazel_rules_ios//:virtualize_frameworks": [":SomeFramework"],
+        # It isn't seeing the `deps` attribute when using
+        # apple_framework_packaging directly
+        "@build_bazel_rules_ios//:virtualize_frameworks": [
+            ":SomeFramework",
+        ],
         "//conditions:default": [],
     }),
 )

--- a/tests/ios/unit-test/test-imports-app/BUILD.bazel
+++ b/tests/ios/unit-test/test-imports-app/BUILD.bazel
@@ -76,5 +76,10 @@ ios_unit_test(
     visibility = ["//visibility:public"],
     deps = [
         ":TestImports-App_framework_unlinked",
-    ],
+    ] + select({
+        # Note: without using apple_framework, it won't set enable_framework_vfs
+        # imported it won't actually be seen
+        "@build_bazel_rules_ios//:virtualize_frameworks": [":SomeFramework"],
+        "//conditions:default": [],
+    }),
 )


### PR DESCRIPTION
Conditionally adds VFS all targets, which right now has conditional side
effect to compile them all as virtual frameworks. In the interim we want
to include the VFS in order to pickup deps that are virtual frameworks.

It also includes a stopgap hack for issues with merging imported
frameworks. The inline comment may be addressed

Additionally, it builds the entire test suite with virtual frameworks
to pickup regressions.