### PR TITLE
Add objc_defines and swift_defines

### DIFF
--- a/design/APPLE_FRAMEWORK.md
+++ b/design/APPLE_FRAMEWORK.md
@@ -43,9 +43,11 @@ apple_framework(
     swift_copts = ["-stuff"],
     objc_copts = ["--stuff"],
     cc_copts = ["--stuff"],
+    swift_defines = ["G", "H=1", "I=0"],
+    objc_defines = ["A=B", "\'C=D E F\'"],
 
     # propagated
-    defines = ["foo=bar"],
+    defines = ["FOO=BAR"],
     linkopts = ["--stuff"],
     other_inputs = [],  # stuff that you need, like swiftc_inputs
     linking_style = None,  # dynamic vs static, defaults to None, which does

--- a/docs/library_doc.md
+++ b/docs/library_doc.md
@@ -66,7 +66,8 @@ Propagates private headers, so they can be accessed if necessary
 
 <pre>
 apple_library(<a href="#apple_library-name">name</a>, <a href="#apple_library-library_tools">library_tools</a>, <a href="#apple_library-export_private_headers">export_private_headers</a>, <a href="#apple_library-namespace_is_module_name">namespace_is_module_name</a>,
-              <a href="#apple_library-default_xcconfig_name">default_xcconfig_name</a>, <a href="#apple_library-xcconfig">xcconfig</a>, <a href="#apple_library-xcconfig_by_build_setting">xcconfig_by_build_setting</a>, <a href="#apple_library-kwargs">kwargs</a>)
+              <a href="#apple_library-default_xcconfig_name">default_xcconfig_name</a>, <a href="#apple_library-xcconfig">xcconfig</a>, <a href="#apple_library-xcconfig_by_build_setting">xcconfig_by_build_setting</a>, <a href="#apple_library-objc_defines">objc_defines</a>, <a href="#apple_library-swift_defines">swift_defines</a>,
+              <a href="#apple_library-kwargs">kwargs</a>)
 </pre>
 
 Create libraries for native source code on Apple platforms.
@@ -87,6 +88,8 @@ reasonable defaults that mimic Xcode's behavior.
 | <a id="apple_library-default_xcconfig_name"></a>default_xcconfig_name |  The name of a default xcconfig to be applied to this target.   |  <code>None</code> |
 | <a id="apple_library-xcconfig"></a>xcconfig |  A dictionary of Xcode build settings to be applied to this target in the           form of different <code>copt</code> attributes.   |  <code>{}</code> |
 | <a id="apple_library-xcconfig_by_build_setting"></a>xcconfig_by_build_setting |  A dictionary of Xcode build settings grouped by bazel build setting.<br><br>                           Each value is applied (overriding any matching setting in 'xcconfig') if                            the respective bazel build setting is resolved during the analysis phase.   |  <code>{}</code> |
+| <a id="apple_library-objc_defines"></a>objc_defines |  A list of Objective-C defines to add to the compilation command line. They should be in the form KEY=VALUE or simply KEY and are passed not only to the compiler for this target (as copts are) but also to all objc_ dependers of this target.   |  <code>[]</code> |
+| <a id="apple_library-swift_defines"></a>swift_defines |  A list of Swift defines to add to the compilation command line. Swift defines do not have values, so strings in this list should be simple identifiers and not KEY=VALUE pairs. (only expections are KEY=1 and KEY=0). These flags are added for the target and every target that depends on it.   |  <code>[]</code> |
 | <a id="apple_library-kwargs"></a>kwargs |  keyword arguments.   |  none |
 
 

--- a/tests/ios/app/BUILD.bazel
+++ b/tests/ios/app/BUILD.bazel
@@ -47,6 +47,42 @@ apple_framework(
     visibility = ["//visibility:public"],
 )
 
+apple_framework(
+    name = "WithDefinesObjc",
+    srcs = glob(["WithDefinesObjc/*.m"]),
+    defines = [
+        "MACRO_A",
+        "MACRO_B=1",
+        "MACRO_C=0",
+    ],
+    objc_defines = [
+        "MACRO_D",
+        "MACRO_E=1",
+        "MACRO_F=0",
+        "\'MACRO_G=1 2 3\'",
+    ],
+    platforms = {"ios": "10.0"},
+    visibility = ["//visibility:public"],
+)
+
+apple_framework(
+    name = "WithDefinesSwift",
+    srcs = glob(["WithDefinesSwift/*.swift"]),
+    defines = [
+        "MACRO_H",
+        "MACRO_I=1",
+        "MACRO_J=0",
+    ],
+    platforms = {"ios": "10.0"},
+    swift_defines = [
+        "MACRO_K",
+        "MACRO_L=1",
+        "MACRO_M=0",
+    ],
+    swift_version = "5.1",
+    visibility = ["//visibility:public"],
+)
+
 ios_application(
     name = "App",
     srcs = ["App/main.m"],
@@ -128,6 +164,38 @@ ios_application(
         ":Empty",
         ":FW",
         ":OnlySources",
+    ],
+)
+
+ios_application(
+    name = "AppWithDefines",
+    srcs = ["App/main.m"],
+    bundle_id = "com.example.app",
+    defines = [
+        "A",
+        "B=1",
+        "C=0",
+    ],
+    minimum_os_version = "10.0",
+    objc_defines = [
+        "D",
+        "E=1",
+        "F=0",
+        "\'G=H I J\'",
+    ],
+    settings_bundle = ":settings_bundle",
+    swift_defines = [
+        "K",
+        "L=1",
+        "M=0",
+    ],
+    swift_version = "5.1",
+    deps = [
+        ":Empty",
+        ":FW",
+        ":OnlySources",
+        ":WithDefinesObjc",
+        ":WithDefinesSwift",
     ],
 )
 

--- a/tests/ios/app/WithDefinesObjc/WithDefines.m
+++ b/tests/ios/app/WithDefinesObjc/WithDefines.m
@@ -1,0 +1,30 @@
+@import Foundation;
+
+@interface WithDefinesObjc : NSObject
+@end
+
+@implementation WithDefinesObjc
+
+#if !MACRO_A
+ thisShouldNotBeCompiled
+#endif
+#if !MACRO_B
+ thisShouldNotBeCompiled
+#endif
+#if MACRO_C
+ thisShouldNotBeCompiled
+#endif
+#if !MACRO_D
+ thisShouldNotBeCompiled
+#endif
+#if !MACRO_E
+ thisShouldNotBeCompiled
+#endif
+#if MACRO_F
+ thisShouldNotBeCompiled
+#endif
+#ifndef MACRO_G
+ thisShouldNotBeCompiled
+#endif
+
+@end

--- a/tests/ios/app/WithDefinesSwift/withDefines.swift
+++ b/tests/ios/app/WithDefinesSwift/withDefines.swift
@@ -1,0 +1,22 @@
+enum WithDefinesSwift {
+  func foo() {
+#if !MACRO_H
+ thisShouldNotBeCompiled
+#endif
+#if !MACRO_I
+ thisShouldNotBeCompiled
+#endif
+#if MACRO_J
+ thisShouldNotBeCompiled
+#endif
+#if !MACRO_K
+ thisShouldNotBeCompiled
+#endif
+#if !MACRO_L
+ thisShouldNotBeCompiled
+#endif
+#if MACRO_M
+ thisShouldNotBeCompiled
+#endif
+  }
+}


### PR DESCRIPTION
Proposal to solve #400 by introducing `swift_defines` and `objc_defines`

**Why not stop supporting `defines`?**

Backwards compatibility in case consumers with more simple use cases are already setting this value

**Why not manipulate `defines` and extract swift/objc from it?**

The `defines` attribute is already in use for a while and it's being propagated "as is" so consumer could be setting `select()` statements in this attribute to handle different settings, meaning we can't assume this attribute contains a list that can be manipulated.

**Why add this as an explicit parameter in `apple_library`?**

It's a good way to ensure there's documentation for these attributes it's clear to consumers what is expected in each. Open to suggestions though.