### PR TITLE
Fix ordering assumptions in input xcframework dictionaries

### DIFF
--- a/rules/import_middleman.bzl
+++ b/rules/import_middleman.bzl
@@ -214,7 +214,7 @@ def _file_collector_rule_impl(ctx):
     )
 
     return [
-        DefaultInfo(files = depset(dynamic_framework_dirs)),
+        DefaultInfo(files = depset(dynamic_framework_dirs + replaced_frameworks)),
         objc,
         _make_imports([depset(dynamic_framework_dirs)]),
     ]

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -310,26 +310,26 @@ def _xcframework(*, library_name, name, slices):
     xcframework_name_vfs = xcframework_name + "_vfs"
     conditions = {}
     conditions_vfs = {}
-    any_ios_arm64_slice = None
+    arm64_ios_device_slice = None
+    arm64_simulator_slice = None
     for slice in slices:
         platform, platform_variant, archs, name, vfs_overlay_target_name = _xcframework_slice(xcframework_name = xcframework_name, **slice)
         platform_setting = "@build_bazel_rules_ios//rules/apple_platform:" + platform
         # platform_variant_setting = "@build_bazel_rules_ios//rules/apple_platform:platform_variant_" + platform_variant if platform_variant else None
 
         for arch in archs:
-            if arch == "arm64" and platform_variant == "simulator":
-                # TODO: support sim on apple silicon by having a config setting for platform_variant
-                any_ios_arm64_slice = name
-                continue
-            elif (arch == "armv7s" or arch == "arm64e") and platform == "ios":
-                # unsupported platform-arch by rules_apple
-                continue
-            elif (arch == "x86_64" or arch == "arm64") and platform_variant == "maccatalyst":
-                # TODO: support maccatalyst
-                continue
-            elif arch == "arm64" and platform == "ios":
-                if not any_ios_arm64_slice:
-                    any_ios_arm64_slice = name
+            if platform == "ios":
+                if (arch == "armv7s" or arch == "arm64e"):
+                    # unsupported platform-arch by rules_apple
+                    continue
+                elif platform_variant == "maccatalyst":
+                    # TODO: support maccatalyst
+                    continue
+                elif arch == "arm64":
+                    if platform_variant == "simulator":
+                        arm64_simulator_slice = name
+                    else:
+                        arm64_ios_device_slice = name
 
             rules_apple_platfrom = "darwin" if platform == "macos" else platform
             arch_setting = "@build_bazel_rules_apple//apple:{}_{}".format(rules_apple_platfrom, arch)
@@ -361,17 +361,18 @@ def _xcframework(*, library_name, name, slices):
             )
 
     # Use the arm64 slice when overriding the CPU
-    if any_ios_arm64_slice:
+    alias_slice = arm64_simulator_slice if arm64_simulator_slice else arm64_ios_device_slice
+    if alias_slice:
         native.alias(name = xcframework_name + "default", actual = select(conditions), tags = _MANUAL)
         native.alias(name = xcframework_name + "default_vfs", actual = select(conditions_vfs), tags = _MANUAL)
 
         conditions = {
             "//conditions:default": xcframework_name + "default",
-            "@build_bazel_rules_ios//:bazel4_override_simulator_cpu_arm64": any_ios_arm64_slice,
+            "@build_bazel_rules_ios//:bazel4_override_simulator_cpu_arm64": alias_slice,
         }
         conditions_vfs = {
             "//conditions:default": xcframework_name + "default_vfs",
-            "@build_bazel_rules_ios//:bazel4_override_simulator_cpu_arm64": any_ios_arm64_slice + "_vfs",
+            "@build_bazel_rules_ios//:bazel4_override_simulator_cpu_arm64": alias_slice + "_vfs",
         }
 
     native.alias(


### PR DESCRIPTION
Depending on what order build files were created by hand or generated this
logic had an ordering problem with the invariant. This hardens the logic and
scopes it to a platform level.