### PR TITLE
Encode incoming string with UTF-8 and replace any invalid ones with default

### DIFF
--- a/tools/xcodeproj_shims/output-processor.rb
+++ b/tools/xcodeproj_shims/output-processor.rb
@@ -7,7 +7,7 @@ class BazelOutputLine
 
   def initialize(line)
     # Otherwise we might get `invalid byte sequence in US-ASCII (ArgumentError)` during matching with regex
-    @text = line.encode("US-ASCII", invalid: :replace, undef: :replace)
+    @text = line.encode("UTF-8", invalid: :replace, undef: :replace)
   end
 
   # Try to create a processed line based on a match rule, or a pass-through

--- a/tools/xcodeproj_shims/output-processor.rb
+++ b/tools/xcodeproj_shims/output-processor.rb
@@ -6,7 +6,8 @@ class BazelOutputLine
   attr_reader :text
 
   def initialize(line)
-    @text = line
+    # Otherwise we might get `invalid byte sequence in US-ASCII (ArgumentError)` during matching with regex
+    @text = line.encode("US-ASCII", invalid: :replace, undef: :replace)
   end
 
   # Try to create a processed line based on a match rule, or a pass-through


### PR DESCRIPTION
Sometimes Bazel log will contain characters ruby cannot handle, so we need to encode it with ASCII and replace anything it does not understand, or downstream project may face `invalid byte sequence in US-ASCII (ArgumentError)` error when trying to do regex match.

Choosing ASCII because according to this article: https://www.cloudbees.com/blog/how-ruby-string-encoding-benefits-developers string is best to be in that encoding for best performance. The log we have can be assumed to be useful with ASCII value only and I don't see the need to encode in more expensive UTF-8, but we can certain use that encoding too.