### PR TITLE
Add target_settings_by_config and pass config type in configs attribute

### DIFF
--- a/tests/ios/xcodeproj/BUILD.bazel
+++ b/tests/ios/xcodeproj/BUILD.bazel
@@ -10,10 +10,10 @@ xcodeproj(
     bazel_path = "bazelisk",
     # Not that 'configs' must hold names for configs present in your .bazelrc file
     # in order to build with the respective Xcode build configurations active
-    configs = [
-        "bar",
-        "foo",
-    ],
+    configs = {
+        "bar": "debug",
+        "foo": "release",
+    },
     generate_schemes_for_product_types = [
         "framework.static",
         "bundle.unit-test",


### PR DESCRIPTION
Change `configs` attribute to also requires the config type XcodeGen uses `debug/release`:

1. New `configs` API (from list to dict), **this is an API breaking change**:
```
Dictionary keyed at config name present in the .bazelrc file and values at one of these two config types: 'debug', 'release'

A Xcode build configuration will be created for each entry and a '--config=$CONFIGURATION' will
be appended to the underlying bazel invocation. Effectively allowing the configs in the .bazelrc file
to control how Xcode builds each build configuration.

If not present the 'Debug' and 'Release' Xcode build configurations will be created by default without
appending any additional bazel invocation flags.
```

2. `target_settings_by_config`:
```
Additional optinal dictionary with Xcode build settings to be added to all targets grouped by config (see 'configs' attribute).

Example:

target_settings_by_config = {
        "my_config": [
            "PRODUCT_BUNDLE_IDENTIFIER=com.company.app.my_config",
            "FOO=bar_1",
        ]
        "Release": [
            "PRODUCT_BUNDLE_IDENTIFIER=com.company.app",
            "FOO=bar_2",
        ],
}

Each config has to exist in 'configs' and be set to one of 'debug'/'release' so xcodegen knows about its existence when creating the target.

Also, note that bazel doesn't support attributes with strings as keys and values at dictionaries so the proposal here is
to pass the settings as an array of strings where each element has the format 'SETTING_NAME=VALUE'.

Read more:
- https://github.com/yonaskolb/XcodeGen/blob/master/Docs/ProjectSpec.md#settings
- https://docs.bazel.build/versions/main/skylark/lib/attr.html
```