### PR TITLE
Bug fix for "_xcframework"

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -362,8 +362,8 @@ def _xcframework(*, library_name, name, slices):
 
     # Use the arm64 slice when overriding the CPU
     if any_ios_arm64_slice:
-        native.alias(name = xcframework_name + "default", actual = select(conditions))
-        native.alias(name = xcframework_name + "default_vfs", actual = select(conditions_vfs))
+        native.alias(name = xcframework_name + "default", actual = select(conditions), tags = _MANUAL)
+        native.alias(name = xcframework_name + "default_vfs", actual = select(conditions_vfs), tags = _MANUAL)
 
         conditions = {
             "//conditions:default": xcframework_name + "default",


### PR DESCRIPTION
# Summary 
One `apple_framework` target with `vendored_xcframeworks` in [cocoapods-bazel](https://github.com/bazel-ios/cocoapods-bazel) failed to build. Adding the `_MANUAL` tags for `native.alias` could solve this issue.

# Steps to reproduce
1. Checkout [cocoapods-bazel](https://github.com/bazel-ios/cocoapods-bazel)
2. run `bin/setup`
3. run `rake/spec`

The error log
```
ERROR: ./spec/integration/tmp/monorepo/transformed/Pods/OneTrust-CMP-XCFramework/BUILD.bazel:3:16: Configurable attribute "actual" doesn't match this configuration (would a default condition help?).
Conditions checked:
 //Pods/OneTrust-CMP-XCFramework:OneTrust-CMP-XCFramework-import-OTPublishersHeadlessSDK.xcframework-ios_simulator_x86_64
 //Pods/OneTrust-CMP-XCFramework:OneTrust-CMP-XCFramework-import-OTPublishersHeadlessSDK.xcframework-ios_arm64
ERROR: Analysis of target '//Pods/OneTrust-CMP-XCFramework:OneTrust-CMP-XCFramework-import-OTPublishersHeadlessSDK.xcframeworkdefault_vfs' failed; build aborted: ./spec/integration/tmp/monorepo/transformed/Pods/OneTrust-CMP-XCFramework/BUILD.bazel:3:16: Configurable attribute "actual" doesn't match this configuration (would a default condition help?).
Conditions checked:
 //Pods/OneTrust-CMP-XCFramework:OneTrust-CMP-XCFramework-import-OTPublishersHeadlessSDK.xcframework-ios_simulator_x86_64
 //Pods/OneTrust-CMP-XCFramework:OneTrust-CMP-XCFramework-import-OTPublishersHeadlessSDK.xcframework-ios_arm64
```

The generated build file that failed to build.
```
apple_framework(
    name = "OneTrust-CMP-XCFramework",
    module_name = "OneTrust_CMP_XCFramework",
    platforms = {"ios": "11.0"},
    vendored_xcframeworks = [
        {
            "name": "OTPublishersHeadlessSDK",
            "slices": [
                {
                    "identifier": "ios-arm64_x86_64-simulator",
                    "platform": "ios",
                    "platform_variant": "simulator",
                    "supported_archs": [
                        "arm64",
                        "x86_64",
                    ],
                    "path": "OTPublishersHeadlessSDK.xcframework/ios-arm64_x86_64-simulator/OTPublishersHeadlessSDK.framework",
                    "build_type": {
                        "linkage": "dynamic",
                        "packaging": "framework",
                    },
                },
                {
                    "identifier": "ios-arm64",
                    "platform": "ios",
                    "platform_variant": "",
                    "supported_archs": ["arm64"],
                    "path": "OTPublishersHeadlessSDK.xcframework/ios-arm64/OTPublishersHeadlessSDK.framework",
                    "build_type": {
                        "linkage": "dynamic",
                        "packaging": "framework",
                    },
                },
            ],
        },
    ],
    visibility = ["//visibility:public"],
)
```

