### PR TITLE
Provide minimum_deployment_os_version for AppleBundleInfo and static …

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -809,6 +809,7 @@ def _bundle_static_framework(ctx, is_extension_safe, outputs):
             entitlements = None,
             infoplist = infoplist,
             minimum_os_version = str(current_apple_platform.target_os_version),
+            minimum_deployment_os_version = ctx.attr.minimum_deployment_os_version,
             platform_type = str(current_apple_platform.platform.platform_type),
             product_type = ctx.attr._product_type,
             uses_swift = outputs.swiftmodule != None,


### PR DESCRIPTION
## Summary

`AppleBundleInfo` has an `minimum_deployment_os_version` we are not passing for static frameworks.

This is part of getting `rules_xcodeproj` to work with `rules_ios`, see more info here: https://github.com/buildbuddy-io/rules_xcodeproj/issues/779