### PR TITLE
Add include_symbols_in_bundle to _IOS_APPLICATION_KWARGS

### DIFF
--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -29,6 +29,7 @@ _IOS_APPLICATION_KWARGS = [
     "settings_bundle",
     "minimum_deployment_os_version",
     "ipa_post_processor",
+    "include_symbols_in_bundle",
 ]
 
 def ios_application(name, apple_library = apple_library, infoplists_by_build_setting = {}, **kwargs):


### PR DESCRIPTION
Add missing `include_symbols_in_bundle` to `_IOS_APPLICATION_KWARGS`