### PR TITLE
Fix broken link for objc_library rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 These rules provide some macros and rules that make it easier to build iOS
 application with Bazel. The heavy lifting of compiling, and packaging is
 still done by the existing
- [`objc_library` rule](https://bazel.build/versions/master/docs/be/objective-c.html#objc_library)
+ [`objc_library` rule](https://bazel.build/reference/be/objective-c#objc_library)
 in Bazel, and by the
 [`swift_library` rule](https://github.com/bazelbuild/rules_swift/blob/master/doc/rules.md#swift_library)
 available from [rules_swift](https://github.com/bazelbuild/rules_swift).


### PR DESCRIPTION
Hi, just noticed a broken link while reading README:

* Current: https://bazel.build/versions/master/docs/be/objective-c.html#objc_library
* Fixed: https://bazel.build/reference/be/objective-c#objc_library
