### PR TITLE
Add arm-to-sim attribute to silence warning

### DIFF
--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -100,6 +100,7 @@ native_binary(
         name = "arm64-to-sim",
         remote = "https://github.com/bogo/arm64-to-sim.git",
         commit = "25599a28689fa42679f23eb0ff031ebe57d3bb9b",
+        shallow_since = "1636567136 -0500",
         build_file_content = """
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
 


### PR DESCRIPTION
This should have shallow_since and it pops in Xcode right now