### PR TITLE
[Buildfarm][AppleSilicon] Make import_middleman hermetic

### DIFF
--- a/rules/import_middleman.bzl
+++ b/rules/import_middleman.bzl
@@ -261,9 +261,7 @@ def _file_collector_rule_impl(ctx):
         additional_providers.append(cc_info)
     else:
         cc_info = objc_provider_utils.merge_cc_info_providers(
-            ctx=ctx,
-            cc_info_providers = [dep[CcInfo] for dep in ctx.attr.deps],
-            # merge_keys = ,
+            cc_info_providers = [dep[CcInfo] for dep in ctx.attr.deps if CcInfo in dep],
         )
         additional_providers.append(cc_info)
 

--- a/rules/import_middleman.bzl
+++ b/rules/import_middleman.bzl
@@ -31,7 +31,6 @@ def _update_framework(ctx, framework):
         outputs = [out_dir, out_file],
         inputs = depset([framework] + ctx.attr.update_in_place[DefaultInfo].default_runfiles.files.to_list()),
         command = cmd,
-        execution_requirements = {"no-remote": "1"},
     )
     return out_file
 
@@ -258,6 +257,13 @@ def _file_collector_rule_impl(ctx):
     if not virtualize_frameworks:
         dep_cc_infos = [dep[CcInfo] for dep in ctx.attr.deps if CcInfo in dep]
         cc_info = cc_common.merge_cc_infos(direct_cc_infos = [], cc_infos = dep_cc_infos)
+        additional_providers.append(cc_info)
+    else:
+        cc_info = objc_provider_utils.merge_cc_info_providers(
+            ctx=ctx,
+            cc_info_providers = [dep[CcInfo] for dep in ctx.attr.deps],
+            # merge_keys = ,
+        )
         additional_providers.append(cc_info)
 
     return [

--- a/rules/import_middleman.bzl
+++ b/rules/import_middleman.bzl
@@ -31,6 +31,7 @@ def _update_framework(ctx, framework):
         outputs = [out_dir, out_file],
         inputs = depset([framework] + ctx.attr.update_in_place[DefaultInfo].default_runfiles.files.to_list()),
         command = cmd,
+        execution_requirements = {"no-remote": "1"},
     )
     return out_file
 

--- a/rules/internal/objc_provider_utils.bzl
+++ b/rules/internal/objc_provider_utils.bzl
@@ -55,9 +55,30 @@ def _merge_dynamic_framework_providers(ctx, dynamic_framework_providers):
 
     return apple_common.new_dynamic_framework_provider(**fields)
 
+def _merge_cc_info_providers(ctx, cc_info_providers):
+    fields = {}
+    merge_keys = [
+        "headers",
+        #"framework_files",
+    ]
+    for key in merge_keys:
+        set = depset(
+            direct = [],
+            # Note:  we may want to merge this with the below inputs?
+            transitive = [getattr(dep.compilation_context, key) for dep in cc_info_providers],
+        )
+        _add_to_dict_if_present(fields, key, set)
+
+    # We don't use this on Bazel 4-5 for now
+    linking_context = cc_common.create_linking_context(linker_inputs = depset())
+    compilation_context = cc_common.create_compilation_context(**fields)
+    return CcInfo(compilation_context = compilation_context, linking_context = linking_context) 
+
+
 objc_provider_utils = struct(
     merge_objc_providers_dict = _merge_objc_providers_dict,
     merge_objc_providers = _merge_objc_providers,
+    merge_cc_info_providers = _merge_cc_info_providers,
     merge_dynamic_framework_providers = _merge_dynamic_framework_providers,
     add_to_dict_if_present = _add_to_dict_if_present,
 )

--- a/rules/internal/objc_provider_utils.bzl
+++ b/rules/internal/objc_provider_utils.bzl
@@ -55,12 +55,10 @@ def _merge_dynamic_framework_providers(ctx, dynamic_framework_providers):
 
     return apple_common.new_dynamic_framework_provider(**fields)
 
-def _merge_cc_info_providers(ctx, cc_info_providers):
+def _merge_cc_info_providers(cc_info_providers, merge_keys = [
+    "headers",
+]):
     fields = {}
-    merge_keys = [
-        "headers",
-        #"framework_files",
-    ]
     for key in merge_keys:
         set = depset(
             direct = [],
@@ -72,8 +70,7 @@ def _merge_cc_info_providers(ctx, cc_info_providers):
     # We don't use this on Bazel 4-5 for now
     linking_context = cc_common.create_linking_context(linker_inputs = depset())
     compilation_context = cc_common.create_compilation_context(**fields)
-    return CcInfo(compilation_context = compilation_context, linking_context = linking_context) 
-
+    return CcInfo(compilation_context = compilation_context, linking_context = linking_context)
 
 objc_provider_utils = struct(
     merge_objc_providers_dict = _merge_objc_providers_dict,


### PR DESCRIPTION
We weren't passing headers upwards to deps from the import middleman.
Fix the provider to make them hermetic