### PR TITLE
Handle toolchain provider renames from `rules_apple`

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -19,7 +19,8 @@ load("@build_bazel_rules_apple//apple/internal:processor.bzl", "processor")
 load("@build_bazel_rules_apple//apple/internal:resource_actions.bzl", "resource_actions")
 load("@build_bazel_rules_apple//apple/internal:resources.bzl", "resources")
 load("@build_bazel_rules_apple//apple/internal:rule_support.bzl", "rule_support")
-load("@build_bazel_rules_apple//apple:providers.bzl", "AppleBundleInfo", "AppleSupportToolchainInfo", "IosFrameworkBundleInfo")
+load("@build_bazel_rules_apple//apple:providers.bzl", "AppleBundleInfo", "IosFrameworkBundleInfo")
+load("@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl", "AppleMacToolsToolchainInfo")
 load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo", "swift_common")
 load(
     "@build_bazel_rules_apple//apple/internal/aspects:resource_aspect.bzl",
@@ -494,7 +495,7 @@ def _merge_root_infoplists(ctx):
     bundle_name = ctx.attr.framework_name
     current_apple_platform = transition_support.current_apple_platform(apple_fragment = ctx.fragments.apple, xcode_config = ctx.attr._xcode_config)
     platform_type = str(current_apple_platform.platform.platform_type)
-    apple_toolchain_info = ctx.attr._toolchain[AppleSupportToolchainInfo]
+    apple_toolchain_info = ctx.attr._toolchain[AppleMacToolsToolchainInfo]
     rule_descriptor = rule_support.rule_descriptor(ctx)
 
     resource_actions.merge_root_infoplists(
@@ -518,7 +519,6 @@ def _merge_root_infoplists(ctx):
             objc_fragment = None,
             platform_type_string = platform_type,
             uses_swift = False,
-            xcode_path_wrapper = None,
             xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
             disabled_features = [],
             features = [],
@@ -545,7 +545,7 @@ def _bundle_dynamic_framework(ctx, avoid_deps):
     Currently, this doesn't include headers or other interface files.
     """
     actions = ctx.actions
-    apple_toolchain_info = ctx.attr._toolchain[AppleSupportToolchainInfo]
+    apple_toolchain_info = ctx.attr._toolchain[AppleMacToolsToolchainInfo]
     bin_root_path = ctx.bin_dir.path
     bundle_id = ctx.attr.bundle_id
     if not bundle_id:
@@ -695,7 +695,7 @@ def _bundle_dynamic_framework(ctx, avoid_deps):
         ),
         partials.resources_partial(
             actions = actions,
-            apple_toolchain_info = apple_toolchain_info,
+            apple_mac_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -1027,8 +1027,8 @@ the framework as a dependency.""",
             doc = "Needed to allow this rule to have an incoming edge configuration transition.",
         ),
         "_toolchain": attr.label(
-            default = Label("@build_bazel_rules_apple//apple/internal:toolchain_support"),
-            providers = [[AppleSupportToolchainInfo]],
+            default = Label("@build_bazel_rules_apple//apple/internal:mac_tools_toolchain"),
+            providers = [[AppleMacToolsToolchainInfo]],
         ),
         "platform_type": attr.string(
             mandatory = False,

--- a/rules/precompiled_apple_resource_bundle.bzl
+++ b/rules/precompiled_apple_resource_bundle.bzl
@@ -16,7 +16,8 @@ load("@build_bazel_rules_apple//apple/internal:resources.bzl", "resources")
 load("@build_bazel_rules_apple//apple/internal:resource_actions.bzl", "resource_actions")
 load("@build_bazel_rules_apple//apple/internal:rule_factory.bzl", "rule_factory")
 load("//rules:transition_support.bzl", "transition_support")
-load("@build_bazel_rules_apple//apple:providers.bzl", "AppleResourceBundleInfo", "AppleResourceInfo", "AppleSupportToolchainInfo")
+load("@build_bazel_rules_apple//apple:providers.bzl", "AppleResourceBundleInfo", "AppleResourceInfo")
+load("@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl", "AppleMacToolsToolchainInfo")
 load("//rules:utils.bzl", "bundle_identifier_for_bundle")
 
 _FAKE_BUNDLE_PRODUCT_TYPE_BY_PLATFORM_TYPE = {
@@ -64,7 +65,6 @@ def _precompiled_apple_resource_bundle_impl(ctx):
             objc_fragment = None,
             platform_type_string = platform_type,
             uses_swift = False,
-            xcode_path_wrapper = None,
             xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
             disabled_features = [],
             features = [],
@@ -79,10 +79,10 @@ def _precompiled_apple_resource_bundle_impl(ctx):
         version = None,
     )
 
-    apple_toolchain_info = ctx.attr._toolchain[AppleSupportToolchainInfo]
+    apple_toolchain_info = ctx.attr._toolchain[AppleMacToolsToolchainInfo]
     partial_output = partial.call(
         partials.resources_partial(
-            apple_toolchain_info = apple_toolchain_info,
+            apple_mac_toolchain_info = apple_toolchain_info,
             resource_deps = ctx.attr.resources,
             top_level_infoplists = resources.collect(
                 attr = ctx.attr,
@@ -271,8 +271,8 @@ the bundle as a dependency.""",
             doc = "Needed to allow this rule to have an incoming edge configuration transition.",
         ),
         _toolchain = attr.label(
-            default = Label("@build_bazel_rules_apple//apple/internal:toolchain_support"),
-            providers = [[AppleSupportToolchainInfo]],
+            default = Label("@build_bazel_rules_apple//apple/internal:mac_tools_toolchain"),
+            providers = [[AppleMacToolsToolchainInfo]],
         ),
     ),
 )

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -61,10 +61,10 @@ def rules_ios_dependencies():
     _maybe(
         github_repo,
         name = "build_bazel_rules_apple",
-        ref = "7115f0188d141d57d64a6875735847c975956dae",  # tag 0.34
+        ref = "7e22b9a6421244462b105e8511e129c2e6d0ba53",  # master on 2022-06-14
         project = "bazelbuild",
         repo = "rules_apple",
-        sha256 = "ddb53fb63947d068f4f1cc492c144c459e474a05d9db157ccf9457485aad2562",
+        sha256 = "d928cf67298389137b116b7e3ff8939d8e048f0a6c82c2e51c38f5924e9cc72c",
     )
 
     _maybe(


### PR DESCRIPTION
**Note:** This bumps `rules_apple` to a non-tagged release so please block if that's not desired.

# Summary
`resources_partial` has renamed `apple_toolchain_info` to `apple_mac_toolchain_info`:

https://github.com/bazelbuild/rules_apple/blob/56c54f25253b616bdd852b569023a437a4f95768/apple/internal/partials/resources.bzl#L558

`AppleSupportToolchainInfo` provider has been renamed to `AppleSupportMacToolsToolchainInfo` (and then to `AppleMacToolsToolchainInfo`):

https://github.com/bazelbuild/rules_apple/commit/eba6e68d11005a11011975c3006bdb18e2b42d2d#diff-f06c6d6866f9332aa9ea85f2e0ccc46f67dfa8e67814a57f243bad6441856f4eL260-R260

https://github.com/bazelbuild/rules_apple/commit/25ae9772eb378fa9ec758ac6ba330d406659005b#diff-fbbb4cbee7c788f8869825280431690c3a1f7994af24a89ab86a17ca72a140c9R17

`xcode_path_wrapper` was removed from `apple_support.run()`:

https://github.com/bazelbuild/rules_apple/commit/c9d6a570cfb0308648f227115ae60298e1e17700#diff-6c787cdc6f35c8d92b621a6469457c92f97d29e4a4005ee6617fb2851725b0f4L81