### PR TITLE
Add ability to `link_dynamic` via `select`

### DIFF
--- a/rules/force_load_direct_deps.bzl
+++ b/rules/force_load_direct_deps.bzl
@@ -1,27 +1,28 @@
 load("//rules:providers.bzl", "AvoidDepsInfo")
 
 def _impl(ctx):
+    if not ctx.attr.should_force_load:
+        return apple_common.new_objc_provider()
+
     force_load = []
 
-    if ctx.attr.should_force_load:
-        avoid_deps = []
-        for dep in ctx.attr.deps:
-            if AvoidDepsInfo in dep:
-                avoid_deps.extend(dep[AvoidDepsInfo].libraries)
+    avoid_deps = []
+    for dep in ctx.attr.deps:
+        if AvoidDepsInfo in dep:
+            avoid_deps.extend(dep[AvoidDepsInfo].libraries)
 
-        avoid_libraries = {}
-        for dep in avoid_deps:
-            if apple_common.Objc in dep:
-                for lib in dep[apple_common.Objc].library.to_list():
-                    avoid_libraries[lib] = True
+    avoid_libraries = {}
+    for dep in avoid_deps:
+        if apple_common.Objc in dep:
+            for lib in dep[apple_common.Objc].library.to_list():
+                avoid_libraries[lib] = True
 
-        force_load = []
-        for dep in ctx.attr.deps:
-            if apple_common.Objc in dep:
-                for lib in dep[apple_common.Objc].library.to_list():
-                    if not lib in avoid_libraries:
-                        force_load.append(lib)
-
+    force_load = []
+    for dep in ctx.attr.deps:
+        if apple_common.Objc in dep:
+            for lib in dep[apple_common.Objc].library.to_list():
+                if not lib in avoid_libraries:
+                    force_load.append(lib)
     return apple_common.new_objc_provider(
         force_load_library = depset(force_load),
         link_inputs = depset(force_load),

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -68,11 +68,18 @@ def apple_framework(name, apple_library = apple_library, **kwargs):
 
     library = apple_library(name = name, **kwargs)
     framework_deps = []
-    if framework_packaging_kwargs.get("link_dynamic") == True:
-        # Setup force loading here - only for direct deps / direct libs
-        force_load_name = name + ".force_load_direct_deps"
-        force_load_direct_deps(name = force_load_name, deps = kwargs.get("deps", []) + library.lib_names, tags = ["manual"])
-        framework_deps.append(force_load_name)
+
+    # Setup force loading here - only for direct deps / direct libs and when `link_dynamic` is set.
+    force_load_name = name + ".force_load_direct_deps"
+    force_load_direct_deps(
+        name = force_load_name,
+        deps = kwargs.get("deps", []) + library.lib_names,
+        should_force_load = framework_packaging_kwargs.get("link_dynamic", False),
+        testonly = kwargs.get("testonly", False),
+        tags = ["manual"],
+    )
+    framework_deps.append(force_load_name)
+
     framework_deps += library.lib_names
     platforms = library.platforms if library.platforms else {}
     apple_framework_packaging(


### PR DESCRIPTION
# Summary
To enable `link_dynamic` to be set via a `select`, shift the choice to force load or not into the implementation of the `force_load_direct_deps` rule. `should_force_load` should be set to `False` when there should be no additional `-force_load` linker args.