### PR TITLE
Fix @xchammer-Quick commit SHA

### DIFF
--- a/rules/third_party/xchammer_repositories.bzl
+++ b/rules/third_party/xchammer_repositories.bzl
@@ -188,7 +188,7 @@ def xchammer_dependencies():
     namespaced_new_git_repository(
         name = "Quick",
         remote = "https://github.com/Quick/Quick.git",
-        commit = "cd6dfb86f496fcd96ce0bc6da962cd936bf41903",
+        commit = "20b340da40ccd2bf62ea1e803e6b8f7933f7515e",
         build_file_content = namespaced_build_file([
             namespaced_swift_library(
                 name = "Quick",


### PR DESCRIPTION
If I run `bazel sync` with the latest rules-ios, it complains 
```
ERROR: An error occurred during the fetch of repository 'xchammer-Quick':
   Traceback (most recent call last):
        File "/private/var/tmp/_bazel_tawang/11e611afa2f11dfb00f2bd11ce6be2fe/external/bazel_tools/tools/build_defs/repo/git.bzl", line 174, column 30, in _new_git_repository_implementation
                update = _clone_or_update(ctx)
        File "/private/var/tmp/_bazel_tawang/11e611afa2f11dfb00f2bd11ce6be2fe/external/bazel_tools/tools/build_defs/repo/git.bzl", line 36, column 20, in _clone_or_update
                git_ = git_repo(ctx, directory)
        File "/private/var/tmp/_bazel_tawang/11e611afa2f11dfb00f2bd11ce6be2fe/external/bazel_tools/tools/build_defs/repo/git_worker.bzl", line 91, column 12, in git_repo
                _update(ctx, git_repo)
        File "/private/var/tmp/_bazel_tawang/11e611afa2f11dfb00f2bd11ce6be2fe/external/bazel_tools/tools/build_defs/repo/git_worker.bzl", line 104, column 10, in _update
                reset(ctx, git_repo)
        File "/private/var/tmp/_bazel_tawang/11e611afa2f11dfb00f2bd11ce6be2fe/external/bazel_tools/tools/build_defs/repo/git_worker.bzl", line 148, column 9, in reset
                _git(ctx, git_repo, "reset", "--hard", git_repo.reset_ref)
        File "/private/var/tmp/_bazel_tawang/11e611afa2f11dfb00f2bd11ce6be2fe/external/bazel_tools/tools/build_defs/repo/git_worker.bzl", line 169, column 15, in _git
                _error(ctx.name, start + list(args), st.stderr)
        File "/private/var/tmp/_bazel_tawang/11e611afa2f11dfb00f2bd11ce6be2fe/external/bazel_tools/tools/build_defs/repo/git_worker.bzl", line 190, column 9, in _error
                fail("error running '%s' while working with @%s:\n%s" % (command_text, name, stderr))
Error in fail: error running 'git reset --hard cd6dfb86f496fcd96ce0bc6da962cd936bf41903' while working with @xchammer-Quick:
fatal: Could not parse object 'cd6dfb86f496fcd96ce0bc6da962cd936bf41903'.
```

It turns out the commit hash `cd6dfb86f496fcd96ce0bc6da962cd936bf41903` is not available in the [xchammer-Quick repo](https://github.com/Quick/Quick.git).

Change this malfunction SHA to latest master `20b340da40ccd2bf62ea1e803e6b8f7933f7515e ` can solve this issue.