### PR TITLE
fix git-repository warning

### DIFF
--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -120,6 +120,7 @@ swift_binary(
             remote = "https://github.com/bazel-ios/xchammer.git",
             # XCHammer dev branch: bazel-ios/rules-ios-xchammer
             commit = "00d339b20ad5f51532c823eaf37e48739be6e697",
+            shallow_since = "1652289435 -0700",
         )
     xchammer_dependencies()
 

--- a/rules/third_party/xchammer_repositories.bzl
+++ b/rules/third_party/xchammer_repositories.bzl
@@ -262,6 +262,7 @@ def xchammer_dependencies():
     namespaced_git_repository(
         name = "Tulsi",
         remote = "https://github.com/bazel-ios/tulsi.git",
+        shallow_since = "1651700898 -0700",
         # These tags are based on the bazel-version - see XCHammer docs for
         # convention. It cherry-picks all changes to HEAD at a give bazel
         # release, then adds changes to this tag for the Bazel release in


### PR DESCRIPTION
When using `git_repository` in WORKSPACE
```
git_repository(
    name = "build_bazel_rules_ios",
    remote = "https://github.com/bazel-ios/rules_ios.git",
    branch = "master",
)
```

bazel build will emit warnings like below, which is treated is build errors in the generated xcode project. Adding `shallow_since` can fix this warning. 
```
DEBUG: Rule 'xchammer' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1652289435 -0700"
DEBUG: Repository xchammer instantiated at:
  XXXX/WORKSPACE:235:23: in <toplevel>
  /private/var/tmp/_bazel_tawang/11e611afa2f11dfb00f2bd11ce6be2fe/external/build_bazel_rules_ios/rules/repositories.bzl:118:23: in rules_ios_dependencies
Repository rule git_repository defined at:
  /private/var/tmp/_bazel_tawang/11e611afa2f11dfb00f2bd11ce6be2fe/external/bazel_tools/tools/build_defs/repo/git.bzl:199:33: in <toplevel>
DEBUG: Rule 'xchammer-Tulsi' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1651700898 -0700"
DEBUG: Repository xchammer-Tulsi instantiated at:
  XXXX/WORKSPACE:235:23: in <toplevel>
  /private/var/tmp/_bazel_tawang/11e611afa2f11dfb00f2bd11ce6be2fe/external/build_bazel_rules_ios/rules/repositories.bzl:124:26: in rules_ios_dependencies
  /private/var/tmp/_bazel_tawang/11e611afa2f11dfb00f2bd11ce6be2fe/external/build_bazel_rules_ios/rules/third_party/xchammer_repositories.bzl:262:30: in xchammer_dependencies
  /private/var/tmp/_bazel_tawang/11e611afa2f11dfb00f2bd11ce6be2fe/external/build_bazel_rules_ios/rules/third_party/xchammer_repositories.bzl:30:19: in namespaced_git_repository
Repository rule git_repository defined at:
  /private/var/tmp/_bazel_tawang/11e611afa2f11dfb00f2bd11ce6be2fe/external/bazel_tools/tools/build_defs/repo/git.bzl:199:33: in <toplevel>
```