### PR TITLE
Fix cp invocation bugs for gnu coreutils

### DIFF
--- a/tools/xcodeproj_shims/xcodeproj-installer.sh
+++ b/tools/xcodeproj_shims/xcodeproj-installer.sh
@@ -2,7 +2,8 @@
 
 # Copies the xcodeproject from the bazel output directory to the BAZEL_WORKSPACE directory when ran
 set -euo pipefail
-readonly project_path="${PWD}/$(project_short_path)"
+# project_path is a symlink and must have the trailing slash for coreutils cp.
+readonly project_path="${PWD}/$(project_short_path)/"
 readonly dest="${BUILD_WORKSPACE_DIRECTORY}/$(project_short_path)/"
 readonly tmp_dest=$(mktemp -d)/$(project_full_path)/
 

--- a/tools/xcodeproj_shims/xcodeproj-installer.sh
+++ b/tools/xcodeproj_shims/xcodeproj-installer.sh
@@ -39,7 +39,7 @@ build_wrapper_runfile_short_paths="$(build_wrapper_runfile_short_paths)"
 for BUILD_WRAPPER_PATH in $build_wrapper_runfile_short_paths
 do
   # coreutils cp must have -L to follow symlinks (mac's cp will do it with -r).
-  cp -Lr "$BUILD_WRAPPER_PATH" "${stubs_dir}/"
+  cp -LR "$BUILD_WRAPPER_PATH" "${stubs_dir}/"
 done
 
 cp "$(clang_stub_short_path)" "${stubs_dir}/clang-stub"

--- a/tools/xcodeproj_shims/xcodeproj-installer.sh
+++ b/tools/xcodeproj_shims/xcodeproj-installer.sh
@@ -38,7 +38,8 @@ cp "$(installer_short_path)" "${installers_dir}/"
 build_wrapper_runfile_short_paths="$(build_wrapper_runfile_short_paths)"
 for BUILD_WRAPPER_PATH in $build_wrapper_runfile_short_paths
 do
-  cp -r "$BUILD_WRAPPER_PATH" "${stubs_dir}/"
+  # coreutils cp must have -L to follow symlinks (mac's cp will do it with -r).
+  cp -Lr "$BUILD_WRAPPER_PATH" "${stubs_dir}/"
 done
 
 cp "$(clang_stub_short_path)" "${stubs_dir}/clang-stub"


### PR DESCRIPTION
Gnu coreutils' cp (often installed with brew or nix) behaves slightly differently from mac's cp. Coreutils cp will not copy the contents of a symlink unless the src has a trailing slash, so we add one in this PR. Coreutils cp also will not follow symlinks with -r, unless -L is also passed, so we add -L.

I compared the resulting behavior of these invocations to confirm that 1) the coreutils cp behavior matches mac's behavior, and 2) mac cp behavior didn't change.