### PR TITLE
Add support for `testonly` in `apple_framework`

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -88,6 +88,7 @@ def apple_framework(name, apple_library = apple_library, **kwargs):
             "@build_bazel_rules_ios//rules/apple_platform:watchos": "watchos",
             "//conditions:default": "",
         }),
+        testonly = kwargs.get("testonly", False),
         **framework_packaging_kwargs
     )
 

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -581,6 +581,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
             swiftmodules = import_swiftmodules,
             hdrs = import_headers,
             tags = _MANUAL,
+            testonly = kwargs.get("testonly", False),
             extra_search_paths = vfs_root,
         )
         import_vfsoverlays.append(import_name + "_vfs")
@@ -623,6 +624,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
             swiftmodules = import_swiftmodules,
             hdrs = import_headers,
             tags = _MANUAL,
+            testonly = kwargs.get("testonly", False),
             extra_search_paths = vfs_root,
         )
         import_vfsoverlays.append(import_name + "_vfs")
@@ -657,6 +659,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
             swiftmodules = import_swiftmodules,
             hdrs = import_headers,
             tags = _MANUAL,
+            testonly = kwargs.get("testonly", False),
         )
         import_vfsoverlays.append(import_name + "_vfs")
 
@@ -741,6 +744,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
         private_hdrs = objc_private_hdrs,
         hdrs = objc_hdrs,
         tags = _MANUAL,
+        testonly = kwargs.get("testonly", False),
         deps = deps + private_deps + lib_names + import_vfsoverlays,
     )
 
@@ -877,6 +881,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
         private_hdrs = objc_private_hdrs,
         hdrs = objc_hdrs,
         tags = _MANUAL,
+        testonly = kwargs.get("testonly", False),
         deps = deps + private_deps + lib_names + import_vfsoverlays,
         #enable_framework_vfs = enable_framework_vfs
     )
@@ -918,6 +923,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
             hdrs = [],
             direct_hdr_providers = [swift_libname],
             tags = _MANUAL,
+            testonly = kwargs.get("testonly", False),
         )
         private_deps.append(swift_doublequote_hmap_name)
         _append_headermap_copts(swift_doublequote_hmap_name, "-iquote", additional_objc_copts, additional_swift_copts, additional_cc_copts)
@@ -930,6 +936,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
             hdrs = [],
             direct_hdr_providers = [swift_libname],
             tags = _MANUAL,
+            testonly = kwargs.get("testonly", False),
         )
         private_deps.append(swift_angle_bracket_hmap_name)
         _append_headermap_copts(swift_angle_bracket_hmap_name, "-I", additional_objc_copts, additional_swift_copts, additional_cc_copts)
@@ -944,6 +951,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
             copts = copts_by_build_setting.cc_copts + cc_copts + additional_cc_copts,
             deps = deps,
             tags = tags_manual,
+            testonly = kwargs.get("testonly", False),
         )
         lib_names.append(cpp_libname)
 

--- a/rules/test.bzl
+++ b/rules/test.bzl
@@ -62,15 +62,15 @@ def _ios_test(name, test_rule, test_suite_rule, apple_library, infoplists_by_bui
         host_args = [ios_test_kwargs["test_host"]]
     else:
         host_args = []
-    library = apple_library(name = name, namespace_is_module_name = False, platforms = {"ios": ios_test_kwargs.get("minimum_os_version")}, **kwargs)
+    library = apple_library(name = name, namespace_is_module_name = False, platforms = {"ios": ios_test_kwargs.get("minimum_os_version")}, testonly = True, **kwargs)
 
     # Setup framework middlemen - need to process deps and libs
     fw_name = name + ".framework_middleman"
-    framework_middleman(name = fw_name, framework_deps = kwargs.get("deps", []) + library.lib_names, tags = ["manual"])
+    framework_middleman(name = fw_name, framework_deps = kwargs.get("deps", []) + library.lib_names, testonly = True, tags = ["manual"])
     frameworks = [fw_name] + ios_test_kwargs.pop("frameworks", [])
 
     dep_name = name + ".dep_middleman"
-    dep_middleman(name = dep_name, deps = kwargs.get("deps", []) + library.lib_names, tags = ["manual"], test_deps = host_args)
+    dep_middleman(name = dep_name, deps = kwargs.get("deps", []) + library.lib_names, testonly = True, tags = ["manual"], test_deps = host_args)
 
     rule(
         name = name,

--- a/tests/ios/frameworks/testonly/BUILD.bazel
+++ b/tests/ios/frameworks/testonly/BUILD.bazel
@@ -1,0 +1,48 @@
+load("//rules:framework.bzl", "apple_framework")
+load("//rules:test.bzl", "ios_unit_test")
+
+apple_framework(
+    name = "SwiftLibrary",
+    testonly = True,
+    srcs = glob(["SwiftLibrary/**/*.swift"]),
+    module_name = "SwiftLibrary",
+    visibility = ["//visibility:public"],
+)
+
+apple_framework(
+    name = "MixedSourceFramework",
+    testonly = True,
+    srcs = glob(
+        include = [
+            "MixedSourceFramework/**/*.h",
+            "MixedSourceFramework/**/*.m",
+            "MixedSourceFramework/**/*.swift",
+        ],
+    ),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":SwiftLibrary",
+    ],
+)
+
+apple_framework(
+    name = "MixedSourceTestLib",
+    testonly = True,
+    srcs = glob(
+        [
+            "MixedSourceTest/**/*.h",
+            "MixedSourceTest/**/*.m",
+            "MixedSourceTest/**/*.swift",
+        ],
+    ),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":MixedSourceFramework",
+    ],
+)
+
+ios_unit_test(
+    name = "MixedSourceTest",
+    minimum_os_version = "12.0",
+    deps = [":MixedSourceTestLib"],
+)

--- a/tests/ios/frameworks/testonly/MixedSourceFramework/Logger/AngleBracketNamespacedLogger.h
+++ b/tests/ios/frameworks/testonly/MixedSourceFramework/Logger/AngleBracketNamespacedLogger.h
@@ -1,0 +1,16 @@
+#ifndef AngleBracketNamespacedLogger_h
+#define AngleBracketNamespacedLogger_h
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AngleBracketNamespacedLogger: NSObject
+
+- (void)logWithMessage:(NSString *)message;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif /* AngleBracketNamespacedLogger_h */

--- a/tests/ios/frameworks/testonly/MixedSourceFramework/Logger/AngleBracketNamespacedLogger.m
+++ b/tests/ios/frameworks/testonly/MixedSourceFramework/Logger/AngleBracketNamespacedLogger.m
@@ -1,0 +1,15 @@
+#import "AngleBracketNamespacedLogger.h"
+#import <MixedSourceFramework/MixedSourceFramework-Swift.h> // The `MixedSourceFramework-Swift.h` header allows
+                                                            // Objective-C files from within a mixed-source framework
+                                                            // to consume Swift files declared in the same framework.
+                                                            //
+                                                            // Here, we prefix our `-Swift.h` import with the namespace
+                                                            // of the framework itself.
+@implementation AngleBracketNamespacedLogger
+
+- (void)logWithMessage:(NSString *)message {
+    SwiftLogger *swiftLogger = [[SwiftLogger alloc] init];
+    [swiftLogger swiftLog:message];
+}
+
+@end

--- a/tests/ios/frameworks/testonly/MixedSourceFramework/Logger/DoubleQuoteLogger.h
+++ b/tests/ios/frameworks/testonly/MixedSourceFramework/Logger/DoubleQuoteLogger.h
@@ -1,0 +1,16 @@
+#ifndef DoubleQuoteLogger_h
+#define DoubleQuoteLogger_h
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface DoubleQuoteLogger: NSObject
+
+- (void)logWithMessage:(NSString *)message;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif /* DoubleQuoteLogger_h */

--- a/tests/ios/frameworks/testonly/MixedSourceFramework/Logger/DoubleQuoteLogger.m
+++ b/tests/ios/frameworks/testonly/MixedSourceFramework/Logger/DoubleQuoteLogger.m
@@ -1,0 +1,15 @@
+#import "DoubleQuoteLogger.h"
+#import "MixedSourceFramework-Swift.h" // The `MixedSourceFramework-Swift.h` header allows
+                                       // Objective-C files from within a mixed-source framework
+                                       // to consume Swift files declared in the same framework.
+                                       //
+                                       // Here, we add no prefix to our `-Swift.h` import
+
+@implementation DoubleQuoteLogger
+
+- (void)logWithMessage:(NSString *)message {
+    SwiftLogger *swiftLogger = [[SwiftLogger alloc] init];
+    [swiftLogger swiftLog:message];
+}
+
+@end

--- a/tests/ios/frameworks/testonly/MixedSourceFramework/Logger/DoubleQuoteNamespacedLogger.h
+++ b/tests/ios/frameworks/testonly/MixedSourceFramework/Logger/DoubleQuoteNamespacedLogger.h
@@ -1,0 +1,16 @@
+#ifndef DoubleQuoteNamespacedLogger_h
+#define DoubleQuoteNamespacedLogger_h
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface DoubleQuoteNamespacedLogger: NSObject
+
+- (void)logWithMessage:(NSString *)message;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif /* DoubleQuoteNamespacedLogger_h */

--- a/tests/ios/frameworks/testonly/MixedSourceFramework/Logger/DoubleQuoteNamespacedLogger.m
+++ b/tests/ios/frameworks/testonly/MixedSourceFramework/Logger/DoubleQuoteNamespacedLogger.m
@@ -1,0 +1,15 @@
+#import "DoubleQuoteNamespacedLogger.h"
+#import "MixedSourceFramework/MixedSourceFramework-Swift.h" // The `MixedSourceFramework-Swift.h` header allows
+                                                            // Objective-C files from within a mixed-source framework
+                                                            // to consume Swift files declared in the same framework.
+                                                            //
+                                                            // Here, we prefix our `-Swift.h` import with the namespace
+                                                            // of the framework itself.
+@implementation DoubleQuoteNamespacedLogger
+
+- (void)logWithMessage:(NSString *)message {
+    SwiftLogger *swiftLogger = [[SwiftLogger alloc] init];
+    [swiftLogger swiftLog:message];
+}
+
+@end

--- a/tests/ios/frameworks/testonly/MixedSourceFramework/Logger/LoggerProtocol.h
+++ b/tests/ios/frameworks/testonly/MixedSourceFramework/Logger/LoggerProtocol.h
@@ -1,0 +1,5 @@
+@import Foundation;
+
+@protocol LoggerProtocol <NSObject>
+
+@end

--- a/tests/ios/frameworks/testonly/MixedSourceFramework/Logger/SwiftLibrary+extension.swift
+++ b/tests/ios/frameworks/testonly/MixedSourceFramework/Logger/SwiftLibrary+extension.swift
@@ -1,0 +1,17 @@
+import SwiftLibrary
+
+/* Declaring this extension used to make the framework build fail with the error:
+* ...MixedSourceFramework-Swift.h:184:9: fatal error: module 'SwiftLibrary' not found
+* @import SwiftLibrary;
+* ~~~~~~~^~~~~~~~~~~~
+* 1 error generated.
+*
+* Find more information in https://github.com/bazel-ios/rules_ios/issues/55
+*/
+public extension Foo {
+    static var aProperty: String { "hey there!" }
+}
+
+// This extension did not trigger any error because Bar does not subclass from NSObject
+extension Bar {
+}

--- a/tests/ios/frameworks/testonly/MixedSourceFramework/Logger/SwiftLogger.swift
+++ b/tests/ios/frameworks/testonly/MixedSourceFramework/Logger/SwiftLogger.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+@objc
+public class SwiftLogger: NSObject, LoggerProtocol {
+    @objc public override init () {}
+    @objc public func swiftLog(_ message: String) {
+        print(message)
+    }
+}
+

--- a/tests/ios/frameworks/testonly/MixedSourceFramework/MixedSourceFramework.h
+++ b/tests/ios/frameworks/testonly/MixedSourceFramework/MixedSourceFramework.h
@@ -1,0 +1,2 @@
+// Needed because the generated -Swift.h header is hard-coded to import this file, instead of the underlying headers / umbrella header for the module
+#import <MixedSourceFramework/MixedSourceFramework-umbrella.h>

--- a/tests/ios/frameworks/testonly/MixedSourceTest/ObjCTest.m
+++ b/tests/ios/frameworks/testonly/MixedSourceTest/ObjCTest.m
@@ -1,0 +1,14 @@
+@import MixedSourceFramework;
+@import XCTest;
+
+@interface ObjCTest : XCTestCase
+@end
+
+@implementation ObjCTest
+
+- (void)test_protocolConformance;
+{
+    XCTAssertTrue([SwiftLogger conformsToProtocol:@protocol(LoggerProtocol)]);
+}
+
+@end

--- a/tests/ios/frameworks/testonly/MixedSourceTest/Tests.swift
+++ b/tests/ios/frameworks/testonly/MixedSourceTest/Tests.swift
@@ -1,0 +1,10 @@
+import Foundation
+import MixedSourceFramework
+import XCTest
+import SwiftLibrary
+
+class Tests: XCTestCase {
+    func test() {
+        XCTAssertEqual(Foo.aProperty, "hey there!")
+    }
+}

--- a/tests/ios/frameworks/testonly/SwiftLibrary/SwiftLibrary.swift
+++ b/tests/ios/frameworks/testonly/SwiftLibrary/SwiftLibrary.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+open class Foo: NSObject {
+}
+
+open class Bar {
+}


### PR DESCRIPTION
# Summary
- Add support for `testonly` in the `apple_framework` macro.
- Add test to confirm `testonly` works based on the `tests/ios/frameworks/mixed-source/only-source` test that already exists.

Closes https://github.com/bazel-ios/rules_ios/issues/365.