### PR TITLE
Fixes xcodeproj error when there is no direct targets

### DIFF
--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -354,7 +354,7 @@ def _xcodeproj_aspect_impl(target, ctx):
             ),
         )
 
-        infos = None
+        infos = []
         actual = None
         if ctx.rule.kind in ("test_suite"):
             actual = getattr(ctx.rule.attr, "tests")[0]


### PR DESCRIPTION
Uses empty list when there is no direct targets. We assume that _TargetInfo.direct_targets is not None on line 946.