### PR TITLE
Quote ARCH variable in update_static.sh

### DIFF
--- a/tools/m1_utils/update_static.sh
+++ b/tools/m1_utils/update_static.sh
@@ -47,7 +47,7 @@ patch() {
      ARCHS=()
      mkdir -p "$(dirname $OF)"
      while read ARCH; do
-          ARCHS+=($ARCH)
+          ARCHS+=("$ARCH")
      done < <(lipo -archs "$FWF")
      if test "${#ARCHS[@]}" -gt 1; then 
          lipo "$FWF" -thin arm64 -output "OF.ar" || cp "$FWF" "OF.ar"


### PR DESCRIPTION
Shellcheck is a static analysis tool that highlights syntactic issues
that lead to common shell bugs. It highlighted that `ARCH` is not quoted
in this script, and when I quote it, the script does not work correctly.

Opening this as a PR at @jerrymarino's request so that he can see the
change.