### PR TITLE
Adding xcodeproj() attr to force x86 binaries for sim on M1

### DIFF
--- a/rules/legacy_xcodeproj.bzl
+++ b/rules/legacy_xcodeproj.bzl
@@ -1026,6 +1026,7 @@ def _xcodeproj_impl(ctx):
         "DONT_RUN_SWIFT_STDLIB_TOOL": True,
         "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
         "SWIFT_VERSION": 5,
+        "FORCE_X86_SIM": ctx.attr.force_x86_sim_on_apple_silicon,
     })
 
     # For debugging config only:
@@ -1258,6 +1259,7 @@ Additional LLDB settings to be added in each target's .lldbinit configuration fi
         "bazel_execution_log_enabled": attr.bool(default = False, mandatory = False),
         "bazel_profile_enabled": attr.bool(default = False, mandatory = False),
         "disable_main_thread_checker": attr.bool(default = False, mandatory = False),
+        "force_x86_sim_on_apple_silicon": attr.bool(default = False, mandatory = False),
     },
     executable = True,
 )

--- a/tools/xcodeproj_shims/build-wrapper.sh
+++ b/tools/xcodeproj_shims/build-wrapper.sh
@@ -22,6 +22,9 @@ fi
 if [ -n "${TARGET_DEVICE_IDENTIFIER:-}" ] && [ "$PLATFORM_NAME" = "iphoneos" ]; then
     echo "Builds with --ios_multi_cpus=arm64 since the target is an iOS device."
     BAZEL_BUILD_OPTIONS+=("--ios_multi_cpus=arm64")
+elif [ $FORCE_X86_SIM -gt 0 ] && [ "$PLATFORM_NAME" = "iphonesimulator" ] && [[ $(sysctl -n machdep.cpu.brand_string) =~ "Apple" ]]; then
+    echo "Builds with --ios_multi_cpus=x86_64 since the target is sim, host architecture is apple silicon, and xcodeproj attribute force_x86_sim_on_apple_silicon is True"
+    BAZEL_BUILD_OPTIONS+=("--ios_multi_cpus=x86_64")
 fi
 
 # If bazel configs (from .bazelrc file) were specificed and the current


### PR DESCRIPTION
## Summary

This PR adds the opt-in ability to force simulator builds to use `--ios_multi_cpus=x86_64` only on Apple Silicon.  The goal is to allow simulator builds that use external dependencies that aren't built for M1 yet to run under rosetta, while maintaining their ability to run on device.

## Details
A new boolean attribute was added to `xcodeproj()` called `force_x86_sim_on_apple_silicon` that will trigger this behavior.  The rule now injects a user defined build setting into the generated .xcodeproj that will be picked up by the bazel-wrapper.sh script.  To determine if the host architecture is Apple the script uses `sysctl` looking for cpu branding.  One alternative considered is using `uname` instead, however `uname` will report x86 if its parent process is running under rosetta.

The attribute defaults to false which is a no-op, and realistically only needs to be used during the transition to M1 compatible frameworks.