### PR TITLE
Request for talks for first annual open Bazel-iOS con

### DIFF
--- a/docs/2022_bazel_ios_con.md
+++ b/docs/2022_bazel_ios_con.md
@@ -1,0 +1,19 @@
+# Bazel-iOS Con 2022: open call for presentations - RSVPs
+
+Congratulations everyone 🎉! 2022 is turning out to be the year of Bazel-iOS.
+We've done a ton of amazing work and are accelerating iOS development at scale.
+I formally invite you to join us for a day of open community, fun, and low level
+iOS build talks.
+
+The event will be held September 29th in San Francisco, CA from 10:00AM -
+5:00PST. We're solidifying the location and minor details. One benefit of the
+event is getting everyone together IRL. We'll also have remote speakers and a
+recording of talks where approved. To put it bluntly - we want to share the
+amazing work we've done with the world!
+
+This is an _open_ call for talks - _especially for contributors 😊_. Please send
+@jerrymarino a quick description of your proposed talk by September 1st - e.g.
+directly or email to jmarino@squaruep.com. If you're not doing a talk - we
+invite you to come and enjoy the show. Please send an RVSP to @jerrymarino in
+some capacity for you _and your teams_. We'll post a general invitation for
+guests soon.

--- a/docs/2022_bazel_ios_con.md
+++ b/docs/2022_bazel_ios_con.md
@@ -13,7 +13,7 @@ amazing work we've done with the world!
 
 This is an _open_ call for talks - _especially for contributors 😊_. Please send
 @jerrymarino a quick description of your proposed talk by September 1st - e.g.
-directly or email to jmarino@squaruep.com. If you're not doing a talk - we
+directly or email to jmarino@squareup.com. If you're not doing a talk - we
 invite you to come and enjoy the show. Please send an RVSP to @jerrymarino in
 some capacity for you _and your teams_. We'll post a general invitation for
 guests soon.


### PR DESCRIPTION
Congratulations everyone 🎉! 2022 is turning out to be the year of Bazel-iOS.
We've done a ton of amazing work and are accelerating iOS development at scale.
I formally invite you to join us for a day of open community, fun, and low level
iOS build talks.

The event will be held September 29th in San Francisco, CA from 10:00AM -
5:00PST. We're solidifying the location and minor details. One benefit of the
event is getting everyone together IRL. We'll also have remote speakers and a
recording of talks where approved. To put it bluntly - we want to share the
amazing work we've done with the world!

This is an _open_ call for talks - _especially for contributors 😊_. Please send
@jerrymarino a quick description of your proposed talk by September 1st - e.g.
directly or email to jmarino@squaruep.com. If you're not doing a talk - we
invite you to come and enjoy the show. Please send an RVSP to @jerrymarino in
some capacity for you _and your teams_. We'll post a general invitation for
guests soon.
