### PR TITLE
Set apple platform type for macOS xcframework

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -314,7 +314,8 @@ def _xcframework(*, library_name, name, slices):
                 # TODO: support maccatalyst
                 continue
 
-            arch_setting = "@build_bazel_rules_apple//apple:{}_{}".format(platform, arch)
+            rules_apple_platfrom = "darwin" if platform == "macos" else platform
+            arch_setting = "@build_bazel_rules_apple//apple:{}_{}".format(rules_apple_platfrom, arch)
             config_setting_name = "{}-{}".format(
                 xcframework_name,
                 "_".join([x for x in (platform, platform_variant, arch) if x]),


### PR DESCRIPTION
Align the key in an xcframework's `slice` attribute
```
                    "platform": "macos",
```
to the `rules_apple` supported platforms. There, it's known as `darwin`,
many others call it `macos` 