### PR TITLE
[XCHammer] rebase, cherry-pick tulsi to HEAD

### DIFF
--- a/rules/legacy_xcodeproj.bzl
+++ b/rules/legacy_xcodeproj.bzl
@@ -406,6 +406,7 @@ env_script=$(mktemp /tmp/bazel-xcodeproj-intermediate.XXXXXX)
 trap "rm -rf $env_script" EXIT
 
 cat > $py_script << "EOF"
+#!/usr/bin/env python3 
 import json, sys, shlex
 build_settings = json.load(sys.stdin)[0]["buildSettings"]
 print("/bin/bash")
@@ -420,7 +421,9 @@ for bs in build_settings:
     else:
         print("export " + bs + "=" + cmds  + "")
 EOF
-""" + target_cmd + """ 2> /dev/null | python $py_script > $env_script
+
+chmod +x $py_script
+""" + target_cmd + """ 2> /dev/null | $py_script > $env_script
 source $env_script
 cat $env_script
 export BAZEL_LLDB_INIT_FILE=$PWD/""" + ctx.outputs.out.path + """

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -118,7 +118,8 @@ swift_binary(
         git_repository(
             name = "xchammer",
             remote = "https://github.com/bazel-ios/xchammer.git",
-            tag = "rules_ios-0.0.1",
+            # XCHammer dev branch: bazel-ios/rules-ios-xchammer
+            commit = "b233c4caba129d9a3a7cad57e8a65bf4c0dfd29f",
         )
     xchammer_dependencies()
 

--- a/rules/third_party/xchammer_repositories.bzl
+++ b/rules/third_party/xchammer_repositories.bzl
@@ -263,10 +263,11 @@ def xchammer_dependencies():
         name = "Tulsi",
         remote = "https://github.com/bazel-ios/tulsi.git",
         # These tags are based on the bazel-version - see XCHammer docs for
-        # convetion. It cherry-picks all changes to HEAD at a give bazel
+        # convention. It cherry-picks all changes to HEAD at a give bazel
         # release, then adds changes to this tag for the Bazel release in
         # question
-        tag = "rules_ios-5.0.0",
+        # Persisted on github tag=rules_ios-5.0.0,
+        commit = "adf9cf592198c1291775b8e4eb6a38d5ddf2f523",
         patch_cmds = [
             """
          sed -i '' 's/\\:__subpackages__/visibility\\:public/g' src/TulsiGenerator/BUILD
@@ -278,6 +279,7 @@ def xchammer_dependencies():
     )
 
     # FIX-ME: Point to 'master' instead of 'thiago/rules-ios-xchammer-1' after resolving issues
+    # TODO(jmarino) remove this
     new_git_repository(
         name = "xchammer_tulsi_aspects",
         remote = "https://github.com/bazel-ios/tulsi.git",

--- a/rules/third_party/xchammer_repositories.bzl
+++ b/rules/third_party/xchammer_repositories.bzl
@@ -262,7 +262,11 @@ def xchammer_dependencies():
     namespaced_git_repository(
         name = "Tulsi",
         remote = "https://github.com/bazel-ios/tulsi.git",
-        tag = "rules_ios-0.0.1",
+        # These tags are based on the bazel-version - see XCHammer docs for
+        # convetion. It cherry-picks all changes to HEAD at a give bazel
+        # release, then adds changes to this tag for the Bazel release in
+        # question
+        tag = "rules_ios-5.0.0",
         patch_cmds = [
             """
          sed -i '' 's/\\:__subpackages__/visibility\\:public/g' src/TulsiGenerator/BUILD


### PR DESCRIPTION
Cherry-pick all rules_ios changes to a fresh slate on 5.0.0 tag

Note:These tags are based on the bazel-version - see XCHammer docs for
convetion. It cherry-picks all changes to HEAD at a give bazel
release, then adds changes to this tag for the Bazel release in
question