### PR TITLE
Measures to debug Bazel's Xcode ingestion flake

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Select Xcode 12.2
-        run: sudo xcode-select -s /Applications/Xcode_12.2.app
+      - name: Select Xcode
+        run: .github/workflows/xcode_select.sh
       - name: Build and Test
         run: |
           # Host config
@@ -34,8 +34,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Select Xcode 12.2
-        run: sudo xcode-select -s /Applications/Xcode_12.2.app
+      - name: Select Xcode
+        run: .github/workflows/xcode_select.sh
       - name: Build and Test
         run: |
           # Host config
@@ -59,8 +59,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Select Xcode 12.2
-        run: sudo xcode-select -s /Applications/Xcode_12.2.app
+      - name: Select Xcode
+        run: .github/workflows/xcode_select.sh
       - name: Build and Test
         run: |
           bazelisk clean # Note: there is a problem with some reuse in rules_swift
@@ -87,8 +87,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Select Xcode 12.2
-        run: sudo xcode-select -s /Applications/Xcode_12.2.app
+      - name: Select Xcode
+        run: .github/workflows/xcode_select.sh
         # Note: we need to pass the absolute to the Bazel run
       - name: buildifier
         run: find $PWD -type f \( -name 'WORKSPACE' -o -name '*.bzl' -o -name '*.bazel' \) | xargs bazel run buildifier -- -lint=fix && git diff --exit-code
@@ -108,7 +108,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Select Xcode 12.2
-        run: sudo xcode-select -s /Applications/Xcode_12.2.app
+      - name: Select Xcode
+        run: .github/workflows/xcode_select.sh
       - name: Build App
         run: bazelisk build -s tests/ios/app/App --apple_platform_type=ios --ios_minimum_os=10.2  --ios_multi_cpus=i386,x86_64

--- a/.github/workflows/xcode_select.sh
+++ b/.github/workflows/xcode_select.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+echo "Selecting Xcode for environment"
+printenv
+sudo xcode-select -p
+sudo xcode-select -s /Applications/Xcode_12.2.app

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -99,3 +99,10 @@ load(
 )
 
 load_framework_dependencies()
+
+load("//tools/toolchains/xcode_configure:xcode_configure.bzl", "xcode_configure")
+
+xcode_configure(
+    remote_xcode_label = "",
+    xcode_locator_label = "//tools/toolchains/xcode_configure:xcode_locator.m",
+)

--- a/tools/toolchains/xcode_configure/BUILD
+++ b/tools/toolchains/xcode_configure/BUILD
@@ -1,0 +1,84 @@
+load(
+    "//tools/toolchains/xcode_configure:xcode_version_flag.bzl",
+    "ios_sdk_version_flag",
+    "macos_sdk_version_flag",
+    "tvos_sdk_version_flag",
+    "watchos_sdk_version_flag",
+    "xcode_version_flag",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"] + ["**/*"]),
+)
+
+
+exports_files([
+    "xcode_locator.m",
+    "xcode_configure.bzl",
+])
+
+DARWIN_XCODE_LOCATOR_COMPILE_COMMAND = """
+  /usr/bin/xcrun --sdk macosx clang -mmacosx-version-min=10.9 -fobjc-arc -framework CoreServices \
+      -framework Foundation -o $@ $<
+"""
+
+genrule(
+    name = "xcode-locator-genrule",
+    srcs = select({
+        ":darwin": ["xcode_locator.m"],
+        ":darwin_x86_64": ["xcode_locator.m"],
+        ":darwin_arm64": ["xcode_locator.m"],
+        ":darwin_arm64e": ["xcode_locator.m"],
+        "//conditions:default": ["xcode_locator_stub.sh"],
+    }),
+    outs = ["xcode-locator"],
+    cmd = select({
+        ":darwin": DARWIN_XCODE_LOCATOR_COMPILE_COMMAND,
+        ":darwin_x86_64": DARWIN_XCODE_LOCATOR_COMPILE_COMMAND,
+        ":darwin_arm64": DARWIN_XCODE_LOCATOR_COMPILE_COMMAND,
+        ":darwin_arm64e": DARWIN_XCODE_LOCATOR_COMPILE_COMMAND,
+        "//conditions:default": "cp $< $@",
+    }),
+    local = 1,
+    output_to_bindir = 1,
+)
+
+# TODO(cparsons): Consolidate with config_settings under //src
+config_setting(
+    name = "darwin",
+    values = {"cpu": "darwin"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "darwin_x86_64",
+    values = {"cpu": "darwin_x86_64"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "darwin_arm64",
+    values = {"cpu": "darwin_arm64"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "darwin_arm64e",
+    values = {"cpu": "darwin_arm64e"},
+    visibility = ["//visibility:public"],
+)
+
+xcode_config_alias(name = "current_xcode_config")
+
+xcode_version_flag(name = "xcode_version_flag")
+
+ios_sdk_version_flag(name = "ios_sdk_version_flag")
+
+tvos_sdk_version_flag(name = "tvos_sdk_version_flag")
+
+watchos_sdk_version_flag(name = "watchos_sdk_version_flag")
+
+macos_sdk_version_flag(name = "macos_sdk_version_flag")

--- a/tools/toolchains/xcode_configure/README.md
+++ b/tools/toolchains/xcode_configure/README.md
@@ -1,0 +1,16 @@
+This is Bazel's Xcode autoconfigure with improvements for debugging
+
+Adds a note to dump the Bazel error and retry if it fails. This is not a
+measure to fix the problem, but to debug it and unblock CI. We don't have
+access to SSH into the github CI so this atleast dumps the error so we can
+further investigate.
+
+Bazel puts this error in the build file which is a problem on the CI because it
+swallows the error and it requires a user to clean --expunge. Bazel requires
+the user to expunge because it thinks the repository was successfully written.
+Probably a better pattern is to fail, but that won't shed light on the problem.
+
+This is not just broken for CI but local developers. The plan is to use
+rules_ios CI to reproduce this and gather more information then propose a fix
+when we know more info.
+

--- a/tools/toolchains/xcode_configure/xcode_configure.bzl
+++ b/tools/toolchains/xcode_configure/xcode_configure.bzl
@@ -1,0 +1,287 @@
+# Copyright 2016 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Repository rule to generate host xcode_config and xcode_version targets.
+
+   The xcode_config and xcode_version targets are configured for xcodes/SDKs
+   installed on the local host.
+"""
+
+_EXECUTE_TIMEOUT = 120
+
+def _search_string(fullstring, prefix, suffix):
+    """Returns the substring between two given substrings of a larger string.
+
+    Args:
+      fullstring: The larger string to search.
+      prefix: The substring that should occur directly before the returned string.
+      suffix: The substring that should occur directly after the returned string.
+    Returns:
+      A string occurring in fullstring exactly prefixed by prefix, and exactly
+      terminated by suffix. For example, ("hello goodbye", "lo ", " bye") will
+      return "good". If there is no such string, returns the empty string.
+    """
+
+    prefix_index = fullstring.find(prefix)
+    if (prefix_index < 0):
+        return ""
+    result_start_index = prefix_index + len(prefix)
+    suffix_index = fullstring.find(suffix, result_start_index)
+    if (suffix_index < 0):
+        return ""
+    return fullstring[result_start_index:suffix_index]
+
+def _search_sdk_output(output, sdkname):
+    """Returns the sdk version given xcodebuild stdout and an sdkname."""
+    return _search_string(output, "(%s" % sdkname, ")")
+
+def _xcode_version_output(repository_ctx, name, version, aliases, developer_dir):
+    """Returns a string containing an xcode_version build target."""
+    build_contents = ""
+    decorated_aliases = []
+    error_msg = ""
+    for alias in aliases:
+        decorated_aliases.append("'%s'" % alias)
+    xcodebuild_result = repository_ctx.execute(
+        ["xcrun", "xcodebuild", "-version", "-sdk"],
+        _EXECUTE_TIMEOUT,
+        {"DEVELOPER_DIR": developer_dir},
+    )
+    if (xcodebuild_result.return_code != 0):
+        error_msg = (
+            "Invoking xcodebuild failed, developer dir: {devdir} ," +
+            "return code {code}, stderr: {err}, stdout: {out}"
+        ).format(
+            devdir = developer_dir,
+            code = xcodebuild_result.return_code,
+            err = xcodebuild_result.stderr,
+            out = xcodebuild_result.stdout,
+        )
+        fail(error_msg)
+
+    ios_sdk_version = _search_sdk_output(xcodebuild_result.stdout, "iphoneos")
+    tvos_sdk_version = _search_sdk_output(xcodebuild_result.stdout, "appletvos")
+    macos_sdk_version = _search_sdk_output(xcodebuild_result.stdout, "macosx")
+    watchos_sdk_version = _search_sdk_output(xcodebuild_result.stdout, "watchos")
+    build_contents += "xcode_version(\n  name = '%s'," % name
+    build_contents += "\n  version = '%s'," % version
+    if aliases:
+        build_contents += "\n  aliases = [%s]," % " ,".join(decorated_aliases)
+    if ios_sdk_version:
+        build_contents += "\n  default_ios_sdk_version = '%s'," % ios_sdk_version
+    if tvos_sdk_version:
+        build_contents += "\n  default_tvos_sdk_version = '%s'," % tvos_sdk_version
+    if macos_sdk_version:
+        build_contents += "\n  default_macos_sdk_version = '%s'," % macos_sdk_version
+    if watchos_sdk_version:
+        build_contents += "\n  default_watchos_sdk_version = '%s'," % watchos_sdk_version
+    build_contents += "\n)\n"
+    return build_contents
+
+VERSION_CONFIG_STUB = "xcode_config(name = 'host_xcodes')"
+
+def run_xcode_locator(repository_ctx, xcode_locator_src_label):
+    """Generates xcode-locator from source and runs it.
+
+    Builds xcode-locator in the current repository directory.
+    Returns the standard output of running xcode-locator with -v, which will
+    return information about locally installed Xcode toolchains and the versions
+    they are associated with.
+
+    This should only be invoked on a darwin OS, as xcode-locator cannot be built
+    otherwise.
+
+    Args:
+      repository_ctx: The repository context.
+      xcode_locator_src_label: The label of the source file for xcode-locator.
+    Returns:
+      A list representing installed xcode toolchain information. Each
+      element of the list is a struct containing information for one installed
+      toolchain. This is an empty list if there was an error building or
+      running xcode-locator.
+    """
+    xcodeloc_src_path = str(repository_ctx.path(xcode_locator_src_label))
+    env = repository_ctx.os.environ
+    xcrun_result = repository_ctx.execute([
+        "env",
+        "-i",
+        "DEVELOPER_DIR={}".format(env.get("DEVELOPER_DIR", default = "")),
+        "xcrun",
+        "--sdk",
+        "macosx",
+        "clang",
+        "-mmacosx-version-min=10.9",
+        "-fobjc-arc",
+        "-framework",
+        "CoreServices",
+        "-framework",
+        "Foundation",
+        "-o",
+        "xcode-locator-bin",
+        xcodeloc_src_path,
+    ], _EXECUTE_TIMEOUT)
+
+    if (xcrun_result.return_code != 0):
+        suggestion = ""
+        if "Agreeing to the Xcode/iOS license" in xcrun_result.stderr:
+            suggestion = ("(You may need to sign the xcode license." +
+                          " Try running 'sudo xcodebuild -license')")
+        error_msg = (
+            "Generating xcode-locator-bin failed. {suggestion} " +
+            "return code {code}, stderr: {err}, stdout: {out}"
+        ).format(
+            suggestion = suggestion,
+            code = xcrun_result.return_code,
+            err = xcrun_result.stderr,
+            out = xcrun_result.stdout,
+        )
+        fail(error_msg.replace("\n", " "))
+
+    xcode_locator_result = repository_ctx.execute(
+        ["./xcode-locator-bin", "-v"],
+        _EXECUTE_TIMEOUT,
+    )
+    if (xcode_locator_result.return_code != 0):
+        error_msg = (
+            "Invoking xcode-locator failed, " +
+            "return code {code}, stderr: {err}, stdout: {out}"
+        ).format(
+            code = xcode_locator_result.return_code,
+            err = xcode_locator_result.stderr,
+            out = xcode_locator_result.stdout,
+        )
+
+        fail(error_msg.replace("\n", " "))
+    xcode_toolchains = []
+
+    # xcode_dump is comprised of newlines with different installed xcode versions,
+    # each line of the form <version>:<comma_separated_aliases>:<developer_dir>.
+    xcode_dump = xcode_locator_result.stdout
+    for xcodeversion in xcode_dump.split("\n"):
+        if ":" in xcodeversion:
+            infosplit = xcodeversion.split(":")
+            toolchain = struct(
+                version = infosplit[0],
+                aliases = infosplit[1].split(","),
+                developer_dir = infosplit[2],
+            )
+            xcode_toolchains.append(toolchain)
+    return xcode_toolchains
+
+def _darwin_build_file(repository_ctx):
+    """Evaluates local system state to create xcode_config and xcode_version targets."""
+    env = repository_ctx.os.environ
+    xcodebuild_result = repository_ctx.execute([
+        "env",
+        "-i",
+        "DEVELOPER_DIR={}".format(env.get("DEVELOPER_DIR", default = "")),
+        "xcrun",
+        "xcodebuild",
+        "-version",
+    ], _EXECUTE_TIMEOUT)
+
+    toolchains = run_xcode_locator(
+        repository_ctx,
+        Label(repository_ctx.attr.xcode_locator),
+    )
+
+    default_xcode_version = ""
+    default_xcode_build_version = ""
+    if xcodebuild_result.return_code == 0:
+        default_xcode_version = _search_string(xcodebuild_result.stdout, "Xcode ", "\n")
+        default_xcode_build_version = _search_string(
+            xcodebuild_result.stdout,
+            "Build version ",
+            "\n",
+        )
+    default_xcode_target = ""
+    target_names = []
+    buildcontents = ""
+
+    for toolchain in toolchains:
+        version = toolchain.version
+        aliases = toolchain.aliases
+        developer_dir = toolchain.developer_dir
+        target_name = "version%s" % version.replace(".", "_")
+        buildcontents += _xcode_version_output(
+            repository_ctx,
+            target_name,
+            version,
+            aliases,
+            developer_dir,
+        )
+        target_label = "':%s'" % target_name
+        target_names.append(target_label)
+        if (version.startswith(default_xcode_version) and
+            version.endswith(default_xcode_build_version)):
+            default_xcode_target = target_label
+    buildcontents += "xcode_config(name = 'host_xcodes',"
+    if target_names:
+        buildcontents += "\n  versions = [%s]," % ", ".join(target_names)
+    if not default_xcode_target and target_names:
+        default_xcode_target = sorted(target_names, reverse = True)[0]
+        print("No default Xcode version is set with 'xcode-select'; picking %s" %
+              default_xcode_target)
+    if default_xcode_target:
+        buildcontents += "\n  default = %s," % default_xcode_target
+
+    buildcontents += "\n)\n"
+    buildcontents += "available_xcodes(name = 'host_available_xcodes',"
+    if target_names:
+        buildcontents += "\n  versions = [%s]," % ", ".join(target_names)
+    if default_xcode_target:
+        buildcontents += "\n  default = %s," % default_xcode_target
+    buildcontents += "\n)\n"
+    if repository_ctx.attr.remote_xcode:
+        buildcontents += "xcode_config(name = 'all_xcodes',"
+        buildcontents += "\n  remote_versions = '%s', " % repository_ctx.attr.remote_xcode
+        buildcontents += "\n  local_versions = ':host_available_xcodes', "
+        buildcontents += "\n)\n"
+    return buildcontents
+
+def _impl(repository_ctx):
+    """Implementation for the local_config_xcode repository rule.
+
+    Generates a BUILD file containing a root xcode_config target named 'host_xcodes',
+    which points to an xcode_version target for each version of xcode installed on
+    the local host machine. If no versions of xcode are present on the machine
+    (for instance, if this is a non-darwin OS), creates a stub target.
+
+    Args:
+      repository_ctx: The repository context.
+    """
+
+    os_name = repository_ctx.os.name.lower()
+    build_contents = "package(default_visibility = ['//visibility:public'])\n\n"
+    if (os_name.startswith("mac os")):
+        build_contents += _darwin_build_file(repository_ctx)
+    else:
+        build_contents += VERSION_CONFIG_STUB
+    repository_ctx.file("BUILD", build_contents)
+
+xcode_autoconf = repository_rule(
+    implementation = _impl,
+    local = True,
+    attrs = {
+        "xcode_locator": attr.string(),
+        "remote_xcode": attr.string(),
+    },
+)
+
+def xcode_configure(xcode_locator_label, remote_xcode_label = None):
+    """Generates a repository containing host xcode version information."""
+    xcode_autoconf(
+        name = "local_config_xcode",
+        xcode_locator = xcode_locator_label,
+        remote_xcode = remote_xcode_label,
+    )

--- a/tools/toolchains/xcode_configure/xcode_locator.m
+++ b/tools/toolchains/xcode_configure/xcode_locator.m
@@ -1,0 +1,294 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Application that finds all Xcodes installed on a given Mac and will return a
+// path for a given version number.
+//
+// If you have 7.0, 6.4.1 and 6.3 installed the inputs will map to:
+//
+// 7,7.0,7.0.0 = 7.0
+// 6,6.4,6.4.1 = 6.4.1
+// 6.3,6.3.0 = 6.3
+
+#if !defined(__has_feature) || !__has_feature(objc_arc)
+#error "This file requires ARC support."
+#endif
+
+#import <CoreServices/CoreServices.h>
+#import <Foundation/Foundation.h>
+
+// Simple data structure for tracking a version of Xcode (i.e. 6.4) with an URL
+// to the appplication.
+@interface XcodeVersionEntry : NSObject
+@property(readonly) NSString *version;
+@property(readonly) NSURL *url;
+@end
+
+@implementation XcodeVersionEntry
+
+- (id)initWithVersion:(NSString *)version url:(NSURL *)url {
+  if ((self = [super init])) {
+    _version = version;
+    _url = url;
+  }
+  return self;
+}
+
+- (id)description {
+  return [NSString stringWithFormat:@"<%@ %p>: %@ %@",
+                   [self class], self, _version, _url];
+}
+
+@end
+
+// Given an entry, insert it into a dictionary that is keyed by versions.
+//
+// For an entry that is 6.4.1:/Applications/Xcode.app, add it for 6.4.1 and
+// optionally add it for 6.4 and 6 if it is "better" than any entry that may
+// already be there, where "better" is defined as:
+//
+// 1. Under /Applications/. (This avoids mounted xcode versions taking
+//    precedence over installed versions.)
+//
+// 2. Not older (at least as high version number).
+static void AddEntryToDictionary(
+  XcodeVersionEntry *entry,
+  NSMutableDictionary<NSString *, XcodeVersionEntry *> *dict) {
+  BOOL inApplications = [entry.url.path hasPrefix:@"/Applications/"];
+  NSString *entryVersion = entry.version;
+  NSString *subversion = entryVersion;
+  if (dict[entryVersion] && !inApplications) {
+    return;
+  }
+  dict[entryVersion] = entry;
+  while (YES) {
+    NSRange range = [subversion rangeOfString:@"." options:NSBackwardsSearch];
+    if (range.length == 0 || range.location == 0) {
+      break;
+    }
+    subversion = [subversion substringToIndex:range.location];
+    XcodeVersionEntry *subversionEntry = dict[subversion];
+    if (subversionEntry) {
+      BOOL atLeastAsLarge = ([subversionEntry.version compare:entry.version]
+                             == NSOrderedDescending);
+      if (inApplications && atLeastAsLarge) {
+        dict[subversion] = entry;
+      }
+    } else {
+      dict[subversion] = entry;
+    }
+  }
+}
+
+// Given a "version", expand it to at least 3 components by adding .0 as
+// necessary.
+static NSString *ExpandVersion(NSString *version) {
+  NSArray *components = [version componentsSeparatedByString:@"."];
+  NSString *appendage = nil;
+  if (components.count == 2) {
+    appendage = @".0";
+  } else if (components.count == 1) {
+    appendage = @".0.0";
+  }
+  if (appendage) {
+    version = [version stringByAppendingString:appendage];
+  }
+  return version;
+}
+
+// Searches for all available Xcodes in the system and returns a dictionary that
+// maps version identifiers of any form (X, X.Y, and X.Y.Z) to the directory
+// where the Xcode bundle lives.
+//
+// If there is a problem locating the Xcodes, prints one or more error messages
+// and returns nil.
+static NSMutableDictionary<NSString *, XcodeVersionEntry *> *FindXcodes()
+  __attribute((ns_returns_retained)) {
+  CFStringRef cfBundleID = CFSTR("com.apple.dt.Xcode");
+  NSString *bundleID = (__bridge NSString *)cfBundleID;
+
+  NSMutableDictionary<NSString *, XcodeVersionEntry *> *dict =
+      [[NSMutableDictionary alloc] init];
+  CFErrorRef cfError;
+  NSArray *array = CFBridgingRelease(LSCopyApplicationURLsForBundleIdentifier(
+      cfBundleID, &cfError));
+  if (array == nil) {
+    NSError *nsError = (__bridge NSError *)cfError;
+    fprintf(stderr, "error: %s\n", nsError.description.UTF8String);
+    return nil;
+  }
+
+  // Scan all bundles but delay returning in case of errors until we are
+  // done. This is to let us log details about all the bundles that were
+  // processed so that a faulty bundle doesn't hide useful information about
+  // other bundles that were found.
+  BOOL errors = NO;
+  for (NSURL *url in array) {
+    NSArray *contents = [
+      [NSFileManager defaultManager] contentsOfDirectoryAtURL:url
+                                   includingPropertiesForKeys:nil
+                                                      options:0
+                                                        error:nil];
+    NSLog(@"Found bundle %@ in %@; contents on disk: %@",
+          bundleID, url, contents);
+
+    NSBundle *bundle = [NSBundle bundleWithURL:url];
+    if (bundle == nil) {
+      NSLog(@"ERROR: Unable to open bundle at URL: %@\n", url);
+      errors = YES;
+      continue;
+    }
+
+    // LSCopyApplicationURLsForBundleIdentifier seems to sometimes return
+    // invalid bundles (e.g. an arbitrary folder), which we should ignore (but
+    // don't treat as an error).
+    //
+    // To work around this issue, we double check to make sure the NSBundle's
+    // bundleIdentifier is that of Xcode's, as invalid bundles won't match.
+    if (![bundle.bundleIdentifier isEqualToString:bundleID]) {
+      NSLog(@"WARNING: Ignoring bundle %@ due to bundleID mismatch "
+            @"(got \"%@\" but expected \"%@\"); info: %@",
+            url, bundle.bundleIdentifier, bundleID, bundle.infoDictionary);
+      continue;
+    }
+
+    NSString *versionKey = @"CFBundleShortVersionString";
+    NSString *version = [bundle.infoDictionary objectForKey:versionKey];
+    if (version == nil) {
+      NSLog(@"ERROR: Cannot find %@ in info for bundle %@; info: %@\n",
+            versionKey, url, bundle.infoDictionary);
+      errors = YES;
+      continue;
+    }
+    NSString *expandedVersion = ExpandVersion(version);
+    NSLog(@"Version strings for %@: short=%@, expanded=%@",
+          url, version, expandedVersion);
+
+    NSURL *versionPlistUrl = [url URLByAppendingPathComponent:@"Contents/version.plist"];
+    NSDictionary *versionPlistContents =
+        [[NSDictionary alloc] initWithContentsOfURL:versionPlistUrl];
+    NSString *productVersion = [versionPlistContents objectForKey:@"ProductBuildVersion"];
+    if (productVersion) {
+      expandedVersion = [expandedVersion stringByAppendingFormat:@".%@", productVersion];
+    }
+
+    NSURL *developerDir =
+        [url URLByAppendingPathComponent:@"Contents/Developer"];
+    XcodeVersionEntry *entry =
+        [[XcodeVersionEntry alloc] initWithVersion:expandedVersion
+                                               url:developerDir];
+    AddEntryToDictionary(entry, dict);
+  }
+  return errors ? nil : dict;
+}
+
+// Prints out the located Xcodes as a set of lines where each line contains the
+// list of versions for a given Xcode and its location on disk.
+static void DumpAsVersionsOnly(
+  FILE *output,
+  NSMutableDictionary<NSString *, XcodeVersionEntry *> *dict) {
+  NSMutableDictionary<NSString *, NSMutableSet <NSString *> *> *aliasDict =
+      [[NSMutableDictionary alloc] init];
+  [dict enumerateKeysAndObjectsUsingBlock:^(NSString *aliasVersion,
+                                            XcodeVersionEntry *entry,
+                                            BOOL *stop) {
+    NSString *versionString = entry.version;
+    if (aliasDict[versionString] == nil) {
+      aliasDict[versionString] = [[NSMutableSet alloc] init];
+    }
+    [aliasDict[versionString] addObject:aliasVersion];
+  }];
+  for (NSString *version in aliasDict) {
+    XcodeVersionEntry *entry = dict[version];
+    fprintf(output, "%s:%s:%s\n",
+            version.UTF8String,
+            [[aliasDict[version] allObjects]
+                   componentsJoinedByString: @","].UTF8String,
+            entry.url.fileSystemRepresentation);
+  }
+}
+
+// Prints out the located Xcodes in JSON format.
+static void DumpAsJson(
+  FILE *output,
+  NSMutableDictionary<NSString *, XcodeVersionEntry *> *dict) {
+  fprintf(output, "{\n");
+  for (NSString *version in dict) {
+    XcodeVersionEntry *entry = dict[version];
+    fprintf(output, "\t\"%s\": \"%s\",\n",
+            version.UTF8String, entry.url.fileSystemRepresentation);
+  }
+  fprintf(output, "}\n");
+}
+
+// Dumps usage information.
+static void usage(FILE *output) {
+  fprintf(
+      output,
+      "xcode-locator [-v|<version_number>]"
+      "\n\n"
+      "Given a version number or partial version number in x.y.z format, "
+      "will attempt to return the path to the appropriate developer "
+      "directory."
+      "\n\n"
+      "Omitting a version number will list all available versions in JSON "
+      "format, alongside their paths."
+      "\n\n"
+      "Passing -v will list all available fully-specified version numbers "
+      "along with their possible aliases and their developer directory, "
+      "each on a new line. For example:"
+      "\n\n"
+      "7.3.1:7,7.3,7.3.1:/Applications/Xcode.app/Contents/Developer"
+      "\n");
+}
+
+int main(int argc, const char * argv[]) {
+  @autoreleasepool {
+    NSString *versionArg = nil;
+    BOOL versionsOnly = NO;
+    if (argc == 1) {
+      versionArg = @"";
+    } else if (argc == 2) {
+      NSString *firstArg = [NSString stringWithUTF8String:argv[1]];
+      if ([@"-v" isEqualToString:firstArg]) {
+        versionsOnly = YES;
+        versionArg = @"";
+      } else {
+        versionArg = firstArg;
+      }
+    }
+    if (versionArg == nil) {
+      usage(stderr);
+      return 1;
+    }
+
+    NSMutableDictionary<NSString *, XcodeVersionEntry *> *dict = FindXcodes();
+    if (dict == nil) {
+      return 1;
+    }
+
+    XcodeVersionEntry *entry = [dict objectForKey:versionArg];
+    if (entry) {
+      printf("%s\n", entry.url.fileSystemRepresentation);
+      return 0;
+    }
+
+    if (versionsOnly) {
+      DumpAsVersionsOnly(stdout, dict);
+    } else {
+      DumpAsJson(stdout, dict);
+    }
+    return ([@"" isEqualToString:versionArg] ? 0 : 1);
+  }
+}

--- a/tools/toolchains/xcode_configure/xcode_locator_stub.sh
+++ b/tools/toolchains/xcode_configure/xcode_locator_stub.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Copyright 2015 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+printf 'xcode_locator should not be invoked on non-darwin systems\n' >&2
+
+exit 1

--- a/tools/toolchains/xcode_configure/xcode_version_flag.bzl
+++ b/tools/toolchains/xcode_configure/xcode_version_flag.bzl
@@ -1,0 +1,135 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rules that allows select() to differentiate between Apple OS versions."""
+
+def _strip_version(version):
+    """Strip trailing characters that aren't digits or '.' from version names.
+
+    Some OS versions look like "9.0gm", which is not useful for select()
+    statements. Thus, we strip the trailing "gm" part.
+
+    Args:
+      version: the version string
+
+    Returns:
+      The version with trailing letters stripped.
+    """
+    result = ""
+    string = str(version)
+    for i in range(len(string)):
+        ch = string[i]
+        if not ch.isdigit() and ch != ".":
+            break
+
+        result += ch
+
+    return result
+
+def _xcode_version_flag_impl(ctx):
+    """A rule that allows select() to differentiate between Xcode versions."""
+    xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+    return config_common.FeatureFlagInfo(value = _strip_version(
+        xcode_config.xcode_version(),
+    ))
+
+def _ios_sdk_version_flag_impl(ctx):
+    """A rule that allows select() to select based on the iOS SDK version."""
+    xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+
+    return config_common.FeatureFlagInfo(value = _strip_version(
+        xcode_config.sdk_version_for_platform(
+            apple_common.platform.ios_device,
+        ),
+    ))
+
+def _tvos_sdk_version_flag_impl(ctx):
+    """A rule that allows select() to select based on the tvOS SDK version."""
+    xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+
+    return config_common.FeatureFlagInfo(value = _strip_version(
+        xcode_config.sdk_version_for_platform(
+            apple_common.platform.tvos_device,
+        ),
+    ))
+
+def _watchos_sdk_version_flag_impl(ctx):
+    """A rule that allows select() to select based on the watchOS SDK version."""
+    xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+
+    return config_common.FeatureFlagInfo(value = _strip_version(
+        xcode_config.sdk_version_for_platform(
+            apple_common.platform.watchos_device,
+        ),
+    ))
+
+def _macos_sdk_version_flag_impl(ctx):
+    """A rule that allows select() to select based on the macOS SDK version."""
+    xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+
+    return config_common.FeatureFlagInfo(value = _strip_version(
+        xcode_config.sdk_version_for_platform(
+            apple_common.platform.macos,
+        ),
+    ))
+
+xcode_version_flag = rule(
+    implementation = _xcode_version_flag_impl,
+    attrs = {
+        "_xcode_config": attr.label(default = configuration_field(
+            fragment = "apple",
+            name = "xcode_config_label",
+        )),
+    },
+)
+
+ios_sdk_version_flag = rule(
+    implementation = _ios_sdk_version_flag_impl,
+    attrs = {
+        "_xcode_config": attr.label(default = configuration_field(
+            fragment = "apple",
+            name = "xcode_config_label",
+        )),
+    },
+)
+
+tvos_sdk_version_flag = rule(
+    implementation = _tvos_sdk_version_flag_impl,
+    attrs = {
+        "_xcode_config": attr.label(default = configuration_field(
+            fragment = "apple",
+            name = "xcode_config_label",
+        )),
+    },
+)
+
+watchos_sdk_version_flag = rule(
+    implementation = _watchos_sdk_version_flag_impl,
+    attrs = {
+        "_xcode_config": attr.label(default = configuration_field(
+            fragment = "apple",
+            name = "xcode_config_label",
+        )),
+    },
+)
+
+macos_sdk_version_flag = rule(
+    implementation = _macos_sdk_version_flag_impl,
+    attrs = {
+        "_xcode_config": attr.label(default = configuration_field(
+            fragment = "apple",
+            name = "xcode_config_label",
+        )),
+    },
+)


### PR DESCRIPTION
Fork Bazel's Xcode autoconfigure for usability improvements and debugging

Fork and improve Bazel's xcode configuration code. This is not a measure to fix
the problem, but to debug it and unblock CI. Github actions is incrediblly
flaky but Bazel should deal with a flaky host better and this is a weak point
(https://github.com/bazel-ios/rules_ios/issues/361)

Bazel puts this error in the build file which is a problem on the CI because it
swallows the error and it requires a user to clean --expunge. Bazel requires
the user to expunge because it thinks the repository was successfully written.
Probably a better pattern is to fail, but that won't shed light on the problem.

This is not just broken for CI but local developers. The plan is to use
rules_ios CI to reproduce this and gather more information then propose a fix
when we know more info.

Ammedum: I have confirmed with this PR, it's related to host over-subscribing
on GitHub Actions. This at least improves it because the user doesn't have to
expunge. PR to fix that to follow. 