### PR TITLE
Correctly find uniq index stores

### DIFF
--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | sort | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | sort | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | sort | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | sort | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | sort | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | sort | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | sort | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | sort | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | sort | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | sort | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | sort | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/indexstores.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | sort | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES

--- a/tools/xcodeproj_shims/installers/indexstores.sh
+++ b/tools/xcodeproj_shims/installers/indexstores.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 echo "Start remapping index files at `date`"
 
-FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | uniq` || true
+FOUND_INDEXSTORES=`grep -o 'command_line: "\(.*\.indexstore\)' $BAZEL_BUILD_EVENT_TEXT_FILENAME | sed 's/.*command_line: "//' | sort | uniq` || true
 
 declare -a EXISTING_INDEXSTORES=()
 for i in $FOUND_INDEXSTORES


### PR DESCRIPTION
Without `sort`, this `uniq` call is really doing nothing. If the same index store appears multiple times in the build event file (which is the case for [bazel-out/rules_ios_global_index_store.indexstore](https://github.com/bazel-ios/rules_ios/blob/bb1f602ea6fe1611b608fcd2e54165f1da554471/rules/library.bzl#L969)) we will pass it multiple times to `index-import` causing performance issues in complex apps.