### PR TITLE
Set index-import parallel-stride to n CPUs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tests/ios/xcodeproj/**/xcuserdata
 **/*.xcodeproj/bazelinstallers/index-import
 /tests/ios/Index/
 /tests/macos/Index/
+/tests/index-import.pid

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -36,14 +36,25 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 # Uses all available cores for intel and a fraction of the performance cores on M1
 PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
-# M1s have more performance cores than efficiency so dividing by 2 here should take
+# M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
 if [[ $(arch) == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
+# Kill existing index-import process if it's running
+# in some cases this process is taking too much resources on the machine so
+# givin priority only to the latest run
+DERIVED_DATA="$BUILD_DIR"/../../..
+if [[ -f $DERIVED_DATA/index-import.pid ]]; then
+  PID=$(cat $DERIVED_DATA/index-import.pid)
+  if ps -p $PID > /dev/null; then
+    kill -10 $PID
+  fi
+fi
+
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $PARALLEL_STRIDE
+    -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \
@@ -53,4 +64,6 @@ $BAZEL_INSTALLERS_DIR/index-import \
     -remap "$bazel_root=$BAZEL_WORKSPACE_ROOT" \
     -remap "^([^//])=$BAZEL_WORKSPACE_ROOT/\$1" \
     "$@" \
-    "$BUILD_DIR"/../../Index/DataStore
+    "$BUILD_DIR"/../../Index/DataStore &
+
+echo $! > $DERIVED_DATA/index-import.pid

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -33,9 +33,17 @@ readonly xcode_external="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$SRCROOT")/exte
 readonly remote_developer_dir="^/.*/.+?\.app/Contents/Developer"
 readonly local_developer_dir="$DEVELOPER_DIR"
 
+# Uses all available cores for intel and a fraction of the performance cores on M1
+PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
+
+# M1s have more performance cores than efficiency so dividing by 2 here should take
+# a good percentage of the performance cores to do this work
+if [[ $(arch) == 'arm64' ]]; then
+  PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
+fi
 
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $(sysctl -n hw.physicalcpu)
+    -parallel-stride $PARALLEL_STRIDE
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -35,6 +35,7 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 
 
 $BAZEL_INSTALLERS_DIR/index-import \
+    -parallel-stride $(sysctl -n hw.physicalcpu)
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -38,7 +38,8 @@ PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
 # M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
-if [[ $(arch) == 'arm64' ]]; then
+ARCH=$(arch)
+if [[ $ARCH == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
@@ -49,9 +50,12 @@ DERIVED_DATA="$BUILD_DIR"/../../..
 if [[ -f $DERIVED_DATA/index-import.pid ]]; then
   PID=$(cat $DERIVED_DATA/index-import.pid)
   if ps -p $PID > /dev/null; then
+    echo "Killing index-import process before invoking it again"
     kill -10 $PID
   fi
 fi
+
+echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq`
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -11,7 +11,13 @@ FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVEN
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
 do
-  if [ -d $i ]
+  # Ensure 'units' and 'records' directories exist before calling index-import
+  # otherwise the process could be interrupet before all index stores are imported
+  #
+  # Still not clear why but I've found some instances where the 'records' folder wouldn't be present after a build
+  UNITS="$(find $i -type d -name 'units')"
+  RECORDS="$(find $i -type d -name 'records')"
+  if [ -d $i ] && [ "$UNITS" != "" ] && [ "$RECORDS" != "" ]
   then
     EXISTING_INDEXSTORES+=($i)
   fi

--- a/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -36,14 +36,25 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 # Uses all available cores for intel and a fraction of the performance cores on M1
 PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
-# M1s have more performance cores than efficiency so dividing by 2 here should take
+# M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
 if [[ $(arch) == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
+# Kill existing index-import process if it's running
+# in some cases this process is taking too much resources on the machine so
+# givin priority only to the latest run
+DERIVED_DATA="$BUILD_DIR"/../../..
+if [[ -f $DERIVED_DATA/index-import.pid ]]; then
+  PID=$(cat $DERIVED_DATA/index-import.pid)
+  if ps -p $PID > /dev/null; then
+    kill -10 $PID
+  fi
+fi
+
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $PARALLEL_STRIDE
+    -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \
@@ -53,4 +64,6 @@ $BAZEL_INSTALLERS_DIR/index-import \
     -remap "$bazel_root=$BAZEL_WORKSPACE_ROOT" \
     -remap "^([^//])=$BAZEL_WORKSPACE_ROOT/\$1" \
     "$@" \
-    "$BUILD_DIR"/../../Index/DataStore
+    "$BUILD_DIR"/../../Index/DataStore &
+
+echo $! > $DERIVED_DATA/index-import.pid

--- a/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -33,9 +33,17 @@ readonly xcode_external="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$SRCROOT")/exte
 readonly remote_developer_dir="^/.*/.+?\.app/Contents/Developer"
 readonly local_developer_dir="$DEVELOPER_DIR"
 
+# Uses all available cores for intel and a fraction of the performance cores on M1
+PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
+
+# M1s have more performance cores than efficiency so dividing by 2 here should take
+# a good percentage of the performance cores to do this work
+if [[ $(arch) == 'arm64' ]]; then
+  PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
+fi
 
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $(sysctl -n hw.physicalcpu)
+    -parallel-stride $PARALLEL_STRIDE
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -35,6 +35,7 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 
 
 $BAZEL_INSTALLERS_DIR/index-import \
+    -parallel-stride $(sysctl -n hw.physicalcpu)
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -38,7 +38,8 @@ PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
 # M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
-if [[ $(arch) == 'arm64' ]]; then
+ARCH=$(arch)
+if [[ $ARCH == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
@@ -49,9 +50,12 @@ DERIVED_DATA="$BUILD_DIR"/../../..
 if [[ -f $DERIVED_DATA/index-import.pid ]]; then
   PID=$(cat $DERIVED_DATA/index-import.pid)
   if ps -p $PID > /dev/null; then
+    echo "Killing index-import process before invoking it again"
     kill -10 $PID
   fi
 fi
+
+echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \

--- a/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq`
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -11,7 +11,13 @@ FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVEN
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
 do
-  if [ -d $i ]
+  # Ensure 'units' and 'records' directories exist before calling index-import
+  # otherwise the process could be interrupet before all index stores are imported
+  #
+  # Still not clear why but I've found some instances where the 'records' folder wouldn't be present after a build
+  UNITS="$(find $i -type d -name 'units')"
+  RECORDS="$(find $i -type d -name 'records')"
+  if [ -d $i ] && [ "$UNITS" != "" ] && [ "$RECORDS" != "" ]
   then
     EXISTING_INDEXSTORES+=($i)
   fi

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -36,14 +36,25 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 # Uses all available cores for intel and a fraction of the performance cores on M1
 PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
-# M1s have more performance cores than efficiency so dividing by 2 here should take
+# M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
 if [[ $(arch) == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
+# Kill existing index-import process if it's running
+# in some cases this process is taking too much resources on the machine so
+# givin priority only to the latest run
+DERIVED_DATA="$BUILD_DIR"/../../..
+if [[ -f $DERIVED_DATA/index-import.pid ]]; then
+  PID=$(cat $DERIVED_DATA/index-import.pid)
+  if ps -p $PID > /dev/null; then
+    kill -10 $PID
+  fi
+fi
+
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $PARALLEL_STRIDE
+    -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \
@@ -53,4 +64,6 @@ $BAZEL_INSTALLERS_DIR/index-import \
     -remap "$bazel_root=$BAZEL_WORKSPACE_ROOT" \
     -remap "^([^//])=$BAZEL_WORKSPACE_ROOT/\$1" \
     "$@" \
-    "$BUILD_DIR"/../../Index/DataStore
+    "$BUILD_DIR"/../../Index/DataStore &
+
+echo $! > $DERIVED_DATA/index-import.pid

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -33,9 +33,17 @@ readonly xcode_external="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$SRCROOT")/exte
 readonly remote_developer_dir="^/.*/.+?\.app/Contents/Developer"
 readonly local_developer_dir="$DEVELOPER_DIR"
 
+# Uses all available cores for intel and a fraction of the performance cores on M1
+PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
+
+# M1s have more performance cores than efficiency so dividing by 2 here should take
+# a good percentage of the performance cores to do this work
+if [[ $(arch) == 'arm64' ]]; then
+  PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
+fi
 
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $(sysctl -n hw.physicalcpu)
+    -parallel-stride $PARALLEL_STRIDE
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -35,6 +35,7 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 
 
 $BAZEL_INSTALLERS_DIR/index-import \
+    -parallel-stride $(sysctl -n hw.physicalcpu)
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -38,7 +38,8 @@ PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
 # M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
-if [[ $(arch) == 'arm64' ]]; then
+ARCH=$(arch)
+if [[ $ARCH == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
@@ -49,9 +50,12 @@ DERIVED_DATA="$BUILD_DIR"/../../..
 if [[ -f $DERIVED_DATA/index-import.pid ]]; then
   PID=$(cat $DERIVED_DATA/index-import.pid)
   if ps -p $PID > /dev/null; then
+    echo "Killing index-import process before invoking it again"
     kill -10 $PID
   fi
 fi
+
+echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq`
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -11,7 +11,13 @@ FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVEN
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
 do
-  if [ -d $i ]
+  # Ensure 'units' and 'records' directories exist before calling index-import
+  # otherwise the process could be interrupet before all index stores are imported
+  #
+  # Still not clear why but I've found some instances where the 'records' folder wouldn't be present after a build
+  UNITS="$(find $i -type d -name 'units')"
+  RECORDS="$(find $i -type d -name 'records')"
+  if [ -d $i ] && [ "$UNITS" != "" ] && [ "$RECORDS" != "" ]
   then
     EXISTING_INDEXSTORES+=($i)
   fi

--- a/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -36,14 +36,25 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 # Uses all available cores for intel and a fraction of the performance cores on M1
 PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
-# M1s have more performance cores than efficiency so dividing by 2 here should take
+# M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
 if [[ $(arch) == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
+# Kill existing index-import process if it's running
+# in some cases this process is taking too much resources on the machine so
+# givin priority only to the latest run
+DERIVED_DATA="$BUILD_DIR"/../../..
+if [[ -f $DERIVED_DATA/index-import.pid ]]; then
+  PID=$(cat $DERIVED_DATA/index-import.pid)
+  if ps -p $PID > /dev/null; then
+    kill -10 $PID
+  fi
+fi
+
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $PARALLEL_STRIDE
+    -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \
@@ -53,4 +64,6 @@ $BAZEL_INSTALLERS_DIR/index-import \
     -remap "$bazel_root=$BAZEL_WORKSPACE_ROOT" \
     -remap "^([^//])=$BAZEL_WORKSPACE_ROOT/\$1" \
     "$@" \
-    "$BUILD_DIR"/../../Index/DataStore
+    "$BUILD_DIR"/../../Index/DataStore &
+
+echo $! > $DERIVED_DATA/index-import.pid

--- a/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -33,9 +33,17 @@ readonly xcode_external="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$SRCROOT")/exte
 readonly remote_developer_dir="^/.*/.+?\.app/Contents/Developer"
 readonly local_developer_dir="$DEVELOPER_DIR"
 
+# Uses all available cores for intel and a fraction of the performance cores on M1
+PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
+
+# M1s have more performance cores than efficiency so dividing by 2 here should take
+# a good percentage of the performance cores to do this work
+if [[ $(arch) == 'arm64' ]]; then
+  PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
+fi
 
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $(sysctl -n hw.physicalcpu)
+    -parallel-stride $PARALLEL_STRIDE
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -35,6 +35,7 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 
 
 $BAZEL_INSTALLERS_DIR/index-import \
+    -parallel-stride $(sysctl -n hw.physicalcpu)
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -38,7 +38,8 @@ PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
 # M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
-if [[ $(arch) == 'arm64' ]]; then
+ARCH=$(arch)
+if [[ $ARCH == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
@@ -49,9 +50,12 @@ DERIVED_DATA="$BUILD_DIR"/../../..
 if [[ -f $DERIVED_DATA/index-import.pid ]]; then
   PID=$(cat $DERIVED_DATA/index-import.pid)
   if ps -p $PID > /dev/null; then
+    echo "Killing index-import process before invoking it again"
     kill -10 $PID
   fi
 fi
+
+echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \

--- a/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq`
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -11,7 +11,13 @@ FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVEN
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
 do
-  if [ -d $i ]
+  # Ensure 'units' and 'records' directories exist before calling index-import
+  # otherwise the process could be interrupet before all index stores are imported
+  #
+  # Still not clear why but I've found some instances where the 'records' folder wouldn't be present after a build
+  UNITS="$(find $i -type d -name 'units')"
+  RECORDS="$(find $i -type d -name 'records')"
+  if [ -d $i ] && [ "$UNITS" != "" ] && [ "$RECORDS" != "" ]
   then
     EXISTING_INDEXSTORES+=($i)
   fi

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/_indexstore.sh
@@ -36,14 +36,25 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 # Uses all available cores for intel and a fraction of the performance cores on M1
 PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
-# M1s have more performance cores than efficiency so dividing by 2 here should take
+# M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
 if [[ $(arch) == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
+# Kill existing index-import process if it's running
+# in some cases this process is taking too much resources on the machine so
+# givin priority only to the latest run
+DERIVED_DATA="$BUILD_DIR"/../../..
+if [[ -f $DERIVED_DATA/index-import.pid ]]; then
+  PID=$(cat $DERIVED_DATA/index-import.pid)
+  if ps -p $PID > /dev/null; then
+    kill -10 $PID
+  fi
+fi
+
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $PARALLEL_STRIDE
+    -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \
@@ -53,4 +64,6 @@ $BAZEL_INSTALLERS_DIR/index-import \
     -remap "$bazel_root=$BAZEL_WORKSPACE_ROOT" \
     -remap "^([^//])=$BAZEL_WORKSPACE_ROOT/\$1" \
     "$@" \
-    "$BUILD_DIR"/../../Index/DataStore
+    "$BUILD_DIR"/../../Index/DataStore &
+
+echo $! > $DERIVED_DATA/index-import.pid

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/_indexstore.sh
@@ -33,9 +33,17 @@ readonly xcode_external="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$SRCROOT")/exte
 readonly remote_developer_dir="^/.*/.+?\.app/Contents/Developer"
 readonly local_developer_dir="$DEVELOPER_DIR"
 
+# Uses all available cores for intel and a fraction of the performance cores on M1
+PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
+
+# M1s have more performance cores than efficiency so dividing by 2 here should take
+# a good percentage of the performance cores to do this work
+if [[ $(arch) == 'arm64' ]]; then
+  PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
+fi
 
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $(sysctl -n hw.physicalcpu)
+    -parallel-stride $PARALLEL_STRIDE
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/_indexstore.sh
@@ -35,6 +35,7 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 
 
 $BAZEL_INSTALLERS_DIR/index-import \
+    -parallel-stride $(sysctl -n hw.physicalcpu)
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/_indexstore.sh
@@ -38,7 +38,8 @@ PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
 # M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
-if [[ $(arch) == 'arm64' ]]; then
+ARCH=$(arch)
+if [[ $ARCH == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
@@ -49,9 +50,12 @@ DERIVED_DATA="$BUILD_DIR"/../../..
 if [[ -f $DERIVED_DATA/index-import.pid ]]; then
   PID=$(cat $DERIVED_DATA/index-import.pid)
   if ps -p $PID > /dev/null; then
+    echo "Killing index-import process before invoking it again"
     kill -10 $PID
   fi
 fi
+
+echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq`
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/indexstores.sh
@@ -11,7 +11,13 @@ FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVEN
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
 do
-  if [ -d $i ]
+  # Ensure 'units' and 'records' directories exist before calling index-import
+  # otherwise the process could be interrupet before all index stores are imported
+  #
+  # Still not clear why but I've found some instances where the 'records' folder wouldn't be present after a build
+  UNITS="$(find $i -type d -name 'units')"
+  RECORDS="$(find $i -type d -name 'records')"
+  if [ -d $i ] && [ "$UNITS" != "" ] && [ "$RECORDS" != "" ]
   then
     EXISTING_INDEXSTORES+=($i)
   fi

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -36,14 +36,25 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 # Uses all available cores for intel and a fraction of the performance cores on M1
 PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
-# M1s have more performance cores than efficiency so dividing by 2 here should take
+# M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
 if [[ $(arch) == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
+# Kill existing index-import process if it's running
+# in some cases this process is taking too much resources on the machine so
+# givin priority only to the latest run
+DERIVED_DATA="$BUILD_DIR"/../../..
+if [[ -f $DERIVED_DATA/index-import.pid ]]; then
+  PID=$(cat $DERIVED_DATA/index-import.pid)
+  if ps -p $PID > /dev/null; then
+    kill -10 $PID
+  fi
+fi
+
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $PARALLEL_STRIDE
+    -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \
@@ -53,4 +64,6 @@ $BAZEL_INSTALLERS_DIR/index-import \
     -remap "$bazel_root=$BAZEL_WORKSPACE_ROOT" \
     -remap "^([^//])=$BAZEL_WORKSPACE_ROOT/\$1" \
     "$@" \
-    "$BUILD_DIR"/../../Index/DataStore
+    "$BUILD_DIR"/../../Index/DataStore &
+
+echo $! > $DERIVED_DATA/index-import.pid

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -33,9 +33,17 @@ readonly xcode_external="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$SRCROOT")/exte
 readonly remote_developer_dir="^/.*/.+?\.app/Contents/Developer"
 readonly local_developer_dir="$DEVELOPER_DIR"
 
+# Uses all available cores for intel and a fraction of the performance cores on M1
+PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
+
+# M1s have more performance cores than efficiency so dividing by 2 here should take
+# a good percentage of the performance cores to do this work
+if [[ $(arch) == 'arm64' ]]; then
+  PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
+fi
 
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $(sysctl -n hw.physicalcpu)
+    -parallel-stride $PARALLEL_STRIDE
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -35,6 +35,7 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 
 
 $BAZEL_INSTALLERS_DIR/index-import \
+    -parallel-stride $(sysctl -n hw.physicalcpu)
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -38,7 +38,8 @@ PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
 # M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
-if [[ $(arch) == 'arm64' ]]; then
+ARCH=$(arch)
+if [[ $ARCH == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
@@ -49,9 +50,12 @@ DERIVED_DATA="$BUILD_DIR"/../../..
 if [[ -f $DERIVED_DATA/index-import.pid ]]; then
   PID=$(cat $DERIVED_DATA/index-import.pid)
   if ps -p $PID > /dev/null; then
+    echo "Killing index-import process before invoking it again"
     kill -10 $PID
   fi
 fi
+
+echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq`
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -11,7 +11,13 @@ FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVEN
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
 do
-  if [ -d $i ]
+  # Ensure 'units' and 'records' directories exist before calling index-import
+  # otherwise the process could be interrupet before all index stores are imported
+  #
+  # Still not clear why but I've found some instances where the 'records' folder wouldn't be present after a build
+  UNITS="$(find $i -type d -name 'units')"
+  RECORDS="$(find $i -type d -name 'records')"
+  if [ -d $i ] && [ "$UNITS" != "" ] && [ "$RECORDS" != "" ]
   then
     EXISTING_INDEXSTORES+=($i)
   fi

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/_indexstore.sh
@@ -36,14 +36,25 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 # Uses all available cores for intel and a fraction of the performance cores on M1
 PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
-# M1s have more performance cores than efficiency so dividing by 2 here should take
+# M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
 if [[ $(arch) == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
+# Kill existing index-import process if it's running
+# in some cases this process is taking too much resources on the machine so
+# givin priority only to the latest run
+DERIVED_DATA="$BUILD_DIR"/../../..
+if [[ -f $DERIVED_DATA/index-import.pid ]]; then
+  PID=$(cat $DERIVED_DATA/index-import.pid)
+  if ps -p $PID > /dev/null; then
+    kill -10 $PID
+  fi
+fi
+
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $PARALLEL_STRIDE
+    -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \
@@ -53,4 +64,6 @@ $BAZEL_INSTALLERS_DIR/index-import \
     -remap "$bazel_root=$BAZEL_WORKSPACE_ROOT" \
     -remap "^([^//])=$BAZEL_WORKSPACE_ROOT/\$1" \
     "$@" \
-    "$BUILD_DIR"/../../Index/DataStore
+    "$BUILD_DIR"/../../Index/DataStore &
+
+echo $! > $DERIVED_DATA/index-import.pid

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/_indexstore.sh
@@ -33,9 +33,17 @@ readonly xcode_external="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$SRCROOT")/exte
 readonly remote_developer_dir="^/.*/.+?\.app/Contents/Developer"
 readonly local_developer_dir="$DEVELOPER_DIR"
 
+# Uses all available cores for intel and a fraction of the performance cores on M1
+PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
+
+# M1s have more performance cores than efficiency so dividing by 2 here should take
+# a good percentage of the performance cores to do this work
+if [[ $(arch) == 'arm64' ]]; then
+  PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
+fi
 
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $(sysctl -n hw.physicalcpu)
+    -parallel-stride $PARALLEL_STRIDE
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/_indexstore.sh
@@ -35,6 +35,7 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 
 
 $BAZEL_INSTALLERS_DIR/index-import \
+    -parallel-stride $(sysctl -n hw.physicalcpu)
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/_indexstore.sh
@@ -38,7 +38,8 @@ PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
 # M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
-if [[ $(arch) == 'arm64' ]]; then
+ARCH=$(arch)
+if [[ $ARCH == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
@@ -49,9 +50,12 @@ DERIVED_DATA="$BUILD_DIR"/../../..
 if [[ -f $DERIVED_DATA/index-import.pid ]]; then
   PID=$(cat $DERIVED_DATA/index-import.pid)
   if ps -p $PID > /dev/null; then
+    echo "Killing index-import process before invoking it again"
     kill -10 $PID
   fi
 fi
+
+echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq`
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/indexstores.sh
@@ -11,7 +11,13 @@ FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVEN
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
 do
-  if [ -d $i ]
+  # Ensure 'units' and 'records' directories exist before calling index-import
+  # otherwise the process could be interrupet before all index stores are imported
+  #
+  # Still not clear why but I've found some instances where the 'records' folder wouldn't be present after a build
+  UNITS="$(find $i -type d -name 'units')"
+  RECORDS="$(find $i -type d -name 'records')"
+  if [ -d $i ] && [ "$UNITS" != "" ] && [ "$RECORDS" != "" ]
   then
     EXISTING_INDEXSTORES+=($i)
   fi

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/_indexstore.sh
@@ -36,14 +36,25 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 # Uses all available cores for intel and a fraction of the performance cores on M1
 PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
-# M1s have more performance cores than efficiency so dividing by 2 here should take
+# M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
 if [[ $(arch) == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
+# Kill existing index-import process if it's running
+# in some cases this process is taking too much resources on the machine so
+# givin priority only to the latest run
+DERIVED_DATA="$BUILD_DIR"/../../..
+if [[ -f $DERIVED_DATA/index-import.pid ]]; then
+  PID=$(cat $DERIVED_DATA/index-import.pid)
+  if ps -p $PID > /dev/null; then
+    kill -10 $PID
+  fi
+fi
+
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $PARALLEL_STRIDE
+    -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \
@@ -53,4 +64,6 @@ $BAZEL_INSTALLERS_DIR/index-import \
     -remap "$bazel_root=$BAZEL_WORKSPACE_ROOT" \
     -remap "^([^//])=$BAZEL_WORKSPACE_ROOT/\$1" \
     "$@" \
-    "$BUILD_DIR"/../../Index/DataStore
+    "$BUILD_DIR"/../../Index/DataStore &
+
+echo $! > $DERIVED_DATA/index-import.pid

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/_indexstore.sh
@@ -33,9 +33,17 @@ readonly xcode_external="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$SRCROOT")/exte
 readonly remote_developer_dir="^/.*/.+?\.app/Contents/Developer"
 readonly local_developer_dir="$DEVELOPER_DIR"
 
+# Uses all available cores for intel and a fraction of the performance cores on M1
+PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
+
+# M1s have more performance cores than efficiency so dividing by 2 here should take
+# a good percentage of the performance cores to do this work
+if [[ $(arch) == 'arm64' ]]; then
+  PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
+fi
 
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $(sysctl -n hw.physicalcpu)
+    -parallel-stride $PARALLEL_STRIDE
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/_indexstore.sh
@@ -35,6 +35,7 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 
 
 $BAZEL_INSTALLERS_DIR/index-import \
+    -parallel-stride $(sysctl -n hw.physicalcpu)
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/_indexstore.sh
@@ -38,7 +38,8 @@ PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
 # M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
-if [[ $(arch) == 'arm64' ]]; then
+ARCH=$(arch)
+if [[ $ARCH == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
@@ -49,9 +50,12 @@ DERIVED_DATA="$BUILD_DIR"/../../..
 if [[ -f $DERIVED_DATA/index-import.pid ]]; then
   PID=$(cat $DERIVED_DATA/index-import.pid)
   if ps -p $PID > /dev/null; then
+    echo "Killing index-import process before invoking it again"
     kill -10 $PID
   fi
 fi
+
+echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq`
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/indexstores.sh
@@ -11,7 +11,13 @@ FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVEN
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
 do
-  if [ -d $i ]
+  # Ensure 'units' and 'records' directories exist before calling index-import
+  # otherwise the process could be interrupet before all index stores are imported
+  #
+  # Still not clear why but I've found some instances where the 'records' folder wouldn't be present after a build
+  UNITS="$(find $i -type d -name 'units')"
+  RECORDS="$(find $i -type d -name 'records')"
+  if [ -d $i ] && [ "$UNITS" != "" ] && [ "$RECORDS" != "" ]
   then
     EXISTING_INDEXSTORES+=($i)
   fi

--- a/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -36,14 +36,25 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 # Uses all available cores for intel and a fraction of the performance cores on M1
 PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
-# M1s have more performance cores than efficiency so dividing by 2 here should take
+# M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
 if [[ $(arch) == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
+# Kill existing index-import process if it's running
+# in some cases this process is taking too much resources on the machine so
+# givin priority only to the latest run
+DERIVED_DATA="$BUILD_DIR"/../../..
+if [[ -f $DERIVED_DATA/index-import.pid ]]; then
+  PID=$(cat $DERIVED_DATA/index-import.pid)
+  if ps -p $PID > /dev/null; then
+    kill -10 $PID
+  fi
+fi
+
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $PARALLEL_STRIDE
+    -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \
@@ -53,4 +64,6 @@ $BAZEL_INSTALLERS_DIR/index-import \
     -remap "$bazel_root=$BAZEL_WORKSPACE_ROOT" \
     -remap "^([^//])=$BAZEL_WORKSPACE_ROOT/\$1" \
     "$@" \
-    "$BUILD_DIR"/../../Index/DataStore
+    "$BUILD_DIR"/../../Index/DataStore &
+
+echo $! > $DERIVED_DATA/index-import.pid

--- a/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -33,9 +33,17 @@ readonly xcode_external="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$SRCROOT")/exte
 readonly remote_developer_dir="^/.*/.+?\.app/Contents/Developer"
 readonly local_developer_dir="$DEVELOPER_DIR"
 
+# Uses all available cores for intel and a fraction of the performance cores on M1
+PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
+
+# M1s have more performance cores than efficiency so dividing by 2 here should take
+# a good percentage of the performance cores to do this work
+if [[ $(arch) == 'arm64' ]]; then
+  PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
+fi
 
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $(sysctl -n hw.physicalcpu)
+    -parallel-stride $PARALLEL_STRIDE
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -35,6 +35,7 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 
 
 $BAZEL_INSTALLERS_DIR/index-import \
+    -parallel-stride $(sysctl -n hw.physicalcpu)
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -38,7 +38,8 @@ PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
 # M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
-if [[ $(arch) == 'arm64' ]]; then
+ARCH=$(arch)
+if [[ $ARCH == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
@@ -49,9 +50,12 @@ DERIVED_DATA="$BUILD_DIR"/../../..
 if [[ -f $DERIVED_DATA/index-import.pid ]]; then
   PID=$(cat $DERIVED_DATA/index-import.pid)
   if ps -p $PID > /dev/null; then
+    echo "Killing index-import process before invoking it again"
     kill -10 $PID
   fi
 fi
+
+echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \

--- a/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq`
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -11,7 +11,13 @@ FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVEN
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
 do
-  if [ -d $i ]
+  # Ensure 'units' and 'records' directories exist before calling index-import
+  # otherwise the process could be interrupet before all index stores are imported
+  #
+  # Still not clear why but I've found some instances where the 'records' folder wouldn't be present after a build
+  UNITS="$(find $i -type d -name 'units')"
+  RECORDS="$(find $i -type d -name 'records')"
+  if [ -d $i ] && [ "$UNITS" != "" ] && [ "$RECORDS" != "" ]
   then
     EXISTING_INDEXSTORES+=($i)
   fi

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/_indexstore.sh
@@ -36,14 +36,25 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 # Uses all available cores for intel and a fraction of the performance cores on M1
 PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
-# M1s have more performance cores than efficiency so dividing by 2 here should take
+# M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
 if [[ $(arch) == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
+# Kill existing index-import process if it's running
+# in some cases this process is taking too much resources on the machine so
+# givin priority only to the latest run
+DERIVED_DATA="$BUILD_DIR"/../../..
+if [[ -f $DERIVED_DATA/index-import.pid ]]; then
+  PID=$(cat $DERIVED_DATA/index-import.pid)
+  if ps -p $PID > /dev/null; then
+    kill -10 $PID
+  fi
+fi
+
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $PARALLEL_STRIDE
+    -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \
@@ -53,4 +64,6 @@ $BAZEL_INSTALLERS_DIR/index-import \
     -remap "$bazel_root=$BAZEL_WORKSPACE_ROOT" \
     -remap "^([^//])=$BAZEL_WORKSPACE_ROOT/\$1" \
     "$@" \
-    "$BUILD_DIR"/../../Index/DataStore
+    "$BUILD_DIR"/../../Index/DataStore &
+
+echo $! > $DERIVED_DATA/index-import.pid

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/_indexstore.sh
@@ -33,9 +33,17 @@ readonly xcode_external="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$SRCROOT")/exte
 readonly remote_developer_dir="^/.*/.+?\.app/Contents/Developer"
 readonly local_developer_dir="$DEVELOPER_DIR"
 
+# Uses all available cores for intel and a fraction of the performance cores on M1
+PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
+
+# M1s have more performance cores than efficiency so dividing by 2 here should take
+# a good percentage of the performance cores to do this work
+if [[ $(arch) == 'arm64' ]]; then
+  PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
+fi
 
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $(sysctl -n hw.physicalcpu)
+    -parallel-stride $PARALLEL_STRIDE
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/_indexstore.sh
@@ -35,6 +35,7 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 
 
 $BAZEL_INSTALLERS_DIR/index-import \
+    -parallel-stride $(sysctl -n hw.physicalcpu)
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/_indexstore.sh
@@ -38,7 +38,8 @@ PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
 # M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
-if [[ $(arch) == 'arm64' ]]; then
+ARCH=$(arch)
+if [[ $ARCH == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
@@ -49,9 +50,12 @@ DERIVED_DATA="$BUILD_DIR"/../../..
 if [[ -f $DERIVED_DATA/index-import.pid ]]; then
   PID=$(cat $DERIVED_DATA/index-import.pid)
   if ps -p $PID > /dev/null; then
+    echo "Killing index-import process before invoking it again"
     kill -10 $PID
   fi
 fi
+
+echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq`
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/indexstores.sh
@@ -11,7 +11,13 @@ FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVEN
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
 do
-  if [ -d $i ]
+  # Ensure 'units' and 'records' directories exist before calling index-import
+  # otherwise the process could be interrupet before all index stores are imported
+  #
+  # Still not clear why but I've found some instances where the 'records' folder wouldn't be present after a build
+  UNITS="$(find $i -type d -name 'units')"
+  RECORDS="$(find $i -type d -name 'records')"
+  if [ -d $i ] && [ "$UNITS" != "" ] && [ "$RECORDS" != "" ]
   then
     EXISTING_INDEXSTORES+=($i)
   fi

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/_indexstore.sh
@@ -36,14 +36,25 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 # Uses all available cores for intel and a fraction of the performance cores on M1
 PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
-# M1s have more performance cores than efficiency so dividing by 2 here should take
+# M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
 if [[ $(arch) == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
+# Kill existing index-import process if it's running
+# in some cases this process is taking too much resources on the machine so
+# givin priority only to the latest run
+DERIVED_DATA="$BUILD_DIR"/../../..
+if [[ -f $DERIVED_DATA/index-import.pid ]]; then
+  PID=$(cat $DERIVED_DATA/index-import.pid)
+  if ps -p $PID > /dev/null; then
+    kill -10 $PID
+  fi
+fi
+
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $PARALLEL_STRIDE
+    -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \
@@ -53,4 +64,6 @@ $BAZEL_INSTALLERS_DIR/index-import \
     -remap "$bazel_root=$BAZEL_WORKSPACE_ROOT" \
     -remap "^([^//])=$BAZEL_WORKSPACE_ROOT/\$1" \
     "$@" \
-    "$BUILD_DIR"/../../Index/DataStore
+    "$BUILD_DIR"/../../Index/DataStore &
+
+echo $! > $DERIVED_DATA/index-import.pid

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/_indexstore.sh
@@ -33,9 +33,17 @@ readonly xcode_external="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$SRCROOT")/exte
 readonly remote_developer_dir="^/.*/.+?\.app/Contents/Developer"
 readonly local_developer_dir="$DEVELOPER_DIR"
 
+# Uses all available cores for intel and a fraction of the performance cores on M1
+PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
+
+# M1s have more performance cores than efficiency so dividing by 2 here should take
+# a good percentage of the performance cores to do this work
+if [[ $(arch) == 'arm64' ]]; then
+  PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
+fi
 
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $(sysctl -n hw.physicalcpu)
+    -parallel-stride $PARALLEL_STRIDE
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/_indexstore.sh
@@ -35,6 +35,7 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 
 
 $BAZEL_INSTALLERS_DIR/index-import \
+    -parallel-stride $(sysctl -n hw.physicalcpu)
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/_indexstore.sh
@@ -38,7 +38,8 @@ PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
 # M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
-if [[ $(arch) == 'arm64' ]]; then
+ARCH=$(arch)
+if [[ $ARCH == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
@@ -49,9 +50,12 @@ DERIVED_DATA="$BUILD_DIR"/../../..
 if [[ -f $DERIVED_DATA/index-import.pid ]]; then
   PID=$(cat $DERIVED_DATA/index-import.pid)
   if ps -p $PID > /dev/null; then
+    echo "Killing index-import process before invoking it again"
     kill -10 $PID
   fi
 fi
+
+echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq`
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/indexstores.sh
@@ -11,7 +11,13 @@ FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVEN
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
 do
-  if [ -d $i ]
+  # Ensure 'units' and 'records' directories exist before calling index-import
+  # otherwise the process could be interrupet before all index stores are imported
+  #
+  # Still not clear why but I've found some instances where the 'records' folder wouldn't be present after a build
+  UNITS="$(find $i -type d -name 'units')"
+  RECORDS="$(find $i -type d -name 'records')"
+  if [ -d $i ] && [ "$UNITS" != "" ] && [ "$RECORDS" != "" ]
   then
     EXISTING_INDEXSTORES+=($i)
   fi

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -36,14 +36,25 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 # Uses all available cores for intel and a fraction of the performance cores on M1
 PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
-# M1s have more performance cores than efficiency so dividing by 2 here should take
+# M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
 if [[ $(arch) == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
+# Kill existing index-import process if it's running
+# in some cases this process is taking too much resources on the machine so
+# givin priority only to the latest run
+DERIVED_DATA="$BUILD_DIR"/../../..
+if [[ -f $DERIVED_DATA/index-import.pid ]]; then
+  PID=$(cat $DERIVED_DATA/index-import.pid)
+  if ps -p $PID > /dev/null; then
+    kill -10 $PID
+  fi
+fi
+
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $PARALLEL_STRIDE
+    -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \
@@ -53,4 +64,6 @@ $BAZEL_INSTALLERS_DIR/index-import \
     -remap "$bazel_root=$BAZEL_WORKSPACE_ROOT" \
     -remap "^([^//])=$BAZEL_WORKSPACE_ROOT/\$1" \
     "$@" \
-    "$BUILD_DIR"/../../Index/DataStore
+    "$BUILD_DIR"/../../Index/DataStore &
+
+echo $! > $DERIVED_DATA/index-import.pid

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -33,9 +33,17 @@ readonly xcode_external="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$SRCROOT")/exte
 readonly remote_developer_dir="^/.*/.+?\.app/Contents/Developer"
 readonly local_developer_dir="$DEVELOPER_DIR"
 
+# Uses all available cores for intel and a fraction of the performance cores on M1
+PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
+
+# M1s have more performance cores than efficiency so dividing by 2 here should take
+# a good percentage of the performance cores to do this work
+if [[ $(arch) == 'arm64' ]]; then
+  PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
+fi
 
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $(sysctl -n hw.physicalcpu)
+    -parallel-stride $PARALLEL_STRIDE
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -35,6 +35,7 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 
 
 $BAZEL_INSTALLERS_DIR/index-import \
+    -parallel-stride $(sysctl -n hw.physicalcpu)
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -38,7 +38,8 @@ PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
 # M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
-if [[ $(arch) == 'arm64' ]]; then
+ARCH=$(arch)
+if [[ $ARCH == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
@@ -49,9 +50,12 @@ DERIVED_DATA="$BUILD_DIR"/../../..
 if [[ -f $DERIVED_DATA/index-import.pid ]]; then
   PID=$(cat $DERIVED_DATA/index-import.pid)
   if ps -p $PID > /dev/null; then
+    echo "Killing index-import process before invoking it again"
     kill -10 $PID
   fi
 fi
+
+echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq`
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -11,7 +11,13 @@ FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVEN
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
 do
-  if [ -d $i ]
+  # Ensure 'units' and 'records' directories exist before calling index-import
+  # otherwise the process could be interrupet before all index stores are imported
+  #
+  # Still not clear why but I've found some instances where the 'records' folder wouldn't be present after a build
+  UNITS="$(find $i -type d -name 'units')"
+  RECORDS="$(find $i -type d -name 'records')"
+  if [ -d $i ] && [ "$UNITS" != "" ] && [ "$RECORDS" != "" ]
   then
     EXISTING_INDEXSTORES+=($i)
   fi

--- a/tools/xcodeproj_shims/installers/_indexstore.sh
+++ b/tools/xcodeproj_shims/installers/_indexstore.sh
@@ -36,14 +36,25 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 # Uses all available cores for intel and a fraction of the performance cores on M1
 PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
-# M1s have more performance cores than efficiency so dividing by 2 here should take
+# M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
 if [[ $(arch) == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
+# Kill existing index-import process if it's running
+# in some cases this process is taking too much resources on the machine so
+# givin priority only to the latest run
+DERIVED_DATA="$BUILD_DIR"/../../..
+if [[ -f $DERIVED_DATA/index-import.pid ]]; then
+  PID=$(cat $DERIVED_DATA/index-import.pid)
+  if ps -p $PID > /dev/null; then
+    kill -10 $PID
+  fi
+fi
+
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $PARALLEL_STRIDE
+    -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \
@@ -53,4 +64,6 @@ $BAZEL_INSTALLERS_DIR/index-import \
     -remap "$bazel_root=$BAZEL_WORKSPACE_ROOT" \
     -remap "^([^//])=$BAZEL_WORKSPACE_ROOT/\$1" \
     "$@" \
-    "$BUILD_DIR"/../../Index/DataStore
+    "$BUILD_DIR"/../../Index/DataStore &
+
+echo $! > $DERIVED_DATA/index-import.pid

--- a/tools/xcodeproj_shims/installers/_indexstore.sh
+++ b/tools/xcodeproj_shims/installers/_indexstore.sh
@@ -33,9 +33,17 @@ readonly xcode_external="$BAZEL_WORKSPACE_ROOT/bazel-$(basename "$SRCROOT")/exte
 readonly remote_developer_dir="^/.*/.+?\.app/Contents/Developer"
 readonly local_developer_dir="$DEVELOPER_DIR"
 
+# Uses all available cores for intel and a fraction of the performance cores on M1
+PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
+
+# M1s have more performance cores than efficiency so dividing by 2 here should take
+# a good percentage of the performance cores to do this work
+if [[ $(arch) == 'arm64' ]]; then
+  PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
+fi
 
 $BAZEL_INSTALLERS_DIR/index-import \
-    -parallel-stride $(sysctl -n hw.physicalcpu)
+    -parallel-stride $PARALLEL_STRIDE
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tools/xcodeproj_shims/installers/_indexstore.sh
+++ b/tools/xcodeproj_shims/installers/_indexstore.sh
@@ -35,6 +35,7 @@ readonly local_developer_dir="$DEVELOPER_DIR"
 
 
 $BAZEL_INSTALLERS_DIR/index-import \
+    -parallel-stride $(sysctl -n hw.physicalcpu)
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \
     -remap "$bazel_module=$xcode_module" \

--- a/tools/xcodeproj_shims/installers/_indexstore.sh
+++ b/tools/xcodeproj_shims/installers/_indexstore.sh
@@ -38,7 +38,8 @@ PARALLEL_STRIDE=$(sysctl -n hw.physicalcpu)
 
 # M1 machines have more performance cores than efficiency cores so dividing by 2 here should take
 # a good percentage of the performance cores to do this work
-if [[ $(arch) == 'arm64' ]]; then
+ARCH=$(arch)
+if [[ $ARCH == 'arm64' ]]; then
   PARALLEL_STRIDE=$(expr $PARALLEL_STRIDE / 2)
 fi
 
@@ -49,9 +50,12 @@ DERIVED_DATA="$BUILD_DIR"/../../..
 if [[ -f $DERIVED_DATA/index-import.pid ]]; then
   PID=$(cat $DERIVED_DATA/index-import.pid)
   if ps -p $PID > /dev/null; then
+    echo "Killing index-import process before invoking it again"
     kill -10 $PID
   fi
 fi
+
+echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \

--- a/tools/xcodeproj_shims/installers/indexstores.sh
+++ b/tools/xcodeproj_shims/installers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq`
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tools/xcodeproj_shims/installers/indexstores.sh
+++ b/tools/xcodeproj_shims/installers/indexstores.sh
@@ -11,7 +11,13 @@ FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVEN
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES
 do
-  if [ -d $i ]
+  # Ensure 'units' and 'records' directories exist before calling index-import
+  # otherwise the process could be interrupet before all index stores are imported
+  #
+  # Still not clear why but I've found some instances where the 'records' folder wouldn't be present after a build
+  UNITS="$(find $i -type d -name 'units')"
+  RECORDS="$(find $i -type d -name 'records')"
+  if [ -d $i ] && [ "$UNITS" != "" ] && [ "$RECORDS" != "" ]
   then
     EXISTING_INDEXSTORES+=($i)
   fi


### PR DESCRIPTION
Resolves https://github.com/bazel-ios/rules_ios/issues/421 

* Invoke `index-import` with `parallel-stride` using different values for Intel vs M1
* Kill `index-import` process early to make sure there's only one instance running at a time
* Ensure only valid stores with both `units` and `records` directories are propagated ([to prevent this failure mode](https://github.dev/MobileNativeFoundation/index-import/blob/7c67cc40fe691f5d78ffa1f6e71cf32d59cf56fc/index-import.cpp#L386-L391))
* Also adds more information to the logs to help us troubleshoot in the future (fixing one bug that was prevent logs to be echo-ed if no stores were found)