### PR TITLE
Repro problem with absolute paths in dot-d files breaking inclusion validation in bazel5

### DIFF
--- a/tests/ios/InclusionProblemRepro/BUILD.bazel
+++ b/tests/ios/InclusionProblemRepro/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//rules:library.bzl", "apple_library")
+load("//rules:hmap.bzl", "headermap")
 
 apple_library(
     name = "LibraryA",
@@ -13,6 +14,68 @@ apple_library(
         "Classes/HeaderB.h",
         "Classes/HeaderC.h",
         "Classes/Extensions/D.h",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+
+headermap(
+    name="LibraryTest_private_hmap",
+    hdrs=glob([
+        "Classes/HeaderB.h",
+        "Classes/HeaderC.h",
+        "Classes/Extensions/D.h",
+    ]),
+)
+
+# it looks like the use of header maps combined with -fmodules is waht causes the problem to happen.
+objc_library(
+    name = "LibraryNoWorky_objc",
+    srcs = glob([
+        "Classes/HeaderB.h",
+        "Classes/HeaderC.h",
+        "Classes/Extensions/D.h",
+        "Classes/Extensions/D.m",
+    ]),
+    deps = ["LibraryTest_private_hmap"],
+    copts = [
+        "-fmodules",
+        "-fmodule-name=LibraryNoWorky",
+        "-iquote$(execpath :LibraryTest_private_hmap)",
+        "-I."
+    ],
+    visibility = ["//visibility:public"],
+)
+
+
+objc_library(
+    name = "LibraryWorky_objc",
+    srcs = glob([
+        "Classes/HeaderB.h",
+        "Classes/HeaderC.h",
+        "Classes/Extensions/D.h",
+        "Classes/Extensions/D.m",
+    ]),
+    copts = [
+        "-fmodules",
+        "-fmodule-name=LibraryWorky",
+        "-iquotetests/ios/InclusionProblemRepro/Classes",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+objc_library(
+    name = "LibraryWorkyToo_objc",
+    srcs = glob([
+        "Classes/HeaderB.h",
+        "Classes/HeaderC.h",
+        "Classes/Extensions/D.h",
+        "Classes/Extensions/D.m",
+    ]),
+    deps = ["LibraryTest_private_hmap"],    
+    copts = [
+        "-iquote$(execpath :LibraryTest_private_hmap)",
+        "-I."
     ],
     visibility = ["//visibility:public"],
 )

--- a/tests/ios/InclusionProblemRepro/BUILD.bazel
+++ b/tests/ios/InclusionProblemRepro/BUILD.bazel
@@ -1,0 +1,18 @@
+load("//rules:library.bzl", "apple_library")
+
+apple_library(
+    name = "LibraryA",
+    srcs = glob([
+        "Classes/HeaderB.h",
+        "Classes/HeaderC.h",
+        "Classes/Extensions/D.h",
+        "Classes/Extensions/D.m",
+    ]),
+    platforms = {"ios": "8.0"},
+    public_headers = [
+        "Classes/HeaderB.h",
+        "Classes/HeaderC.h",
+        "Classes/Extensions/D.h",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/tests/ios/InclusionProblemRepro/Classes/Extensions/D.h
+++ b/tests/ios/InclusionProblemRepro/Classes/Extensions/D.h
@@ -1,0 +1,1 @@
+#import "HeaderC.h"

--- a/tests/ios/InclusionProblemRepro/Classes/Extensions/D.m
+++ b/tests/ios/InclusionProblemRepro/Classes/Extensions/D.m
@@ -1,0 +1,1 @@
+#import "D.h"

--- a/tests/ios/InclusionProblemRepro/Classes/HeaderC.h
+++ b/tests/ios/InclusionProblemRepro/Classes/HeaderC.h
@@ -1,0 +1,1 @@
+#import "HeaderB.h"


### PR DESCRIPTION
Using this branch to reproduce the problem reported in https://github.com/bazelbuild/bazel/issues/14346