### PR TITLE
Only import iOS swiftmodules

### DIFF
--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -13,7 +13,7 @@ fi
 declare -a EXISTING_SWIFTMODULES=()
 for i in $FOUND_SWIFTMODULES
 do
-  if [[ -f $i ]]
+  if [[ -f $i ]] && [[ $i == bazel-out/ios-* ]]
   then
     EXISTING_SWIFTMODULES+=($i)
   fi

--- a/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -13,7 +13,7 @@ fi
 declare -a EXISTING_SWIFTMODULES=()
 for i in $FOUND_SWIFTMODULES
 do
-  if [[ -f $i ]]
+  if [[ -f $i ]] && [[ $i == bazel-out/ios-* ]]
   then
     EXISTING_SWIFTMODULES+=($i)
   fi

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -13,7 +13,7 @@ fi
 declare -a EXISTING_SWIFTMODULES=()
 for i in $FOUND_SWIFTMODULES
 do
-  if [[ -f $i ]]
+  if [[ -f $i ]] && [[ $i == bazel-out/ios-* ]]
   then
     EXISTING_SWIFTMODULES+=($i)
   fi

--- a/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -13,7 +13,7 @@ fi
 declare -a EXISTING_SWIFTMODULES=()
 for i in $FOUND_SWIFTMODULES
 do
-  if [[ -f $i ]]
+  if [[ -f $i ]] && [[ $i == bazel-out/ios-* ]]
   then
     EXISTING_SWIFTMODULES+=($i)
   fi

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -13,7 +13,7 @@ fi
 declare -a EXISTING_SWIFTMODULES=()
 for i in $FOUND_SWIFTMODULES
 do
-  if [[ -f $i ]]
+  if [[ -f $i ]] && [[ $i == bazel-out/ios-* ]]
   then
     EXISTING_SWIFTMODULES+=($i)
   fi

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -13,7 +13,7 @@ fi
 declare -a EXISTING_SWIFTMODULES=()
 for i in $FOUND_SWIFTMODULES
 do
-  if [[ -f $i ]]
+  if [[ -f $i ]] && [[ $i == bazel-out/ios-* ]]
   then
     EXISTING_SWIFTMODULES+=($i)
   fi

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -13,7 +13,7 @@ fi
 declare -a EXISTING_SWIFTMODULES=()
 for i in $FOUND_SWIFTMODULES
 do
-  if [[ -f $i ]]
+  if [[ -f $i ]] && [[ $i == bazel-out/ios-* ]]
   then
     EXISTING_SWIFTMODULES+=($i)
   fi

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -13,7 +13,7 @@ fi
 declare -a EXISTING_SWIFTMODULES=()
 for i in $FOUND_SWIFTMODULES
 do
-  if [[ -f $i ]]
+  if [[ -f $i ]] && [[ $i == bazel-out/ios-* ]]
   then
     EXISTING_SWIFTMODULES+=($i)
   fi

--- a/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -13,7 +13,7 @@ fi
 declare -a EXISTING_SWIFTMODULES=()
 for i in $FOUND_SWIFTMODULES
 do
-  if [[ -f $i ]]
+  if [[ -f $i ]] && [[ $i == bazel-out/ios-* ]]
   then
     EXISTING_SWIFTMODULES+=($i)
   fi

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -13,7 +13,7 @@ fi
 declare -a EXISTING_SWIFTMODULES=()
 for i in $FOUND_SWIFTMODULES
 do
-  if [[ -f $i ]]
+  if [[ -f $i ]] && [[ $i == bazel-out/ios-* ]]
   then
     EXISTING_SWIFTMODULES+=($i)
   fi

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -13,7 +13,7 @@ fi
 declare -a EXISTING_SWIFTMODULES=()
 for i in $FOUND_SWIFTMODULES
 do
-  if [[ -f $i ]]
+  if [[ -f $i ]] && [[ $i == bazel-out/ios-* ]]
   then
     EXISTING_SWIFTMODULES+=($i)
   fi

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/swiftmodules.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/swiftmodules.sh
@@ -13,7 +13,7 @@ fi
 declare -a EXISTING_SWIFTMODULES=()
 for i in $FOUND_SWIFTMODULES
 do
-  if [[ -f $i ]]
+  if [[ -f $i ]] && [[ $i == bazel-out/ios-* ]]
   then
     EXISTING_SWIFTMODULES+=($i)
   fi

--- a/tools/xcodeproj_shims/installers/swiftmodules.sh
+++ b/tools/xcodeproj_shims/installers/swiftmodules.sh
@@ -13,7 +13,7 @@ fi
 declare -a EXISTING_SWIFTMODULES=()
 for i in $FOUND_SWIFTMODULES
 do
-  if [[ -f $i ]]
+  if [[ -f $i ]] && [[ $i == bazel-out/ios-* ]]
   then
     EXISTING_SWIFTMODULES+=($i)
   fi


### PR DESCRIPTION
If you have the same module also compiled for the host tools, the macOS
one could overwrite the iOS one and cause indexing error, for example:

```
module 'SwiftProtobuf' was created for incompatible target
x86_64-apple-macosx12.0
```
