### PR TITLE
Basic test case of protobuf codegen / integration 

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -103,3 +103,20 @@ xcode_configure(
     remote_xcode_label = "",
     xcode_locator_label = "//tools/toolchains/xcode_configure:xcode_locator.m",
 )
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_proto_grpc",
+    sha256 = "507e38c8d95c7efa4f3b1c0595a8e8f139c885cb41a76cab7e20e4e67ae87731",
+    strip_prefix = "rules_proto_grpc-4.1.1",
+    urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/4.1.1.tar.gz"],
+)
+
+load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_toolchains", "rules_proto_grpc_repos")
+rules_proto_grpc_toolchains()
+rules_proto_grpc_repos()
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+rules_proto_dependencies()
+rules_proto_toolchains()

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -471,14 +471,6 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
             swift_sources.append(f)
         elif f.endswith((".cc", ".cpp")):
             cpp_sources.append(f)
-        elif f.count("sample_objc_proto_srcs") > 0:
-            objc_sources.append(f)
-        elif f.count("sample_objc_proto_hdrs") > 0:
-            objc_hdrs.append(f)
-        elif f.count("second_objc_proto_srcs") > 0:
-            objc_sources.append(f)
-        elif f.count("second_objc_proto_hdrs") > 0:
-            objc_hdrs.append(f)
         else:
             fail("Unable to compile %s in apple_framework %s" % (f, name))
 

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -471,6 +471,14 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
             swift_sources.append(f)
         elif f.endswith((".cc", ".cpp")):
             cpp_sources.append(f)
+        elif f.count("sample_objc_proto_srcs") > 0:
+            objc_sources.append(f)
+        elif f.count("sample_objc_proto_hdrs") > 0:
+            objc_hdrs.append(f)
+        elif f.count("second_objc_proto_srcs") > 0:
+            objc_sources.append(f)
+        elif f.count("second_objc_proto_hdrs") > 0:
+            objc_hdrs.append(f)
         else:
             fail("Unable to compile %s in apple_framework %s" % (f, name))
 

--- a/tests/ios/frameworks/protos/BUILD.bazel
+++ b/tests/ios/frameworks/protos/BUILD.bazel
@@ -4,7 +4,6 @@ load("//rules:framework.bzl", "apple_framework")
 
 exports_files(["*.proto"])
 
-
 proto_library(
     name = "sample_proto",
     srcs = ["sample.proto"],
@@ -17,22 +16,25 @@ objc_proto_compile(
 
 # Filter files to sources and headers
 filter_files(
-    name = "sample_objc_proto_srcs",
-    target = "sample_objc_proto",
+    name = "sample_objc_proto.m",
     extensions = ["m"],
+    target = "sample_objc_proto",
 )
 
 filter_files(
-    name = "sample_objc_proto_hdrs",
-    target = "sample_objc_proto",
+    name = "sample_objc_proto.h",
     extensions = ["h"],
+    target = "sample_objc_proto",
 )
 
 apple_framework(
-    name = "SampleProtoFramework",    
-    srcs = [":sample_objc_proto_srcs", ":sample_objc_proto_hdrs"],
-    deps = ["@com_google_protobuf//:protobuf_objc"],
+    name = "SampleProtoFramework",
+    srcs = [
+        ":sample_objc_proto.h",
+        ":sample_objc_proto.m",
+    ],
+    includes = ["sample_objc_proto"],
     platforms = {"ios": "10.0"},
     visibility = ["//visibility:public"],
-    includes = ["sample_objc_proto"],
+    deps = ["@com_google_protobuf//:protobuf_objc"],
 )

--- a/tests/ios/frameworks/protos/BUILD.bazel
+++ b/tests/ios/frameworks/protos/BUILD.bazel
@@ -1,0 +1,38 @@
+load("@rules_proto_grpc//objc:defs.bzl", "objc_proto_compile")
+load("@rules_proto_grpc//internal:filter_files.bzl", "filter_files")
+load("//rules:framework.bzl", "apple_framework")
+
+exports_files(["*.proto"])
+
+
+proto_library(
+    name = "sample_proto",
+    srcs = ["sample.proto"],
+)
+
+objc_proto_compile(
+    name = "sample_objc_proto",
+    protos = [":sample_proto"],
+)
+
+# Filter files to sources and headers
+filter_files(
+    name = "sample_objc_proto_srcs",
+    target = "sample_objc_proto",
+    extensions = ["m"],
+)
+
+filter_files(
+    name = "sample_objc_proto_hdrs",
+    target = "sample_objc_proto",
+    extensions = ["h"],
+)
+
+apple_framework(
+    name = "SampleProtoFramework",    
+    srcs = [":sample_objc_proto_srcs", ":sample_objc_proto_hdrs"],
+    deps = ["@com_google_protobuf//:protobuf_objc"],
+    platforms = {"ios": "10.0"},
+    visibility = ["//visibility:public"],
+    includes = ["sample_objc_proto"],
+)

--- a/tests/ios/frameworks/protos/sample.proto
+++ b/tests/ios/frameworks/protos/sample.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package example;
+
+message Thing {
+    string name = 1;
+}


### PR DESCRIPTION
This PR adds usage of code generated protos using `rules_proto_grpc`

Next, we'll need to ensure the generated code is aligned with import statements