### PR TITLE
Add output discriminator param

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -485,6 +485,7 @@ def _merge_root_infoplists(ctx):
         launch_storyboard = None,
         output_plist = output_plist,
         output_pkginfo = None,
+        output_discriminator = None,
         platform_prerequisites = platform_support.platform_prerequisites(
             apple_fragment = ctx.fragments.apple,
             config_vars = ctx.var,

--- a/rules/precompiled_apple_resource_bundle.bzl
+++ b/rules/precompiled_apple_resource_bundle.bzl
@@ -107,6 +107,7 @@ def _precompiled_apple_resource_bundle_impl(ctx):
         input_plists = ctx.files.infoplists,
         output_pkginfo = None,
         output_plist = output_plist,
+        output_discriminator = None,
         resolved_plisttool = apple_toolchain_info.resolved_plisttool,
         **partials_args
     )
@@ -165,9 +166,10 @@ def _precompiled_apple_resource_bundle_impl(ctx):
         post_processor = "",
     )
     bundletool_instructions_file = intermediates.file(
-        ctx.actions,
-        ctx.label.name,
-        "bundletool_actions.json",
+        actions = ctx.actions,
+        target_name = ctx.label.name,
+        output_discriminator = None,
+        file_name = "bundletool_actions.json",
     )
     ctx.actions.write(
         output = bundletool_instructions_file,

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -52,7 +52,7 @@ def rules_ios_dependencies():
         ref = "d1d40821dc932ee488eb22c0b9712e26f39c04fa",
         project = "bazelbuild",
         repo = "rules_apple",
-        # sha256 = "2d4b0b1616cb7a7fe5d35dfbd1c813c5ae216169ff34c7a81f7a85f1b99a9cf2",
+        sha256 = "159a100b4dd6a9debb8e514abc3c0d929285d329741772406604c23393464b5f",
     )
 
     _maybe(

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -55,7 +55,6 @@ def rules_ios_dependencies():
         # sha256 = "2d4b0b1616cb7a7fe5d35dfbd1c813c5ae216169ff34c7a81f7a85f1b99a9cf2",
     )
 
-
     _maybe(
         http_archive,
         name = "bazel_skylib",

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -49,11 +49,12 @@ def rules_ios_dependencies():
     _maybe(
         github_repo,
         name = "build_bazel_rules_apple",
-        ref = "3baff5b829177f8007619d1f16971761d68a64e1",
+        ref = "d1d40821dc932ee488eb22c0b9712e26f39c04fa",
         project = "bazelbuild",
         repo = "rules_apple",
-        sha256 = "2d4b0b1616cb7a7fe5d35dfbd1c813c5ae216169ff34c7a81f7a85f1b99a9cf2",
+        # sha256 = "2d4b0b1616cb7a7fe5d35dfbd1c813c5ae216169ff34c7a81f7a85f1b99a9cf2",
     )
+
 
     _maybe(
         http_archive,


### PR DESCRIPTION
The latest rules_apple includes an output_discriminator param to intermediates.file, so just adding that in.