### PR TITLE
Fix analysis failure when providing `data` targets that are marked `testonly`

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -841,7 +841,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
     if swift_version:
         additional_swift_copts += ["-swift-version", swift_version]
 
-    module_data = library_tools["wrap_resources_in_filegroup"](name = module_name + "_data", srcs = data)
+    module_data = library_tools["wrap_resources_in_filegroup"](name = module_name + "_data", srcs = data, testonly = kwargs.get("testonly", False),)
 
     if swift_sources:
         additional_swift_copts.extend(("-Xcc", "-I."))

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -841,7 +841,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
     if swift_version:
         additional_swift_copts += ["-swift-version", swift_version]
 
-    module_data = library_tools["wrap_resources_in_filegroup"](name = module_name + "_data", srcs = data, testonly = kwargs.get("testonly", False),)
+    module_data = library_tools["wrap_resources_in_filegroup"](name = module_name + "_data", srcs = data, testonly = kwargs.get("testonly", False))
 
     if swift_sources:
         additional_swift_copts.extend(("-Xcc", "-I."))

--- a/tests/ios/frameworks/testonly/BUILD.bazel
+++ b/tests/ios/frameworks/testonly/BUILD.bazel
@@ -7,6 +7,9 @@ apple_framework(
     srcs = glob(["SwiftLibrary/**/*.swift"]),
     module_name = "SwiftLibrary",
     visibility = ["//visibility:public"],
+    data = [
+        ":TestOnlyFixture",
+    ],
 )
 
 apple_framework(
@@ -45,4 +48,11 @@ ios_unit_test(
     name = "MixedSourceTest",
     minimum_os_version = "12.0",
     deps = [":MixedSourceTestLib"],
+)
+
+genrule(
+    name = "TestOnlyFixture",
+    outs = ["fixture.txt"],
+    cmd = "touch $@",
+    testonly = True,
 )

--- a/tests/ios/frameworks/testonly/BUILD.bazel
+++ b/tests/ios/frameworks/testonly/BUILD.bazel
@@ -5,11 +5,11 @@ apple_framework(
     name = "SwiftLibrary",
     testonly = True,
     srcs = glob(["SwiftLibrary/**/*.swift"]),
-    module_name = "SwiftLibrary",
-    visibility = ["//visibility:public"],
     data = [
         ":TestOnlyFixture",
     ],
+    module_name = "SwiftLibrary",
+    visibility = ["//visibility:public"],
 )
 
 apple_framework(
@@ -52,7 +52,7 @@ ios_unit_test(
 
 genrule(
     name = "TestOnlyFixture",
+    testonly = True,
     outs = ["fixture.txt"],
     cmd = "touch $@",
-    testonly = True,
 )


### PR DESCRIPTION
Follow up to https://github.com/bazel-ios/rules_ios/pull/469 that propagates `testonly` to the `{module name}_data` target when the parent framework has resources.