### PR TITLE
Improve xcframework compatibility with `--incompatible_disallow_empty_glob`

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -286,9 +286,11 @@ def _xcframework_slice(*, xcframework_name, identifier, platform, platform_varia
     )
     import_module_maps = native.glob(
         ["%s/**/*.modulemap" % path],
+        allow_empty = True,
     )
     import_swiftmodules = native.glob(
         ["%s/**/*.swiftmodule/*.*" % path],
+        allow_empty = True,
     )
     if len(import_module_maps) > 0:
         import_module_map = import_module_maps[0]
@@ -565,9 +567,11 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
         )
         import_module_maps = native.glob(
             ["%s/**/*.modulemap" % vendored_static_framework],
+            allow_empty = True,
         )
         import_swiftmodules = native.glob(
             ["%s/**/*.swiftmodule/*.*" % vendored_static_framework],
+            allow_empty = True,
         )
         vfs_root = vendored_static_framework
         if len(import_module_maps) > 0:
@@ -607,9 +611,11 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
         )
         import_module_maps = native.glob(
             ["%s/**/*.modulemap" % vendored_dynamic_framework],
+            allow_empty = True,
         )
         import_swiftmodules = native.glob(
             ["%s/**/*.swiftmodule/*.*" % vendored_dynamic_framework],
+            allow_empty = True,
         )
         if len(import_module_maps) > 0:
             import_module_map = import_module_maps[0]
@@ -645,9 +651,11 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
         )
         import_module_maps = native.glob(
             ["**/*.modulemap"],
+            allow_empty = True,
         )
         import_swiftmodules = native.glob(
             ["**/*.swiftmodule/*.*"],
+            allow_empty = True,
         )
         if len(import_module_maps) > 0:
             import_module_map = import_module_maps[0]


### PR DESCRIPTION
Improve xcframework compatibility with `--incompatible_disallow_empty_glob` by explicitly allowing empty results.

- `*.swiftmodule/*.*` doesn't match anything in a 100% Obj-C framework
- I applied the same change to `*.modulemap` for frameworks that would end up failing the `len(import_module_maps) > 0` check just below.