### PR TITLE
Bump cocoapods-downloader in test

### DIFF
--- a/tests/ios/frameworks/sources-with-prebuilt-binaries/Gemfile.lock
+++ b/tests/ios/frameworks/sources-with-prebuilt-binaries/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
       claide (>= 1.0.2, < 2.0)
       cocoapods-core (= 1.8.4)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
-      cocoapods-downloader (>= 1.2.2, < 2.0)
+      cocoapods-downloader (>= 1.6.2, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
       cocoapods-stats (>= 1.0.0, < 2.0)


### PR DESCRIPTION
Dependabot says there's a vulnerability and gives a scary warning in the GitHub home page so make it happy by bumping the test dependency.