### PR TITLE
Fix bug in unarchive function for m1 

### DIFF
--- a/tools/m1_utils/update_static.sh
+++ b/tools/m1_utils/update_static.sh
@@ -17,8 +17,6 @@ unarchive() {
        return 0
     fi
 
-    echo "hiasdhiashdoiqwhe"
-    echo "asdoiqwhe oihqweoi hqwoieh oiqwhe "
     uniq -D -i objs.txt > duplicate_objs.txt
     i=0
     while IFS=\\\n read -r var; do

--- a/tools/m1_utils/update_static.sh
+++ b/tools/m1_utils/update_static.sh
@@ -10,29 +10,24 @@ unarchive() {
 
     rm -rf *.o 
     ar -x "$FILE" 
-    ar t "$FILE" | grep \.o$ | sort > objs.txt
+    ar t "$FILE" | grep \.o$ | sort --ignore-case > objs.txt
 
     # Assume default extraction strategy is OK if no dupes
-    if [[ -z "$(uniq -d objs.txt)" ]]; then
+    if [[ -z "$(uniq -di objs.txt)" ]]; then
        return 0
     fi
 
+    echo "hiasdhiashdoiqwhe"
+    echo "asdoiqwhe oihqweoi hqwoieh oiqwhe "
+    uniq -D -i objs.txt > duplicate_objs.txt
     i=0
-    LAST_OBJ=""
     while IFS=\\\n read -r var; do
         OBJ="$var"
-        if [[ ! "$LAST_OBJ" == "$OBJ" ]]; then
-            LAST_OBJ="$OBJ"
-            continue
-        fi
-        LAST_OBJ="$OBJ"
-
         (( i+=1 ))
         ar -p "$FILE" "$OBJ"  > "$i-$OBJ"
-
         # Note that this operation is slow, consider moving duplicates
         ar -d "$FILE" "$OBJ"
-    done < objs.txt
+    done < duplicate_objs.txt
 }
 
 

--- a/tools/m1_utils/update_static.sh
+++ b/tools/m1_utils/update_static.sh
@@ -17,9 +17,7 @@ unarchive() {
        return 0
     fi
 
-    uniq -D -i objs.txt > duplicate_objs.txt
     i=0
-
     # Unarchive the dupes only because we have already extracted the non dupes with ar
     while IFS=\\\n read -r var; do
         OBJ="$var"

--- a/tools/m1_utils/update_static.sh
+++ b/tools/m1_utils/update_static.sh
@@ -10,15 +10,17 @@ unarchive() {
 
     rm -rf *.o 
     ar -x "$FILE" 
-    ar t "$FILE" | grep \.o$ | sort --ignore-case > objs.txt
+    ar t "$FILE" | grep \.o$ | sort --ignore-case | uniq -D -i > duplicate_objs.txt
 
     # Assume default extraction strategy is OK if no dupes
-    if [[ -z "$(uniq -di objs.txt)" ]]; then
+    if [[ -z duplicate_objs.txt ]]; then
        return 0
     fi
 
     uniq -D -i objs.txt > duplicate_objs.txt
     i=0
+
+    # Unarchive the dupes only because we have already extracted the non dupes with ar
     while IFS=\\\n read -r var; do
         OBJ="$var"
         (( i+=1 ))


### PR DESCRIPTION
Building Apps with Bazel for Apple Silicon invokes conversion from arm64 binary to arm64 simulator binary. Unarchiving the binary file has a bug where when an archive file has distinct objects with names that are only different in casing, the extracted contents are incorrect (e.g. `lib_test.a` has `test.cpp.o` and and `TEST.cpp.o`, running using `ar` to extract objects, `ar -x`, content for the `TEST.cpp.o` is overwritten by that of `test.cpp.o` ). 

**Changes**
1. Handle the edge case described above
2. Simply the existing logic using `uniq`