### PR TITLE
Use --copy-links in rsync call to copy symlink files

### DIFF
--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/install.sh
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/installer
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/install.sh
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/installer
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/install.sh
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/installer
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/install.sh
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/installer
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/install.sh
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/installer
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/install.sh
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/installer
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/install.sh
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/installer
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/install.sh
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/installer
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/install.sh
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/installer
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/install.sh
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/installer
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/install.sh
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/installer
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/install.sh
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/installer
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tools/xcodeproj_shims/install.sh
+++ b/tools/xcodeproj_shims/install.sh
@@ -83,7 +83,7 @@ for input in "${input_options[@]}"; do
         unzip -qq -d "$TARGET_BUILD_DIR" "$input"
     else
         rsync \
-            --recursive --chmod=u+w --delete \
+            --recursive --chmod=u+w --delete --copy-links \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 


### PR DESCRIPTION
This is mostly relevant if:

- Not using index-while-building
- Build a scheme with a non-app primary output

Specifically, headers were not being copied over because they were symlinks and the default behavior of rsync is to skip these. Xcode indexing would fail because the modulemap would point to these files that were not being copied to derived data.

![image](https://user-images.githubusercontent.com/75236/136452395-70564965-c216-4a31-a1cc-26570cba318c.png)
![image](https://user-images.githubusercontent.com/75236/136452560-77d12e3a-31d0-415e-b154-8caf3749df6b.png)
