### PR TITLE
Integrate dynamic linking / embedding of apple_framework

### DIFF
--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -33,6 +33,7 @@ _IOS_APPLICATION_KWARGS = [
     "minimum_deployment_os_version",
     "ipa_post_processor",
     "include_symbols_in_bundle",
+    "frameworks",
 ]
 
 def ios_application(name, apple_library = apple_library, infoplists_by_build_setting = {}, **kwargs):
@@ -59,9 +60,9 @@ def ios_application(name, apple_library = apple_library, infoplists_by_build_set
     application_kwargs["families"] = application_kwargs.pop("families", ["iphone", "ipad"])
 
     force_load_name = name + ".force_load_direct_deps"
-    force_load_direct_deps(name = force_load_name, deps = library.lib_names, tags = ["manual"])
-    default_deps = [force_load_name] + library.lib_names
+    force_load_direct_deps(name = force_load_name, deps = kwargs.get("deps"), tags = ["manual"])
 
+    default_deps = [force_load_name] + library.lib_names
     import_middleman(name = name + ".import_middleman", deps = default_deps, tags = ["manual"])
     rules_apple_ios_application(
         name = name,

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -1,24 +1,34 @@
 """Framework rules"""
 
-load("@build_bazel_rules_apple//apple/internal:apple_product_type.bzl", "apple_product_type")
-load("@build_bazel_rules_apple//apple:providers.bzl", "AppleBundleInfo", "AppleSupportToolchainInfo")
-load("@build_bazel_rules_apple//apple/internal:platform_support.bzl", "platform_support")
-load("@build_bazel_rules_apple//apple/internal:resource_actions.bzl", "resource_actions")
-load("@build_bazel_rules_apple//apple/internal:rule_support.bzl", "rule_support")
-load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo", "swift_common")
-load("//rules:library.bzl", "PrivateHeadersInfo", "apple_library")
-load("//rules:transition_support.bzl", "transition_support")
-load("//rules:providers.bzl", "FrameworkInfo")
 load("//rules/framework:vfs_overlay.bzl", "VFSOverlayInfo", "make_vfsoverlay")
 load("//rules:features.bzl", "feature_names")
+load("//rules:library.bzl", "PrivateHeadersInfo", "apple_library")
 load("//rules:plists.bzl", "info_plists_by_setting")
+load("//rules:providers.bzl", "AvoidDepsInfo", "FrameworkInfo")
+load("//rules:transition_support.bzl", "transition_support")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@build_bazel_rules_apple//apple/internal:apple_product_type.bzl", "apple_product_type")
+load("@build_bazel_rules_apple//apple/internal:bundling_support.bzl", "bundling_support")
+load("@build_bazel_rules_apple//apple/internal:features_support.bzl", "features_support")
+load("@build_bazel_rules_apple//apple/internal:linking_support.bzl", "linking_support")
+load("@build_bazel_rules_apple//apple/internal:outputs.bzl", "outputs")
+load("@build_bazel_rules_apple//apple/internal:partials.bzl", "partials")
+load("@build_bazel_rules_apple//apple/internal:platform_support.bzl", "platform_support")
+load("@build_bazel_rules_apple//apple/internal:processor.bzl", "processor")
+load("@build_bazel_rules_apple//apple/internal:resource_actions.bzl", "resource_actions")
+load("@build_bazel_rules_apple//apple/internal:resources.bzl", "resources")
+load("@build_bazel_rules_apple//apple/internal:rule_support.bzl", "rule_support")
+load("@build_bazel_rules_apple//apple:providers.bzl", "AppleBundleInfo", "AppleSupportToolchainInfo", "IosFrameworkBundleInfo")
+load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo", "swift_common")
 
 _APPLE_FRAMEWORK_PACKAGING_KWARGS = [
     "visibility",
+    "frameworks",
     "tags",
+    "data",
     "bundle_id",
     "skip_packaging",
+    "link_dynamic",
 ]
 
 def apple_framework(name, apple_library = apple_library, **kwargs):
@@ -515,6 +525,252 @@ def _attrs_for_split_slice(attrs_by_split_slices, split_slice_key):
     else:
         return attrs_by_split_slices[split_slice_key]
 
+def _bundle_dynamic_framework(ctx, avoid_deps):
+    """Packages this as dynamic framework
+
+    Currently, this doesn't include headers or other interface files.
+    """
+    actions = ctx.actions
+    apple_toolchain_info = ctx.attr._toolchain[AppleSupportToolchainInfo]
+    bin_root_path = ctx.bin_dir.path
+    bundle_id = ctx.attr.bundle_id
+    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    executable_name = bundling_support.executable_name(ctx)
+    features = features_support.compute_enabled_features(
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+    label = ctx.label
+    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+
+    # This file is used as part of the rules_apple bundling logic
+    archive = actions.declare_file(ctx.attr.name + ".framework")
+    predeclared_outputs = struct(archive = archive)
+
+    provisioning_profile = None
+    resource_deps = ctx.attr.data
+    rule_descriptor = rule_support.rule_descriptor(ctx)
+    signed_frameworks = []
+    if provisioning_profile:
+        signed_frameworks = [
+            bundle_name + rule_descriptor.bundle_extension,
+        ]
+    top_level_resources = resources.collect(
+        attr = ctx.attr,
+        res_attrs = ["data"],
+    )
+
+    extra_linkopts = [
+        "-dynamiclib",
+        "-Wl,-install_name,@rpath/{name}{extension}/{name}".format(
+            extension = bundle_extension,
+            name = bundle_name,
+        ),
+    ]
+
+    top_level_infoplists = resources.collect(
+        attr = ctx.attr,
+        res_attrs = ["infoplists"],
+    )
+    link_result = linking_support.register_linking_action(
+        ctx,
+        avoid_deps = avoid_deps,
+        entitlements = None,
+        extra_linkopts = extra_linkopts,
+        platform_prerequisites = platform_prerequisites,
+        stamp = ctx.attr.stamp,
+    )
+    binary_artifact = link_result.binary
+    debug_outputs_provider = link_result.debug_outputs_provider
+
+    archive_for_embedding = outputs.archive_for_embedding(
+        actions = actions,
+        bundle_name = bundle_name,
+        bundle_extension = bundle_extension,
+        executable_name = executable_name,
+        label_name = label.name,
+        rule_descriptor = rule_descriptor,
+        platform_prerequisites = platform_prerequisites,
+        predeclared_outputs = predeclared_outputs,
+    )
+
+    # TODO(jmarino) - consider how to better handle frameworks of frameworks
+    dep_frameworks = ctx.attr.frameworks
+    processor_partials = [
+        partials.apple_bundle_info_partial(
+            actions = actions,
+            bundle_extension = bundle_extension,
+            bundle_id = bundle_id,
+            bundle_name = bundle_name,
+            executable_name = executable_name,
+            label_name = label.name,
+            platform_prerequisites = platform_prerequisites,
+            predeclared_outputs = predeclared_outputs,
+            product_type = rule_descriptor.product_type,
+        ),
+        partials.binary_partial(
+            actions = actions,
+            binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
+            executable_name = executable_name,
+            label_name = label.name,
+        ),
+        partials.bitcode_symbols_partial(
+            actions = actions,
+            binary_artifact = binary_artifact,
+            debug_outputs_provider = debug_outputs_provider,
+            dependency_targets = dep_frameworks,
+            label_name = label.name,
+            platform_prerequisites = platform_prerequisites,
+        ),
+        partials.codesigning_dossier_partial(
+            actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
+            bundle_extension = bundle_extension,
+            bundle_location = processor.location.framework,
+            bundle_name = bundle_name,
+            embed_target_dossiers = False,
+            embedded_targets = dep_frameworks,
+            label_name = label.name,
+            platform_prerequisites = platform_prerequisites,
+            provisioning_profile = provisioning_profile,
+            rule_descriptor = rule_descriptor,
+        ),
+        partials.clang_rt_dylibs_partial(
+            actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
+            binary_artifact = binary_artifact,
+            features = features,
+            label_name = label.name,
+            platform_prerequisites = platform_prerequisites,
+        ),
+        partials.debug_symbols_partial(
+            actions = actions,
+            bin_root_path = bin_root_path,
+            bundle_extension = bundle_extension,
+            bundle_name = bundle_name,
+            debug_dependencies = dep_frameworks,
+            debug_outputs_provider = debug_outputs_provider,
+            dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
+            executable_name = executable_name,
+            platform_prerequisites = platform_prerequisites,
+            rule_label = label,
+        ),
+        partials.embedded_bundles_partial(
+            frameworks = [archive_for_embedding],
+            embeddable_targets = dep_frameworks,
+            platform_prerequisites = platform_prerequisites,
+            signed_frameworks = depset(signed_frameworks),
+        ),
+
+        # Don't bake the headers here - for distrobution mode, this is done with
+        # xcframework
+        partials.framework_provider_partial(
+            actions = actions,
+            bin_root_path = bin_root_path,
+            binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
+            bundle_only = False,
+            objc_provider = link_result.objc,
+            rule_label = label,
+        ),
+        partials.resources_partial(
+            actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
+            bundle_extension = bundle_extension,
+            bundle_id = bundle_id,
+            bundle_name = bundle_name,
+            environment_plist = ctx.file.environment_plist,
+            executable_name = executable_name,
+            launch_storyboard = None,
+            platform_prerequisites = platform_prerequisites,
+            resource_deps = resource_deps,
+            rule_descriptor = rule_descriptor,
+            rule_label = label,
+            targets_to_avoid = avoid_deps,
+            top_level_infoplists = top_level_infoplists,
+            top_level_resources = top_level_resources,
+            version = None,
+            version_keys_required = False,
+        ),
+        partials.swift_dylibs_partial(
+            actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
+            binary_artifact = binary_artifact,
+            dependency_targets = dep_frameworks,
+            label_name = label.name,
+            platform_prerequisites = platform_prerequisites,
+        ),
+        partials.apple_symbols_file_partial(
+            actions = actions,
+            binary_artifact = binary_artifact,
+            debug_outputs_provider = debug_outputs_provider,
+            dependency_targets = dep_frameworks,
+            label_name = label.name,
+            include_symbols_in_bundle = False,
+            platform_prerequisites = platform_prerequisites,
+        ),
+    ]
+
+    processor_result = processor.process(
+        actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
+        bundle_extension = bundle_extension,
+        bundle_name = bundle_name,
+        # TODO - consider adding this post_processor
+        # ipa_post_processor = ctx.executable.ipa_post_processor,
+        codesign_inputs = [],
+        codesignopts = [],
+        executable_name = executable_name,
+        features = features,
+        ipa_post_processor = None,
+        partials = processor_partials,
+        platform_prerequisites = platform_prerequisites,
+        predeclared_outputs = predeclared_outputs,
+        process_and_sign_template = apple_toolchain_info.process_and_sign_template,
+        provisioning_profile = provisioning_profile,
+        rule_descriptor = rule_descriptor,
+        rule_label = label,
+    )
+
+    return struct(
+        files = processor_result.output_files,
+        providers = [
+            IosFrameworkBundleInfo(),
+            OutputGroupInfo(
+                **outputs.merge_output_groups(
+                    link_result.output_groups,
+                    processor_result.output_groups,
+                )
+            ),
+        ] + processor_result.providers,
+    )
+
+def _bundle_static_framework(ctx, outputs):
+    """Returns bundle info for a static framework commonly used intra-build"""
+    infoplist = _merge_root_infoplists(ctx)
+
+    current_apple_platform = transition_support.current_apple_platform(apple_fragment = ctx.fragments.apple, xcode_config = ctx.attr._xcode_config)
+
+    # Static packaging - archives are passed from library deps
+    # Merges Info.plists and converts them into binary
+    return struct(files = depset([]), providers = [
+        AppleBundleInfo(
+            archive = None,
+            archive_root = None,
+            binary = outputs.binary[0] if outputs.binary else None,
+            bundle_id = ctx.attr.bundle_id,
+            bundle_name = ctx.attr.framework_name,
+            bundle_extension = ctx.attr.bundle_extension,
+            entitlements = None,
+            infoplist = infoplist,
+            minimum_os_version = str(current_apple_platform.target_os_version),
+            platform_type = str(current_apple_platform.platform.platform_type),
+            product_type = ctx.attr._product_type,
+            uses_swift = outputs.swiftmodule != None,
+        ),
+    ])
+
 def _apple_framework_packaging_impl(ctx):
     # The current build architecture
     arch = ctx.fragments.apple.single_arch_cpu
@@ -571,6 +827,21 @@ def _apple_framework_packaging_impl(ctx):
         dep_cc_infos = [dep[CcInfo] for dep in transitive_deps if CcInfo in dep]
         cc_info = cc_common.merge_cc_infos(direct_cc_infos = [cc_info_provider], cc_infos = dep_cc_infos)
 
+    # Propagate the avoid deps information upwards
+    avoid_deps = []
+    for dep in ctx.attr.transitive_deps:
+        if AvoidDepsInfo in dep:
+            avoid_deps.extend(dep[AvoidDepsInfo].libraries)
+            if dep[AvoidDepsInfo].link_dynamic:
+                avoid_deps.append(dep)
+
+    # If we link dynamic - then package it as dynamic
+    if ctx.attr.link_dynamic:
+        bundle_outs = _bundle_dynamic_framework(ctx, avoid_deps = avoid_deps)
+        avoid_deps_info = AvoidDepsInfo(libraries = depset(avoid_deps + ctx.attr.deps).to_list(), link_dynamic = True)
+    else:
+        bundle_outs = _bundle_static_framework(ctx, outputs = outputs)
+        avoid_deps_info = AvoidDepsInfo(libraries = depset(avoid_deps).to_list(), link_dynamic = False)
     swift_info = _get_merged_swift_info(ctx, framework_files, transitive_deps)
 
     # Build out the default info provider
@@ -580,38 +851,21 @@ def _apple_framework_packaging_impl(ctx):
     out_files.extend(outputs.headers)
     out_files.extend(outputs.private_headers)
     out_files.extend(outputs.modulemap)
-    default_info = DefaultInfo(files = depset(out_files))
+    default_info = DefaultInfo(files = depset(out_files + bundle_outs.files.to_list()))
 
-    # Merges Info.plists and converts them into binary
-    infoplist = _merge_root_infoplists(ctx)
-
-    current_apple_platform = transition_support.current_apple_platform(ctx.fragments.apple, ctx.attr._xcode_config)
     return [
+        avoid_deps_info,
         framework_info,
         _get_merged_objc_provider(ctx, deps, transitive_deps),
         cc_info,
         swift_info,
         default_info,
-        AppleBundleInfo(
-            archive = None,
-            archive_root = None,
-            binary = outputs.binary[0] if outputs.binary else None,
-            bundle_id = ctx.attr.bundle_id,
-            bundle_name = ctx.attr.framework_name,
-            bundle_extension = ctx.attr.bundle_extension,
-            entitlements = None,
-            infoplist = infoplist,
-            minimum_os_version = str(current_apple_platform.target_os_version),
-            platform_type = str(current_apple_platform.platform.platform_type),
-            product_type = ctx.attr._product_type,
-            uses_swift = outputs.swiftmodule != None,
-        ),
-    ]
+    ] + bundle_outs.providers
 
 apple_framework_packaging = rule(
     implementation = _apple_framework_packaging_impl,
     cfg = transition_support.apple_rule_transition,
-    fragments = ["apple"],
+    fragments = ["apple", "cpp", "objc"],
     output_to_genfiles = True,
     attrs = {
         "framework_name": attr.string(
@@ -625,6 +879,23 @@ apple_framework_packaging = rule(
             cfg = apple_common.multi_arch_split,
             doc =
                 """Objc or Swift rules to be packed by the framework rule
+""",
+        ),
+        "data": attr.label_list(
+            mandatory = False,
+            cfg = apple_common.multi_arch_split,
+            allow_files = True,
+            doc =
+                """Objc or Swift rules to be packed by the framework rule
+""",
+        ),
+        "link_dynamic": attr.bool(
+            mandatory = False,
+            default = False,
+            doc =
+                """Weather or not if this framework is dynamic
+
+The default behavior bakes this into the top level app. When false, it's statically linked.
 """,
         ),
         "vfs": attr.label_list(
@@ -673,12 +944,34 @@ Valid values are:
             ),
             executable = True,
         ),
+        "frameworks": attr.label_list(
+            providers = [[AppleBundleInfo, IosFrameworkBundleInfo]],
+            doc = """
+A list of framework targets (see
+[`ios_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-ios.md#ios_framework))
+that this target depends on.
+""",
+            cfg = apple_common.multi_arch_split,
+        ),
         "_headermap_builder": attr.label(
             executable = True,
             cfg = "host",
             default = Label(
                 "//rules/hmap:hmaptool",
             ),
+        ),
+        "stamp": attr.int(
+            mandatory = False,
+            default = 0,
+        ),
+        "exported_symbols_lists": attr.label_list(
+            allow_files = True,
+            doc = """
+            """,
+        ),
+        "_child_configuration_dummy": attr.label(
+            cfg = apple_common.multi_arch_split,
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
         ),
         "bundle_id": attr.string(
             mandatory = False,
@@ -697,10 +990,6 @@ If not given, the framework will be built for the platform it inherits from the 
 the framework as a dependency.""",
         ),
         "_product_type": attr.string(default = apple_product_type.static_framework),
-        # TODO: allow customizing binary type between dynamic/static
-        #         "binary_type": attr.string(
-        #             default = "dylib",
-        #         ),
         "_xcode_config": attr.label(
             default = configuration_field(
                 name = "xcode_config_label",
@@ -727,6 +1016,16 @@ the framework as a dependency.""",
             doc =
                 """Internal - currently rules_ios the dict `platforms`
 """,
+        ),
+        "minimum_deployment_os_version": attr.string(
+            mandatory = False,
+            doc = "The bundle identifier of the framework. Currently unused.",
+            default = "",
+        ),
+        "_xcode_path_wrapper": attr.label(
+            cfg = "exec",
+            executable = True,
+            default = Label("@build_bazel_apple_support//tools:xcode_path_wrapper"),
         ),
     },
     doc = "Packages compiled code into an Apple .framework package",

--- a/rules/import_middleman.bzl
+++ b/rules/import_middleman.bzl
@@ -53,14 +53,15 @@ def _add_to_dict_if_present(dict, key, value):
 
 def _make_imports(transitive_sets):
     provider_fields = {}
-    if transitive_sets:
-        provider_fields["framework_imports"] = depset(transitive = transitive_sets)
+    if len(transitive_sets):
+        provider_fields["framework_imports"] = depset(transitive_sets)
+
     provider_fields["build_archs"] = depset(["arm64"])
     provider_fields["debug_info_binaries"] = depset(transitive_sets)
 
     # TODO: consider passing along the dsyms
     provider_fields["dsym_imports"] = depset()
-    return AppleFrameworkImportInfo(**provider_fields)
+    return [AppleFrameworkImportInfo(**provider_fields)]
 
 def _find_imports_impl(target, ctx):
     static_framework_file = []
@@ -241,8 +242,7 @@ def _file_collector_rule_impl(ctx):
     return [
         DefaultInfo(files = depset(dynamic_framework_dirs + replaced_frameworks)),
         objc,
-        _make_imports([depset(dynamic_framework_dirs)]),
-    ]
+    ] + _make_imports(dynamic_framework_dirs)
 
 import_middleman = rule(
     implementation = _file_collector_rule_impl,

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -1019,6 +1019,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
         transitive_deps = deps,
         deps = lib_names + deps,
         module_name = module_name,
+        data = module_data,
         launch_screen_storyboard_name = launch_screen_storyboard_name,
         namespace = namespace,
         linkopts = copts_by_build_setting.linkopts + linkopts,

--- a/rules/providers.bzl
+++ b/rules/providers.bzl
@@ -9,3 +9,10 @@ FrameworkInfo = provider(
         "swiftdoc": " The Swift doc",
     },
 )
+
+AvoidDepsInfo = provider(
+    fields = {
+        "libraries": "Libraries to avoid",
+        "link_dynamic": "Weather or not if this dep is dynamic",
+    },
+)

--- a/tests/ios/frameworks/dynamic/App/main.swift
+++ b/tests/ios/frameworks/dynamic/App/main.swift
@@ -1,0 +1,1 @@
+import a

--- a/tests/ios/frameworks/dynamic/BUILD.bazel
+++ b/tests/ios/frameworks/dynamic/BUILD.bazel
@@ -1,0 +1,30 @@
+load("//rules:app.bzl", "ios_application")
+load("//rules:test.bzl", "ios_unit_test")
+
+ios_application(
+    name = "App",
+    srcs = ["App/main.swift"],
+    bundle_id = "com.example.app",
+
+    # FIXME: we still need this here because of infoplist merging
+    frameworks = [
+        "//tests/ios/frameworks/dynamic/a",
+        "//tests/ios/frameworks/dynamic/b",
+    ],
+    minimum_os_version = "10.0",
+    visibility = ["//visibility:public"],
+
+    # Internally the lib has a dep on a, so we need to pass the dep. Would be
+    # to pass that through the framework - it drops our providers though
+    deps = [
+        "//tests/ios/frameworks/dynamic/a",
+        "//tests/ios/frameworks/dynamic/b",
+    ],
+)
+
+ios_unit_test(
+    name = "TestAppWithDylibs",
+    srcs = ["empty_tests.m"],
+    minimum_os_version = "10.0",
+    test_host = ":App",
+)

--- a/tests/ios/frameworks/dynamic/a/BUILD.bazel
+++ b/tests/ios/frameworks/dynamic/a/BUILD.bazel
@@ -1,0 +1,11 @@
+load("//rules:framework.bzl", "apple_framework")
+
+apple_framework(
+    name = "a",
+    srcs = glob(["*.swift"]),
+    infoplists = ["Info.plist"],
+    link_dynamic = True,
+    platforms = {"ios": "10.0"},
+    visibility = ["//visibility:public"],
+    deps = ["//tests/ios/frameworks/dynamic/b"],
+)

--- a/tests/ios/frameworks/dynamic/a/Info.plist
+++ b/tests/ios/frameworks/dynamic/a/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>org.bazel.${PRODUCT_NAME:rfc1034identifier}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${BUNDLE_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+	<key>TargetName</key>
+	<string>${TARGET_NAME}</string>
+</dict>
+</plist>

--- a/tests/ios/frameworks/dynamic/a/lib.swift
+++ b/tests/ios/frameworks/dynamic/a/lib.swift
@@ -1,0 +1,6 @@
+import b
+
+struct A {
+    public static func run() { B.run() }
+    public static func NATURE_OF_A() { B.run() }
+}

--- a/tests/ios/frameworks/dynamic/b/BUILD.bazel
+++ b/tests/ios/frameworks/dynamic/b/BUILD.bazel
@@ -1,0 +1,13 @@
+load("//rules:framework.bzl", "apple_framework")
+
+apple_framework(
+    name = "b",
+    srcs = glob(["*.swift"]),
+    bundle_id = "foo.bar.bang",
+    data = ["b_data.txt"],
+    infoplists = ["Info.plist"],
+    link_dynamic = True,
+    platforms = {"ios": "10.0"},
+    visibility = ["//visibility:public"],
+    deps = ["//tests/ios/frameworks/dynamic/c"],
+)

--- a/tests/ios/frameworks/dynamic/b/Info.plist
+++ b/tests/ios/frameworks/dynamic/b/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+        <string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${BUNDLE_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+	<key>TargetName</key>
+	<string>${TARGET_NAME}</string>
+</dict>
+</plist>

--- a/tests/ios/frameworks/dynamic/b/lib.swift
+++ b/tests/ios/frameworks/dynamic/b/lib.swift
@@ -1,0 +1,6 @@
+import c
+
+public struct B {
+    public static func run() { C.run() }
+    public static func NATURE_OF_B() { B.run() }
+}

--- a/tests/ios/frameworks/dynamic/c/BUILD.bazel
+++ b/tests/ios/frameworks/dynamic/c/BUILD.bazel
@@ -1,0 +1,8 @@
+load("//rules:framework.bzl", "apple_framework")
+
+apple_framework(
+    name = "c",
+    srcs = glob(["*.swift"]),
+    platforms = {"ios": "10.0"},
+    visibility = ["//visibility:public"],
+)

--- a/tests/ios/frameworks/dynamic/c/lib.swift
+++ b/tests/ios/frameworks/dynamic/c/lib.swift
@@ -1,0 +1,4 @@
+public struct C {
+    public static func run() { print("runs here") }
+    public static func NATURE_OF_C() { C.run() }
+}

--- a/tests/ios/frameworks/dynamic/empty_tests.m
+++ b/tests/ios/frameworks/dynamic/empty_tests.m
@@ -1,0 +1,12 @@
+@import XCTest;
+
+@interface EmptyTests : XCTestCase
+
+@end
+
+@implementation EmptyTests
+
+- (void)test_infoplist_values {
+}
+
+@end


### PR DESCRIPTION
This PR adds the ability to easily link an `apple_framework` dynamically
and embed it into consumers with a single flag `link_dynamic`.

It also introduces a new provider to AvoidDeps. In dynamic linking, we
need to avoid linking deps that are in dep frameworks. This PR
propagates `AvoidDeps` upwards in the build graph to leverage in
linking. It currently uses `rules_apple` partials to help bundle: e.g.
handle resources, debug etc and interface with other bundling code.

Additionally, I have added a build test example that splits an app into
to 2 framework binaries, and resources are correctly paced.

```
app -> a.framework[dynamic] -> b.framework[dynamic] -> c
```

I considered using `ios_framework` but there were too many problems:
First it did't work with our plist rules. Then, it required me to add
more rules and macros, then replicate the framework structure to
consumers: a framework for `apple_framework` and a framework for
`ios_framework`, in `deps` and `frameworks`. That also doesn't integrate
well with custom plist rules. Additionally, I'd like to determine this
information at analysis time longer term - say auto-configure some
targets to `link_dynamic`. This becomes easier when it's determined in
the analysis phase. Finally, some `apple_frameworks` should always
`link_dynamic` - and this makes it easy to ensure that happens.