### PR TITLE
[m1_utils] Fix -D not available to uniq

### DIFF
--- a/tools/m1_utils/update_static.sh
+++ b/tools/m1_utils/update_static.sh
@@ -10,7 +10,21 @@ unarchive() {
 
     rm -rf *.o 
     ar -x "$FILE" 
-    ar t "$FILE" | grep \.o$ | sort --ignore-case | uniq -D -i > duplicate_objs.txt
+    ar t "$FILE" | grep \.o$ | sort --ignore-case > objs.txt
+
+    # What this awk command does:
+    # ------------------------
+    # count = {} # define empty dictionary count
+    # if NR == FNR: #if first time iterating through objs.txt
+    #     for line in the objs.txt: 
+    #         count[lowercase(line)] += 1  # count the number of times each line showed up in the file (case insensitive)
+    #         continue 
+    # else: 
+    #     for line in the objs.txt: 
+    #         if count[lowercase(line)] > 1: 
+    #             print(line, dest=duplicate_objs.txt) # print only when this has appear more than once in objs.txt (case insensitive)
+    # ------------------------
+    awk 'NR==FNR {count[tolower($0)]++; next} count[tolower($0)]>1' objs.txt objs.txt > duplicate_objs.txt
 
     # Assume default extraction strategy is OK if no dupes
     if [[ -z duplicate_objs.txt ]]; then


### PR DESCRIPTION
**Background**
-D option is recently added to `uniq` tool, so change the code compatible to old Mac OS versions. 

**Explanation about the awk command used in this PR**

A few notes:
- awk will iterate objs.txt two times because objs.txt is input-ed twice.
- NR==FNR (FNR refers to the record/line number in the current file, NR refers to the total record/line number. ) is true only when iterating the objs.txt the first time, because FNR resets to 0 for each file, whereas NR keeps incrementing without resetting.
- each line of a file objs.txt is a name of an object (e.g. GL.cpp.o)

And here's the pseudocode of what this `awk command(awk 'NR==FNR {count[tolower($0)]++; next} count[tolower($0)]>1' objs.txt objs.txt > duplicate_objs.txt)` does:

```
count = {} # define empty dictionary count
if NR == FNR: #if first time iterating through objs.txt
    for line in the objs.txt: 
        count[lowercase(line)] += 1  # count the number of times each line showed up in the file (case insensitive)
        continue 
else: 
    for line in the objs.txt: 
        if count[lowercase(line)] > 1: 
            print(line, dest=duplicate_objs.txt) # print only when this has appear more than once in objs.txt (case insensitive)
```