### PR TITLE
Fix invalid byte sequence error in ruby (second take)

### DIFF
--- a/tools/xcodeproj_shims/output-processor.rb
+++ b/tools/xcodeproj_shims/output-processor.rb
@@ -7,7 +7,8 @@ class BazelOutputLine
 
   def initialize(line)
     # Otherwise we might get `invalid byte sequence in US-ASCII (ArgumentError)` during matching with regex
-    @text = line.encode("UTF-8", invalid: :replace, undef: :replace)
+
+    @text = line.encode("US-ASCII", invalid: :replace, undef: :replace, replace: '')
   end
 
   # Try to create a processed line based on a match rule, or a pass-through
@@ -41,7 +42,7 @@ class StarlarkLine < RegexMatchLine
 
     super(line)
 
-    return unless (@match_data = line.match(@regex))
+    return unless (@match_data = @text.match(@regex))
 
     message_type, starlark_file, file_ext, file_line, message = @match_data.captures
 
@@ -62,7 +63,7 @@ class CompilerMessageLine < RegexMatchLine
 
     super(line)
 
-    return unless (@match_data = line.match(@regex))
+    return unless (@match_data = @text.match(@regex))
 
     _, file_path, error_level, message = match_data.captures
     expanded_file_path = File.expand_path(file_path, BAZEL_WORKSPACE)


### PR DESCRIPTION
1. explicitly set replace to be using empty string
2. fix stilling tring to call match against the raw inpue (line) not (@text)
Test done: red green via an existing dev that run into problem on their local machine