### PR TITLE
Generate lldbinits from installer for LLDB test

### DIFF
--- a/rules/test/lldb/lldb_sim_runner.py
+++ b/rules/test/lldb/lldb_sim_runner.py
@@ -94,11 +94,10 @@ def pack_tree_artifact(ios_application_output_path, app_name):
                     "--delete",
                     "--checksum",
                     "--chmod=u+w",
-                    "--verbose",
                     os.path.realpath(ios_application_output_path),
                     archive_app_path
                     ], check=True)
-    subprocess.run(["zip", "-r",  ipa_path, "Payload", ],
+    subprocess.run(["zip", "-rq", ipa_path, "Payload", ],
                    check=True, cwd=archive_root)
 
     return ipa_path

--- a/tests/ios/lldb/app/BUILD.bazel
+++ b/tests/ios/lldb/app/BUILD.bazel
@@ -1,6 +1,7 @@
 load("//rules/test/lldb:lldb_test.bzl", "ios_lldb_breakpoint_command_test", "ios_lldb_breakpoint_po_test")
 load("//rules:xcodeproj.bzl", "xcodeproj")
 load("//rules:app.bzl", "ios_application")
+load("@build_bazel_rules_ios//rules:xcodeproj.bzl", "xcodeproj_lldbinit")
 
 ios_application(
     name = "ObjcApp",
@@ -24,13 +25,19 @@ xcodeproj(
     ],
 )
 
+xcodeproj_lldbinit(
+    name = "Objc-proj_xc_lldbinit",
+    out = "Objc-proj_xc_lldbinit" + ".xc.lldbinit",
+    target_name = "ObjcApp",
+    project = ":Objc-Project",
+)
+
 ios_lldb_breakpoint_po_test(
     name = "objc_app_variable_test",
     application = "ObjcApp",
     device = "iPhone X",
     expected_value = "some",
-    # TODO: Feed this from Xcode
-    lldbinit = None,
+    lldbinit = ":Objc-proj_xc_lldbinit",
     sdk = "14.5",
     set_cmd = "breakpoint set --file 'tests/ios/lldb/app/App/main.m' --line 6",
     tags = ["manual"],
@@ -42,8 +49,7 @@ ios_lldb_breakpoint_command_test(
     application = "ObjcApp",
     cmds = ["po x"],
     device = "iPhone X",
-    # TODO: Feed this from Xcode
-    lldbinit = None,
+    lldbinit = ":Objc-proj_xc_lldbinit",
     match_substrs = [
         "execute: po x",
         "cmd_result: po x some",


### PR DESCRIPTION
Feeds the LLDB init test from the rules into the xcodeproj

It sxport Xcode build settings JSON to an env file, sources it and then
runs `lldb-settings.sh` Gist is to dump showBuildSettings to replicate
xcode runscript actions

This is a quick hack for testing, and the env file is not reproducible
because the absolute paths.  Theoretically the LLDBInit should be
relative, the LLDBInit is less necessary it's current form with "virtual
frameworks".

Additionally silence output that is large on a big app