### PR TITLE
Populate `[AppleBundleInfo].binary` in `framework_middleman`

### DIFF
--- a/rules/internal/framework_middleman.bzl
+++ b/rules/internal/framework_middleman.bzl
@@ -74,6 +74,7 @@ def _framework_middleman(ctx):
         AppleBundleInfo(
             archive = None,
             archive_root = None,
+            binary = None,
 
             # These arguments are unused - however, put them here incase that
             # somehow changes to make it easier to debug


### PR DESCRIPTION
**Summary:**
Allow `bazelisk coverage …` to work with targets that come from `framework_middleman` since `_coverage_files_aspect_impl` accesses `[AppleBundleInfo].binary` when `AppleBundleInfo` exists. This plus https://github.com/bazelbuild/rules_apple/pull/1423 allow coverage to work when `framework_middleman` is involved.