### PR TITLE
Add bundle_name to list of iOS application kwargs

### DIFF
--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -12,6 +12,7 @@ load("//rules:force_load_direct_deps.bzl", "force_load_direct_deps")
 # - Perhaps we can just remove this wrapper longer term.
 _IOS_APPLICATION_KWARGS = [
     "bundle_id",
+    "bundle_name",
     "infoplists",
     "env",
     "minimum_os_version",


### PR DESCRIPTION
So consumers can customize this property

See: https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-ios.md#ios_application