### PR TITLE
Provide executable_name for AppleBundleInfo and static frameworks

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -797,6 +797,8 @@ def _bundle_static_framework(ctx, is_extension_safe, outputs):
         ),
     )
 
+    executable_name = bundling_support.executable_name(ctx)
+
     # Static packaging - archives are passed from library deps
     return struct(files = depset([]), providers = [
         AppleBundleInfo(
@@ -807,6 +809,7 @@ def _bundle_static_framework(ctx, is_extension_safe, outputs):
             bundle_name = ctx.attr.framework_name,
             bundle_extension = ctx.attr.bundle_extension,
             entitlements = None,
+            executable_name = executable_name,
             infoplist = infoplist,
             minimum_os_version = str(current_apple_platform.target_os_version),
             minimum_deployment_os_version = ctx.attr.minimum_deployment_os_version,


### PR DESCRIPTION
## Summary

`AppleBundleInfo` has an `executable_name` we are not passing for static frameworks, this is properly passed for dynamic frameworks however.

This is part of getting `rules_xcodeproj` to work with `rules_ios`, see more info here: https://github.com/buildbuddy-io/rules_xcodeproj/issues/779