### PR TITLE
Add `-fapplication-extension` validation for `apple_framework`

### DIFF
--- a/docs/framework_doc.md
+++ b/docs/framework_doc.md
@@ -9,8 +9,9 @@ Framework rules
 <pre>
 apple_framework_packaging(<a href="#apple_framework_packaging-name">name</a>, <a href="#apple_framework_packaging-bundle_extension">bundle_extension</a>, <a href="#apple_framework_packaging-bundle_id">bundle_id</a>, <a href="#apple_framework_packaging-data">data</a>, <a href="#apple_framework_packaging-deps">deps</a>, <a href="#apple_framework_packaging-environment_plist">environment_plist</a>,
                           <a href="#apple_framework_packaging-exported_symbols_lists">exported_symbols_lists</a>, <a href="#apple_framework_packaging-framework_name">framework_name</a>, <a href="#apple_framework_packaging-frameworks">frameworks</a>, <a href="#apple_framework_packaging-infoplists">infoplists</a>,
-                          <a href="#apple_framework_packaging-link_dynamic">link_dynamic</a>, <a href="#apple_framework_packaging-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#apple_framework_packaging-minimum_os_version">minimum_os_version</a>,
-                          <a href="#apple_framework_packaging-platform_type">platform_type</a>, <a href="#apple_framework_packaging-platforms">platforms</a>, <a href="#apple_framework_packaging-skip_packaging">skip_packaging</a>, <a href="#apple_framework_packaging-stamp">stamp</a>, <a href="#apple_framework_packaging-transitive_deps">transitive_deps</a>, <a href="#apple_framework_packaging-vfs">vfs</a>)
+                          <a href="#apple_framework_packaging-library_linkopts">library_linkopts</a>, <a href="#apple_framework_packaging-link_dynamic">link_dynamic</a>, <a href="#apple_framework_packaging-minimum_deployment_os_version">minimum_deployment_os_version</a>,
+                          <a href="#apple_framework_packaging-minimum_os_version">minimum_os_version</a>, <a href="#apple_framework_packaging-platform_type">platform_type</a>, <a href="#apple_framework_packaging-platforms">platforms</a>, <a href="#apple_framework_packaging-skip_packaging">skip_packaging</a>, <a href="#apple_framework_packaging-stamp">stamp</a>,
+                          <a href="#apple_framework_packaging-transitive_deps">transitive_deps</a>, <a href="#apple_framework_packaging-vfs">vfs</a>)
 </pre>
 
 Packages compiled code into an Apple .framework package
@@ -30,6 +31,7 @@ Packages compiled code into an Apple .framework package
 | <a id="apple_framework_packaging-framework_name"></a>framework_name |  Name of the framework, usually the same as the module name   | String | required |  |
 | <a id="apple_framework_packaging-frameworks"></a>frameworks |  A list of framework targets (see [<code>ios_framework</code>](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-ios.md#ios_framework)) that this target depends on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="apple_framework_packaging-infoplists"></a>infoplists |  The infoplists for the framework   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="apple_framework_packaging-library_linkopts"></a>library_linkopts |  Internal - A list of strings representing extra flags that are passed to the linker for the underlying library.   | List of strings | optional | [] |
 | <a id="apple_framework_packaging-link_dynamic"></a>link_dynamic |  Weather or not if this framework is dynamic<br><br>The default behavior bakes this into the top level app. When false, it's statically linked.   | Boolean | optional | False |
 | <a id="apple_framework_packaging-minimum_deployment_os_version"></a>minimum_deployment_os_version |  The bundle identifier of the framework. Currently unused.   | String | optional | "" |
 | <a id="apple_framework_packaging-minimum_os_version"></a>minimum_os_version |  Internal - currently rules_ios the dict <code>platforms</code>   | String | optional | "" |

--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -15,6 +15,7 @@ _IOS_APPLICATION_KWARGS = [
     "bundle_name",
     "infoplists",
     "env",
+    "executable_name",
     "minimum_os_version",
     "test_host",
     "families",

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -943,7 +943,7 @@ apple_framework_packaging = rule(
         ),
         "library_linkopts": attr.string_list(
             doc = """
-A list of strings representing extra flags that should be passed to the linker.
+Internal - A list of strings representing extra flags that are passed to the linker for the underlying library.
 """,
         ),
         "link_dynamic": attr.bool(

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -7,6 +7,7 @@ load("//rules:plists.bzl", "info_plists_by_setting")
 load("//rules:providers.bzl", "AvoidDepsInfo", "FrameworkInfo")
 load("//rules:transition_support.bzl", "transition_support")
 load("//rules/internal:objc_provider_utils.bzl", "objc_provider_utils")
+load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@build_bazel_rules_apple//apple/internal:apple_product_type.bzl", "apple_product_type")
 load("@build_bazel_rules_apple//apple/internal:bundling_support.bzl", "bundling_support")
@@ -84,6 +85,7 @@ def apple_framework(name, apple_library = apple_library, **kwargs):
         vfs = library.import_vfsoverlays,
         deps = framework_deps,
         platforms = platforms,
+        library_linkopts = library.linkopts,
         # At the time of writing this is still used in the output path
         # computation
         minimum_os_version = select({
@@ -540,7 +542,7 @@ def _attrs_for_split_slice(attrs_by_split_slices, split_slice_key):
     else:
         return attrs_by_split_slices[split_slice_key]
 
-def _bundle_dynamic_framework(ctx, avoid_deps):
+def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps):
     """Packages this as dynamic framework
 
     Currently, this doesn't include headers or other interface files.
@@ -588,6 +590,8 @@ def _bundle_dynamic_framework(ctx, avoid_deps):
             name = bundle_name,
         ),
     ]
+    if is_extension_safe:
+        extra_linkopts.append("-fapplication-extension")
 
     top_level_infoplists = resources.collect(
         attr = ctx.attr,
@@ -685,6 +689,11 @@ def _bundle_dynamic_framework(ctx, avoid_deps):
             platform_prerequisites = platform_prerequisites,
             signed_frameworks = depset(signed_frameworks),
         ),
+        partials.extension_safe_validation_partial(
+            is_extension_safe = is_extension_safe,
+            rule_label = label,
+            targets_to_validate = dep_frameworks,
+        ),
 
         # Don't bake the headers here - for distro mode, this is done with
         # xcframework
@@ -767,11 +776,19 @@ def _bundle_dynamic_framework(ctx, avoid_deps):
         ] + processor_result.providers,
     )
 
-def _bundle_static_framework(ctx, outputs):
+def _bundle_static_framework(ctx, is_extension_safe, outputs):
     """Returns bundle info for a static framework commonly used intra-build"""
     infoplist = _merge_root_infoplists(ctx)
 
     current_apple_platform = transition_support.current_apple_platform(apple_fragment = ctx.fragments.apple, xcode_config = ctx.attr._xcode_config)
+
+    partial_output = partial.call(
+        partials.extension_safe_validation_partial(
+            is_extension_safe = is_extension_safe,
+            rule_label = ctx.label,
+            targets_to_validate = ctx.attr.frameworks,
+        ),
+    )
 
     # Static packaging - archives are passed from library deps
     return struct(files = depset([]), providers = [
@@ -789,7 +806,7 @@ def _bundle_static_framework(ctx, outputs):
             product_type = ctx.attr._product_type,
             uses_swift = outputs.swiftmodule != None,
         ),
-    ])
+    ] + partial_output.providers)
 
 def _apple_framework_packaging_impl(ctx):
     # The current build architecture
@@ -797,6 +814,11 @@ def _apple_framework_packaging_impl(ctx):
 
     # The current Apple platform type, such as iOS, macOS, tvOS, or watchOS
     platform = str(ctx.fragments.apple.single_arch_platform.platform_type)
+
+    # Use 'library_linkopts' to determine if resulting binary should be application extension safe.
+    # This allows manual `linkopts` OR `xcconfig` in the upstream `apple_library` implementation
+    # to pass in the right value to the packaging step in this rule.
+    is_extension_safe = "-fapplication-extension" in ctx.attr.library_linkopts
 
     # When building with multiple architectures (e.g.,
     # --ios_multi_cpus=x86_64,arm64), we should only pick the slice for the
@@ -862,10 +884,10 @@ def _apple_framework_packaging_impl(ctx):
 
     # If we link dynamic - then package it as dynamic
     if ctx.attr.link_dynamic:
-        bundle_outs = _bundle_dynamic_framework(ctx, avoid_deps = avoid_deps)
+        bundle_outs = _bundle_dynamic_framework(ctx, is_extension_safe = is_extension_safe, avoid_deps = avoid_deps)
         avoid_deps_info = AvoidDepsInfo(libraries = depset(avoid_deps + ctx.attr.deps).to_list(), link_dynamic = True)
     else:
-        bundle_outs = _bundle_static_framework(ctx, outputs = outputs)
+        bundle_outs = _bundle_static_framework(ctx, is_extension_safe = is_extension_safe, outputs = outputs)
         avoid_deps_info = AvoidDepsInfo(libraries = depset(avoid_deps).to_list(), link_dynamic = False)
     swift_info = _get_merged_swift_info(ctx, framework_files, transitive_deps)
 
@@ -917,6 +939,11 @@ apple_framework_packaging = rule(
             allow_files = True,
             doc =
                 """Objc or Swift rules to be packed by the framework rule
+""",
+        ),
+        "library_linkopts": attr.string_list(
+            doc = """
+A list of strings representing extra flags that should be passed to the linker.
 """,
         ),
         "link_dynamic": attr.bool(

--- a/rules/internal/framework_middleman.bzl
+++ b/rules/internal/framework_middleman.bzl
@@ -106,7 +106,7 @@ def _framework_middleman(ctx):
             rule_label = ctx.label,
             # Pass 'ctx.attr.framework_deps' once 'partials.extension_safe_validation_partial'
             # is populated on from 'apple_framework_packaging' implementation.
-            targets_to_validate = [],
+            targets_to_validate = ctx.attr.framework_deps,
         ),
     )
 

--- a/rules/test/output/output_checker.sh
+++ b/rules/test/output/output_checker.sh
@@ -15,17 +15,30 @@ fi
 
 STATUS=0
 
-expect_output() {
-   echo "TEST $1"
-   if [[ ! -e "$1" ]]; then 
-     echo "Missing output $1"
-     STATUS=1
+check_expected_output() {
+    echo "TEST EXPECTED $1"
+    if [[ ! -e "$1" ]]; then 
+        echo "Missing output $1"
+        STATUS=1
    fi
 }
 
 EXPECT=%EXPECT%
 for f in ${EXPECT[@]}; do
-    expect_output "$f"
+    check_expected_output "$f"
+done
+
+check_unxpected_output() {
+    echo "TEST UNEXPECTED $1"
+    if [[ -e "$1" ]]; then 
+        echo "Has unexpected output $1"
+        STATUS=1
+   fi
+}
+
+UNEXPECT=%UNEXPECT%
+for f in ${UNEXPECT[@]}; do
+    check_unxpected_output "$f"
 done
 
 # Dump the directory to better diagnose a failure

--- a/rules/test/output/output_test.bzl
+++ b/rules/test/output/output_test.bzl
@@ -15,7 +15,8 @@ def _output_test_impl(ctx):
         is_executable = True,
         substitutions = {
             "%TARGET%": target_file.short_path,
-            "%EXPECT%": "( " + " ".join(ctx.attr.expect) + " )",
+            "%EXPECT%": "( " + " ".join(ctx.attr.expected) + " )",
+            "%UNEXPECT%": "( " + " ".join(ctx.attr.unexpected) + " )",
         },
     )
     return [DefaultInfo(runfiles = ctx.runfiles(files = ctx.attr.target[DefaultInfo].files.to_list()))]
@@ -26,10 +27,11 @@ output_test = rule(
     attrs = {
         "target": attr.label(),
         "output_checker": attr.label(default = "//rules/test/output:output_checker.sh", allow_single_file = True),
-        "expect": attr.string_list(mandatory = True),
+        "expected": attr.string_list(mandatory = True),
+        "unexpected": attr.string_list(mandatory = False, default = []),
     },
     doc = """
-    Basic test runner you can add expectations on output. feeds target and
-expect to the template
+    Basic test runner you can add expectations on output. feeds target,
+expected, and unexpected to the template
      """,
 )

--- a/tests/ios/app/BUILD.bazel
+++ b/tests/ios/app/BUILD.bazel
@@ -392,7 +392,7 @@ ios_application(
 
 output_test(
     name = "AppWithSelectableCopts_output_test",
-    expect = [
+    expected = [
         "LaunchScreen.storyboardc",
         "Info.plist",
         "AppWithSelectableCopts",

--- a/tests/ios/extensions/BUILD.bazel
+++ b/tests/ios/extensions/BUILD.bazel
@@ -15,3 +15,19 @@ ios_extension(
         "//tests/ios/app:FW",
     ],
 )
+
+ios_extension(
+    name = "ExampleExtensionWithDylibs",
+    bundle_id = "com.example.app.example-extension",
+    families = [
+        "iphone",
+    ],
+    infoplists = [
+        "ExampleExtension/Info.plist",
+    ],
+    minimum_os_version = "10.0",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tests/ios/frameworks/dynamic/a",
+    ],
+)

--- a/tests/ios/frameworks/dynamic/BUILD.bazel
+++ b/tests/ios/frameworks/dynamic/BUILD.bazel
@@ -15,6 +15,22 @@ ios_application(
     ],
 )
 
+ios_application(
+    name = "AppWithExtension",
+    srcs = ["App/main.m"],
+    bundle_id = "com.example.app",
+    executable_name = "App",
+    extensions = [
+        "//tests/ios/extensions:ExampleExtensionWithDylibs",
+    ],
+    minimum_os_version = "10.0",
+    visibility = ["//visibility:public"],
+    # This should automatically bake in a,b
+    deps = [
+        "//tests/ios/frameworks/dynamic/a",
+    ],
+)
+
 apple_xcframework(
     name = "iOSSwiftXCFramework",
     bundle_id = "com.google.example",
@@ -63,27 +79,43 @@ ios_unit_test(
     ],
 )
 
+SHARED_APP_EXPECTATIONS = [
+    "LaunchScreen.storyboardc",
+    "Info.plist",
+    "App",
+    "Frameworks/a.framework/a",
+    "Frameworks/a.framework/Info.plist",
+
+    # Assertions for B - see that transitive data is packed here
+    "Frameworks/b.framework/b",
+    "Frameworks/b.framework/b_data.txt",
+    "Frameworks/b.framework/c_data.txt",
+    "Frameworks/b.framework/Info.plist",
+]
+
 output_test(
     name = "App_output_test",
-    expect = [
-        "LaunchScreen.storyboardc",
-        "Info.plist",
-        "App",
-        "Frameworks/a.framework/a",
-        "Frameworks/a.framework/Info.plist",
-
-        # Assertions for B - see that transitive data is packed here
-        "Frameworks/b.framework/b",
-        "Frameworks/b.framework/b_data.txt",
-        "Frameworks/b.framework/c_data.txt",
-        "Frameworks/b.framework/Info.plist",
-    ],
+    expected = SHARED_APP_EXPECTATIONS,
     target = ":App",
 )
 
 output_test(
+    name = "AppWithExtension_output_test",
+    expected = SHARED_APP_EXPECTATIONS + [
+        # Assertions for extension
+        "PlugIns/ExampleExtensionWithDylibs.appex/ExampleExtensionWithDylibs",
+        "PlugIns/ExampleExtensionWithDylibs.appex/Info.plist",
+    ],
+    target = ":AppWithExtension",
+    unexpected = [
+        "PlugIns/ExampleExtensionWithDylibs.appex/Frameworks/a.framework/a",
+        "PlugIns/ExampleExtensionWithDylibs.appex/Frameworks/b.framework/b",
+    ],
+)
+
+output_test(
     name = "TestAppWithDylibs_output_test",
-    expect = [
+    expected = [
         "Frameworks/a.framework/a",
         "Frameworks/a.framework/Info.plist",
         # Assertions for B - see that transitive data is packed here

--- a/tests/ios/frameworks/dynamic/a/BUILD.bazel
+++ b/tests/ios/frameworks/dynamic/a/BUILD.bazel
@@ -8,5 +8,6 @@ apple_framework(
     link_dynamic = True,
     platforms = {"ios": "10.0"},
     visibility = ["//visibility:public"],
+    xcconfig = {"APPLICATION_EXTENSION_API_ONLY": "YES"},
     deps = ["//tests/ios/frameworks/dynamic/b"],
 )

--- a/tests/ios/frameworks/dynamic/b/BUILD.bazel
+++ b/tests/ios/frameworks/dynamic/b/BUILD.bazel
@@ -9,5 +9,6 @@ apple_framework(
     link_dynamic = True,
     platforms = {"ios": "10.0"},
     visibility = ["//visibility:public"],
+    xcconfig = {"APPLICATION_EXTENSION_API_ONLY": "YES"},
     deps = ["//tests/ios/frameworks/dynamic/c"],
 )


### PR DESCRIPTION
# Summary
Continuation of https://github.com/bazel-ios/rules_ios/pull/507 the adds tests + populates the partials in the "correct" way:
- Add `executable_name` as a forward param to `ios_application` to change the underlying app binary name.
- Forward the `-fapplication-extension` linker flag within `_bundle_dynamic_framework` signaled by checking for `-fapplication-extension` in the underlying library's `linkopts`.
- Ensure the `_bundle_static_framework` has the proper `extension_safe_validation_partial` call as well despite it being linked differently where it's unlikely to be necessary.
- Update `output_test` to be able to confirm that files don't exist in `target`'s output as well.
- Add `//tests/ios/frameworks/dynamic:AppWithExtension_output_test` to confirm that the dependent dynamic frameworks aren't duplicated into the extension `appex` as well as the `.app` root.

# Testing
Make `//tests/ios/frameworks/dynamic/a` not extension safe and build `//tests/ios/extensions:ExampleExtensionWithDylibs` to test message:
```
$ bazelisk build //tests/ios/extensions:ExampleExtensionWithDylibs
DEBUG: /private/var/tmp/_bazel_matt.robinson/0e64031a9efbb95e4728094ee9457143/external/build_bazel_rules_apple/apple/internal/partials/extension_safe_validation.bzl:42:22: The target //tests/ios/extensions:ExampleExtensionWithDylibs.framework_middleman is for an extension but its framework dependency //tests/ios/frameworks/dynamic/a:a is not marked extension-safe. Specify 'extension_safe = 1' on the framework target. This will soon cause a build failure.
...
```