### PR TITLE
Avoid running xcode-locator which can be super slow (and can fail) if the machine has many Xcode versions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,6 +33,10 @@ build --features swift.index_while_building
 # Prevents leaking unexpected binaries via PATH to tests
 build --test_env=PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
+# Avoid running xcode-locator which can be super slow if the machine has many
+# Xcode versions
+build --xcode_version_config=//:host_xcodes
+
 # A toolchain to build the arm64 sim under Bazel 4. The problem is
 # that Bazel should have a new CPU but that needs much work in Bazel. The idea of
 # this toolchain is to conditionally compile x86_64 simulator as arm64. This has

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -35,3 +35,27 @@ config_setting(
         "features": feature_names.bazel4_override_simulator_cpu_arm64,
     },
 )
+
+xcode_version(
+    name = "version12_2_0_12B45b",
+    aliases = [
+        "12",
+        "12.2",
+        "12.2.0",
+        "12.2.0.12B45b",
+    ],
+    default_ios_sdk_version = "14.2",
+    default_macos_sdk_version = "11.0",
+    default_tvos_sdk_version = "14.2",
+    default_watchos_sdk_version = "7.1",
+    version = "12.2.0.12B45b",
+)
+
+xcode_config(
+    name = "host_xcodes",
+    default = ":version12_2_0_12B45b",
+    versions = [
+        ":version12_2_0_12B45b",
+    ],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This fixes the flaky CI.