### PR TITLE
[Apple Silicon] Fix error if Xcode.app is out of /Applications

### DIFF
--- a/tools/toolchains/bazel4_local_config_cc/BUILD
+++ b/tools/toolchains/bazel4_local_config_cc/BUILD
@@ -89,7 +89,7 @@ cc_toolchain_suite(
         compiler = "compiler",
         cpu = arch,
         cxx_builtin_include_directories = [
-            "/Applications/",
+            "/",
             "/Library/",
         ],
         tool_paths_overrides = {},


### PR DESCRIPTION
Broaden the include validation predicate which was previously set to
/Applications. When using this toolchain, the validation will otherwise fail

```
/var/tmp/_bazel_x/53998339ce49dbe95d8d2305f25af2f8/external/build_bazel_rules_ios/rules/hmap/BUILD.bazel:11:11: Compiling rules/hmap/lines.c [for host] failed: undeclared inclusion(s) in rule '@build_bazel_rules_ios//rules/hmap:lines':
```