### PR TITLE
Ignore Index directories in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ bazel-*
 tests/macos/xcodeproj/**/xcuserdata
 tests/ios/xcodeproj/**/xcuserdata
 **/*.xcodeproj/bazelinstallers/index-import
+/tests/ios/Index/
+/tests/macos/Index/


### PR DESCRIPTION
These are generated when run `tests/xcodeproj-tests.sh --clean`.
