### PR TITLE
Add a remote cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,6 +33,10 @@ build --features swift.index_while_building
 # Prevents leaking unexpected binaries via PATH to tests
 build --test_env=PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
+build --remote_cache=grpcs://remote.buildbuddy.io
+build --remote_instance_name=rules_ios
+build --noremote_upload_local_results
+
 # A toolchain to build the arm64 sim under Bazel 4. The problem is
 # that Bazel should have a new CPU but that needs much work in Bazel. The idea of
 # this toolchain is to conditionally compile x86_64 simulator as arm64. This has
@@ -47,3 +51,5 @@ common:bazel4_arm64_simulator_arm64_host --features bazel4.override_simulator_cp
 # Similar to above but doesn't override the host CPU 
 common:bazel4_arm64_simulator_x86_64_host --features apple.arm64_simulator_use_device_deps 
 common:bazel4_arm64_simulator_x86_64_host --features bazel4.override_simulator_cpu_arm64
+
+try-import %workspace%/.bazelrc.ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Select Xcode
         run: .github/workflows/xcode_select.sh
+      - name: Generate .bazelrc.ci
+        run: echo "build --remote_upload_local_results" > .bazelrc.ci
       - name: Build and Test
         run: |
           # Host config
@@ -36,6 +38,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Select Xcode
         run: .github/workflows/xcode_select.sh
+      - name: Generate .bazelrc.ci
+        run: echo "build --remote_upload_local_results" > .bazelrc.ci
       - name: Build and Test
         run: |
           # Host config
@@ -61,6 +65,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Select Xcode
         run: .github/workflows/xcode_select.sh
+      - name: Generate .bazelrc.ci
+        run: echo "build --remote_upload_local_results" > .bazelrc.ci
       - name: Build and Test
         run: |
           bazelisk clean # Note: there is a problem with some reuse in rules_swift
@@ -90,6 +96,8 @@ jobs:
       - name: Select Xcode
         run: .github/workflows/xcode_select.sh
         # Note: we need to pass the absolute to the Bazel run
+      - name: Generate .bazelrc.ci
+        run: echo "build --remote_upload_local_results" > .bazelrc.ci
       - name: buildifier
         run: find $PWD -type f \( -name 'WORKSPACE' -o -name '*.bzl' -o -name '*.bazel' \) | xargs bazel run buildifier -- -lint=fix && git diff --exit-code
       - name: Check docs
@@ -101,6 +109,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Select Xcode 12.2
         run: sudo xcode-select -s /Applications/Xcode_12.2.app
+      - name: Generate .bazelrc.ci
+        run: echo "build --remote_upload_local_results" > .bazelrc.ci
       - name: Run tests
         run: ./tests/xcodeproj-tests.sh --clean
   multi_arch_support:
@@ -110,5 +120,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Select Xcode
         run: .github/workflows/xcode_select.sh
+      - name: Generate .bazelrc.ci
+        run: echo "build --remote_upload_local_results" > .bazelrc.ci
       - name: Build App
         run: bazelisk build -s tests/ios/app/App --apple_platform_type=ios --ios_minimum_os=10.2  --ios_multi_cpus=i386,x86_64

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tests/ios/xcodeproj/**/xcuserdata
 **/*.xcodeproj/bazelinstallers/index-import
 /tests/ios/Index/
 /tests/macos/Index/
+/.bazelrc.ci


### PR DESCRIPTION
Test running is taking almost an hour each to run. This adds a remote
cache option to speed it up, using the unauthenticate remote cache from
BuildBuddy.
