### PR TITLE
A rule to link with `-force_load` for direct `deps`

### DIFF
--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -57,7 +57,7 @@ def ios_application(name, apple_library = apple_library, infoplists_by_build_set
     application_kwargs["launch_storyboard"] = application_kwargs.pop("launch_storyboard", library.launch_screen_storyboard_name)
     application_kwargs["families"] = application_kwargs.pop("families", ["iphone", "ipad"])
 
-    force_load_direct_deps(name = name + ".__internal__.force_load_direct_deps", deps = library.deps)
+    force_load_direct_deps(name = name + ".__internal__.force_load_direct_deps", deps = library.deps, tags = ["manual"])
 
     import_middleman(name = name + ".import_middleman", deps = library.deps + [name + ".force_load"], tags = ["manual"])
     rules_apple_ios_application(

--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -57,14 +57,16 @@ def ios_application(name, apple_library = apple_library, infoplists_by_build_set
     application_kwargs["launch_storyboard"] = application_kwargs.pop("launch_storyboard", library.launch_screen_storyboard_name)
     application_kwargs["families"] = application_kwargs.pop("families", ["iphone", "ipad"])
 
-    force_load_direct_deps(name = name + ".__internal__.force_load_direct_deps", deps = library.deps, tags = ["manual"])
+    force_load_name = name + ".force_load_direct_deps"
+    force_load_direct_deps(name = force_load_name, deps = library.lib_names, tags = ["manual"])
+    default_deps = [force_load_name] + library.lib_names
 
-    import_middleman(name = name + ".import_middleman", deps = library.deps + [name + ".force_load"], tags = ["manual"])
+    import_middleman(name = name + ".import_middleman", deps = default_deps, tags = ["manual"])
     rules_apple_ios_application(
         name = name,
         deps = select({
             "@build_bazel_rules_ios//:arm64_simulator_use_device_deps": [name + ".import_middleman"],
-            "//conditions:default": library.lib_names + [name + ".__internal__.force_load_direct_deps"],
+            "//conditions:default": default_deps,
         }),
         output_discriminator = None,
         infoplists = info_plists_by_setting(name = name, infoplists_by_build_setting = infoplists_by_build_setting, default_infoplists = application_kwargs.pop("infoplists", [])),

--- a/rules/force_load_direct_deps.bzl
+++ b/rules/force_load_direct_deps.bzl
@@ -1,0 +1,41 @@
+def _impl(ctx):
+    linkopts = []
+    for dep in ctx.attr.deps:
+        if apple_common.Objc in dep:
+            for lib in dep[apple_common.Objc].library.to_list():
+                linkopts.extend(["-Wl,-force_load,{}".format(lib.path)])
+
+    return apple_common.new_objc_provider(
+        linkopt = depset(linkopts),
+    )
+
+force_load_direct_deps = rule(
+    implementation = _impl,
+    attrs = {"deps": attr.label_list()},
+    doc = """
+A rule to link with `-force_load` for direct`deps`
+
+ld has different behavior when loading members of a static library VS objects
+as far as visibility. Under `-dynamic`
+- linked _swift object files_ can have public visibility
+- symbols from _swift static libraries_ are omitted unless used, and not
+visible otherwise
+
+By using `-force_load`, we can load static libraries in the attributes of an
+application's direct depenencies. These args need go at the _front_ of the
+linker invocation otherwise these arguments don't work with lds logic.
+
+Why not put it into `rules_apple`? Ideally it could be, and perhaps consider a
+PR to there .The underlying java rule, `AppleBinary.linkMultiArchBinary`
+places `extraLinkopts` at the end of the linker invocation. At the time of
+writing these args need to go into the current rule context where
+`AppleBinary.linkMultiArchBinary` is called.
+
+One use case of this is that iOS developers want to load above mentioned
+symbols from applications. Another alternate could be to create an aspect,
+that actually generates a different application and linker invocation instead
+of force loading symbols. This could be more complicated from an integration
+perspective so it isn't used.
+
+    """,
+)

--- a/rules/force_load_direct_deps.bzl
+++ b/rules/force_load_direct_deps.bzl
@@ -1,12 +1,11 @@
 def _impl(ctx):
-    linkopts = []
+    force_load = []
     for dep in ctx.attr.deps:
         if apple_common.Objc in dep:
-            for lib in dep[apple_common.Objc].library.to_list():
-                linkopts.extend(["-Wl,-force_load,{}".format(lib.path)])
+            force_load.append(dep[apple_common.Objc].library)
 
     return apple_common.new_objc_provider(
-        linkopt = depset(linkopts),
+        force_load_library = depset(transitive = force_load),
     )
 
 force_load_direct_deps = rule(


### PR DESCRIPTION
ld has different behavior when loading members of a static library VS objects
as far as visibility. Under `-dynamic`
- linked _swift object files_ can have public visibility
- symbols from _swift static libraries_ are omitted unless used, and not visible otherwise

By using `-force_load`, we can load static libraries in the attributes of an
application's direct depenencies. These args need go at the _front_ of the
linker invocation otherwise these arguments don't work with lds logic.

Why not put it into `rules_apple`? Ideally it could be, and perhaps consider a
PR to there .The underlying java rule, `AppleBinary.linkMultiArchBinary`
places `extraLinkopts` at the end of the linker invocation. At the time of
writing these args need to go into the current rule context where
`AppleBinary.linkMultiArchBinary` is called.

One use case of this is that iOS developers want to load above mentioned
symbols from applications. Another alternate could be to create an aspect, that
actually generates a different application and linker invocation instead of
force loading symbols. This could be more complicated from an integration
perspective so it isn't used. Another case is present in dynamic frameworks in
rules_apple ( https://github.com/bazelbuild/rules_apple/issues/332 )