### PR TITLE
Fix: Remove NSPrincipalClass in rules Info.plist files

### DIFF
--- a/rules/test_host_app/Info.plist
+++ b/rules/test_host_app/Info.plist
@@ -16,8 +16,6 @@
     <string>????</string>
     <key>CFBundleVersion</key>
     <string>1.0.0</string>
-    <key>NSPrincipalClass</key>
-    <string></string>
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
     <key>CFBundleExecutable</key>

--- a/tests/ios/unit-test/BUILD.bazel
+++ b/tests/ios/unit-test/BUILD.bazel
@@ -43,3 +43,14 @@ ios_unit_test(
     minimum_os_version = "11.0",
     resources = ["resource-file.txt"],
 )
+
+ios_unit_test(
+    name = "NSPrincipalClassDefinedInPlist",
+    srcs = [
+        "TestSuiteObserver.swift",
+        "empty.m",
+        "empty.swift",
+    ],
+    infoplists = [{"NSPrincipalClass": "TestSuiteObserver"}],
+    minimum_os_version = "11.0",
+)

--- a/tests/ios/unit-test/TestSuiteObserver.swift
+++ b/tests/ios/unit-test/TestSuiteObserver.swift
@@ -1,0 +1,20 @@
+import Foundation
+import XCTest
+
+/// Observes significant events in the progress of test runs
+/// Demonstrates defining NSPrincipalClass in unit test bundles.
+@objc(TestSuiteObserver)
+class TestSuiteObserver: NSObject, XCTestObservation {
+
+    // MARK: - Life Cycle
+
+    override init() {
+        super.init()
+
+        XCTestObservationCenter.shared.addTestObserver(self)
+    }
+
+    // MARK: - Test Observation
+
+    func testBundleWillStart(_ testBundle: Bundle) {}
+}


### PR DESCRIPTION
## Summary

This fixes an issue in unit test bundles where defining `NSPrincipalClass` within a test bundle's Info.plist would cause a build failure due to merging plists.

This PR fixes this issue by removing the defined `NSPrincipalClass` key from the `Info.plists` used by the rules. This key is already automatically defined by Xcode for iOS and macOS app targets so I don't believe we need to define this key in the rules.

> Xcode sets the default value of this key to NSApplication for macOS apps, and to UIApplication for iOS and tvOS apps. For other types of bundles, you must set this key in The Info.plist File.

Source: https://developer.apple.com/documentation/bundleresources/information_property_list/nsprincipalclass

I've also added a unit test to assert this behavior, this new test fails in the current master branch with error:

```sh
bazel test //tests/ios/unit-test:NSPrincipalClassDefinedInPlist    
...
...                                                  
ERROR: While processing target "//tests/ios/unit-test:NSPrincipalClassDefinedInPlist.__internal__.__test_bundle"; found key "NSPrincipalClass" in two plists with different values: "TestSuiteObserver" != ""
Target //tests/ios/unit-test:NSPrincipalClassDefinedInPlist failed to build
INFO: Elapsed time: 0.349s, Critical Path: 0.20s
INFO: 2 processes: 2 internal.
FAILED: Build did NOT complete successfully
//tests/ios/unit-test:NSPrincipalClassDefinedInPlist            FAILED TO BUILD

FAILED: Build did NOT complete successfully
```

With this change the new test should pass successfully. 
