### PR TITLE
[xcodeproj] support running UI test without debugger

### DIFF
--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -742,7 +742,11 @@ def _populate_xcodeproj_targets_and_schemes(ctx, targets, src_dot_dots, all_tran
         })
 
         # For UI tests, passing sources add Compile Sources Build Phase and having this build phase makes 'Check Dependencies' step fail with the error message "Target has its own product"
-        sources_for_target_name = compiled_sources + compiled_non_arc_sources + asset_sources if product_type != "bundle.ui-testing" else []
+        sources_for_target_name = compiled_sources + compiled_non_arc_sources + asset_sources
+        if product_type == "bundle.ui-testing":
+            for source in sources_for_target_name:
+                source["buildPhase"] = "none"
+
         xcodeproj_targets_by_name[target_name] = {
             "sources": sources_for_target_name,
             "type": product_type,

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -237,7 +237,7 @@ def _xcodeproj_aspect_impl(target, ctx):
         bundle_info = target[AppleBundleInfo]
         test_host_appname = None
         test_host_target = None
-        if ctx.rule.kind == "ios_unit_test":
+        if ctx.rule.kind == "ios_unit_test" or ctx.rule.kind == "ios_ui_test":
             # The following converts {"env_k1": "env_v1", "env_k2": "env_v2"}
             # to (("env_k1", "env_v1"), ("env_k2", "env_v2"))
             # for both "env vars" and "command line args"
@@ -722,7 +722,9 @@ def _populate_xcodeproj_targets_and_schemes(ctx, targets, src_dot_dots, all_tran
         test_host_appname = getattr(target_info, "test_host_appname", None)
         if test_host_appname:
             target_dependencies.append({"target": test_host_appname})
-            target_settings["TEST_HOST"] = "$(BUILT_PRODUCTS_DIR)/{test_host_appname}.app/{test_host_appname}".format(test_host_appname = test_host_appname)
+            if product_type != "bundle.ui-testing":
+                # TEST_HOST setting for UI tests cannot be set because TEST_HOST conflicts with USES_XCTRUNNER
+                target_settings["TEST_HOST"] = "$(BUILT_PRODUCTS_DIR)/{test_host_appname}.app/{test_host_appname}".format(test_host_appname = test_host_appname)
 
         if target_info.targeted_device_family:
             target_settings["TARGETED_DEVICE_FAMILY"] = target_info.targeted_device_family
@@ -739,8 +741,10 @@ def _populate_xcodeproj_targets_and_schemes(ctx, targets, src_dot_dots, all_tran
             "script": _BUILD_WITH_BAZEL_SCRIPT,
         })
 
+        # For UI tests, passing sources add Compile Sources Build Phase and having this build phase makes 'Check Dependencies' step fail with the error message "Target has its own product"
+        sources_for_target_name = compiled_sources + compiled_non_arc_sources + asset_sources if product_type != "bundle.ui-testing" else []
         xcodeproj_targets_by_name[target_name] = {
-            "sources": compiled_sources + compiled_non_arc_sources + asset_sources,
+            "sources": sources_for_target_name,
             "type": product_type,
             "platform": _PLATFORM_MAPPING[target_info.platform_type],
             "deploymentTarget": target_info.minimum_os_version,
@@ -795,11 +799,13 @@ def _populate_xcodeproj_targets_and_schemes(ctx, targets, src_dot_dots, all_tran
         build_target_to_scheme_info = {scheme_info.build_target: scheme_info for scheme_info in scheme_infos}
 
         # They will show as `TestableReference` under the scheme
-        if target_info.product_type == "bundle.unit-test":
+        if target_info.product_type == "bundle.unit-test" or target_info.product_type == "bundle.ui-testing":
             # All test targets will by default have a test action for themselves.
             xcodeproj_schemes_by_name[target_name]["test"] = {
                 "targets": [target_name],
                 "customLLDBInit": lldbinit_file,
+                # TODO : Attaching debugger for UI tests is failing mysteriously, so disable for now.
+                "debugEnabled": False if target_info.product_type == "bundle.ui-testing" else True,
             }
 
         elif target_name in build_target_to_scheme_info:

--- a/tests/ios/ui-test/BUILD.bazel
+++ b/tests/ios/ui-test/BUILD.bazel
@@ -16,4 +16,5 @@ ios_ui_test(
     ],
     minimum_os_version = "11.0",
     test_host = "//tests/ios/ui-test/test-app-host:TestAppHost",
+    visibility = ["//visibility:public"],
 )

--- a/tests/ios/xcodeproj/BUILD.bazel
+++ b/tests/ios/xcodeproj/BUILD.bazel
@@ -198,3 +198,13 @@ xcodeproj(
         "//tests/ios/app:FW",
     ],
 )
+
+xcodeproj(
+    name = "Test-UI-Test-Target",
+    testonly = True,
+    bazel_path = "bazelisk",
+    include_transitive_targets = True,
+    deps = [
+        "//tests/ios/ui-test:SimpleTest",
+    ],
+)

--- a/tools/xcodeproj_shims/install.sh
+++ b/tools/xcodeproj_shims/install.sh
@@ -37,6 +37,14 @@ com.apple.product-type.bundle.unit-test)
         "bazel-bin/$BAZEL_BIN_SUBDIR/${BAZEL_BUILD_TARGET_LABEL#*:}.runfiles/${BAZEL_BUILD_TARGET_WORKSPACE}/${BAZEL_BIN_SUBDIR}/$TARGET_NAME.zip"
     )
     ;;
+com.apple.product-type.bundle.ui-testing)
+    input_options=(
+        "bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}"
+        "bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}_archive-root/Payload/$TARGET_NAME${WRAPPER_SUFFIX:-}"
+        "bazel-bin/$BAZEL_BIN_SUBDIR/${BAZEL_BUILD_TARGET_LABEL#*:}.runfiles/${BAZEL_BUILD_TARGET_WORKSPACE}/${BAZEL_BIN_SUBDIR}/${FULL_PRODUCT_NAME}"
+        "bazel-bin/$BAZEL_BIN_SUBDIR/${BAZEL_BUILD_TARGET_LABEL#*:}.runfiles/${BAZEL_BUILD_TARGET_WORKSPACE}/${BAZEL_BIN_SUBDIR}/$TARGET_NAME.zip"
+    )
+    ;;
 com.apple.product-type.application)
     input_options=(
         "bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}"


### PR DESCRIPTION
**Background**
Issue : https://github.com/bazel-ios/rules_ios/issues/413
Running UI test from Xcode IDE is not currently supported. 

**Changes**
1. Install.sh -- Add case to install apps for UI test 
2. xcodeproj.bzl -- Add cases for UI test so that xcodegen generates the UI test target correctly. 
3. BUILD.bazel -- Make an example `xcodeproj` target for testing the UI test execution in Xcode IDE

**Test Plan**
1. `bazelisk run //tests/ios/xcodeproj:Test-UI-Test-Target` 
2.  `open tests/ios/xcodeproj/Test-UI-Test-Target.xcodeproj`
3. `⌘ + U` to run the test 

**Notes** 
1. Set the `sources` attribute for UI test target to `[]` because having source file results in Xcode's `check dependencies` step before running build script, and that fails with a weird error "This target might include its own product.". Removing the `Compile Sources` phase or removing the source files from the phase silences the error, but if other ways exist, I am down to try. 
2. Passed `debugEnabled=False` for UI test because otherwise executing the test fails with the error message "failed to attach to pid, check Console.app" and console.app didn't show any useful message. I believe the debuggable UI test execution can be addressed separately from this PR. But any help/advice is appreciated.   
