### PR TITLE
Explicitly set the required py version to use.

### DIFF
--- a/rules/framework/BUILD.bazel
+++ b/rules/framework/BUILD.bazel
@@ -4,4 +4,5 @@ py_binary(
     name = "framework_packaging",
     srcs = ["framework_packaging.py"],
     visibility = ["//visibility:public"],
+    python_version = "PY2",
 )


### PR DESCRIPTION
Enforce the correct version to avoid potential issues and warnings like this:
```
Note: The failure of target @build_bazel_rules_ios//rules/framework:framework_packaging (with exit code 1) may have been caused by the fact that it is running under Python 3 instead of Python 2. Examine the error to determine if that appears to be the problem. Since this target is built in the host configuration, the only way to change its version is to set --host_force_python=PY2, which affects the entire build.

If this error started occurring in Bazel 0.27 and later, it may be because the Python toolchain now enforces that targets analyzed as PY2 and PY3 run under a Python 2 and Python 3 interpreter, respectively. See https://github.com/bazelbuild/bazel/issues/7899 for more information.
```