### PR TITLE
Add support for `version` in `ios_application`

### DIFF
--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -34,6 +34,7 @@ _IOS_APPLICATION_KWARGS = [
     "ipa_post_processor",
     "include_symbols_in_bundle",
     "frameworks",
+    "version",
 ]
 
 def ios_application(name, apple_library = apple_library, infoplists_by_build_setting = {}, **kwargs):


### PR DESCRIPTION
# Summary
Add support for `version` in the `ios_application` macro:

https://github.com/bazelbuild/rules_apple/blob/b915183c461b6d404a7666312e7d7c1156e31ac6/apple/internal/rule_factory.bzl#L403-L409

This allows something like:
```Starlark
load("@build_bazel_rules_ios//rules:app.bzl", "ios_application")
load("@build_bazel_rules_apple//apple:versioning.bzl", "apple_bundle_version")

apple_bundle_version(
    name = "Version",
    build_version = "308963",
    short_version_string = "2022.17.0",
    visibility = ["//visibility:public"],
)

ios_application(
    ...
    version = ":Version",
)