### PR TITLE
Fix  NullPointerException under aspect actions

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -1041,6 +1041,11 @@ the framework as a dependency.""",
             executable = True,
             default = Label("@build_bazel_apple_support//tools:xcode_path_wrapper"),
         ),
+        "_xcrunwrapper": attr.label(
+            cfg = "exec",
+            default = Label("@bazel_tools//tools/objc:xcrunwrapper"),
+            executable = True,
+        ),
     },
     doc = "Packages compiled code into an Apple .framework package",
 )

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -47,13 +47,6 @@ def apple_framework(name, apple_library = apple_library, **kwargs):
     framework_packaging_kwargs = {arg: kwargs.pop(arg) for arg in _APPLE_FRAMEWORK_PACKAGING_KWARGS if arg in kwargs}
     kwargs["enable_framework_vfs"] = kwargs.pop("enable_framework_vfs", True)
 
-    framework_deps = []
-    if framework_packaging_kwargs.get("link_dynamic") == True:
-        # Setup force loading here - only for direct deps / direct libs
-        force_load_name = name + ".force_load_direct_deps"
-        force_load_direct_deps(name = force_load_name, deps = kwargs.get("deps"), tags = ["manual"])
-        framework_deps.append(force_load_name)
-
     infoplists_by_build_setting = kwargs.pop("infoplists_by_build_setting", {})
     default_infoplists = kwargs.pop("infoplists", [])
     infoplists = None
@@ -72,6 +65,12 @@ def apple_framework(name, apple_library = apple_library, **kwargs):
     }))
 
     library = apple_library(name = name, **kwargs)
+    framework_deps = []
+    if framework_packaging_kwargs.get("link_dynamic") == True:
+        # Setup force loading here - only for direct deps / direct libs
+        force_load_name = name + ".force_load_direct_deps"
+        force_load_direct_deps(name = force_load_name, deps = kwargs.get("deps") + library.lib_names, tags = ["manual"])
+        framework_deps.append(force_load_name)
     framework_deps += library.lib_names
     apple_framework_packaging(
         name = name,


### PR DESCRIPTION
```
Caused by: net.starlark.java.eval.Starlark: NullPointerException thrown during Starlark evaluation (**)
at <starlark>.link_multi_arch_binary(<builtin>:0)
at <starlark>._register_linking_action(/private/var/tmp/_b/a91c18bd9ce258d03b3a6b38c636ee8d/external/build_bazel_rules_apple/apple/internal/linking_support.bzl:167)
at <starlark>._bundle_dynamic_framework(/private/var/tmp/_b/a91c18bd9ce258d03b3a6b38c636ee8d/external/build_bazel_rules_ios/rules/framework.bzl:583)
at <starlark>._apple_framework_packaging_impl(/private/var/tmp/_b/a91c18bd9ce258d03b3a6b38c636ee8d/external/build_bazel_rules_ios/rules/framework.bzl:849)
Caused by: java.lang.NullPointerException: apple_framework_packaging attribute  is not defined
```

We hit a null pointer when feeding these frameworks to certian aspects.
It just _needs_ this attribute present here.