### PR TITLE
Add ipa_post_processor to list of ios kwargs

### DIFF
--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -28,6 +28,7 @@ _IOS_APPLICATION_KWARGS = [
     "alternate_icons",
     "settings_bundle",
     "minimum_deployment_os_version",
+    "ipa_post_processor",
 ]
 
 def ios_application(name, apple_library = apple_library, infoplists_by_build_setting = {}, **kwargs):


### PR DESCRIPTION
So we can use: https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-ios.md#ios_application-ipa_post_processor