### PR TITLE
Add ability to split a test bundle.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Select Xcode 12.5.1
         run: .github/workflows/xcode_select.sh
       - name: Run tests
-        run: ./tests/xcodeproj-tests.sh --clean
+        run: ./tests/xcodeproj-tests.sh --clean && ./tests/test-tests.sh
       - uses: actions/upload-artifact@v2
         if: failure()
         with:

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -62,10 +62,10 @@ def rules_ios_dependencies():
     _maybe(
         github_repo,
         name = "build_bazel_rules_apple",
-        ref = "942c24380a6cb001d3521c510fdb9b61ee164585",
+        ref = "c17af58765d4903a8878d3d6c8004679de4fe8ab",
         project = "bazelbuild",
         repo = "rules_apple",
-        sha256 = "2556021318e6250e00039175e07196d9ae479993712f69047fd239f168f811ee",
+        sha256 = "45846e9da2f055065b99e066fd3e6e438085c81909e6203aedc8c2773819fe90",
     )
 
     _maybe(

--- a/tests/ios/unit-test/BUILD.bazel
+++ b/tests/ios/unit-test/BUILD.bazel
@@ -45,6 +45,22 @@ ios_unit_test(
 )
 
 ios_unit_test(
+    name = "SplitTests",
+    srcs = [
+        "empty.m",
+        "empty.swift",
+    ],
+    minimum_os_version = "10.0",
+    split_name_to_kwargs = {
+        "shard_1": {"test_filter": "EmptySwiftTests"},
+        "shard_2": {"test_filter": "EmptyTests"},
+    },
+    test_host = True,
+    # Adding visibility so the xcodeproject tests can depend on this target
+    visibility = ["//visibility:public"],
+)
+
+ios_unit_test(
     name = "NSPrincipalClassDefinedInPlist",
     srcs = [
         "TestSuiteObserver.swift",

--- a/tests/test-tests.sh
+++ b/tests/test-tests.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+## split tests
+test_suite_count=$(bazelisk query 'kind("test_suite", //tests/ios/unit-test:SplitTests)' | wc -l | xargs)
+if [[ "$test_suite_count" != "1" ]]; then
+  echo "Expected 1 test suite for split tests got $test_suite_count"
+  exit 1
+fi
+
+tests_count=$(bazelisk query 'tests(kind("test_suite", //tests/ios/unit-test:SplitTests))' | wc -l | xargs)
+if [[ "$tests_count" != "2" ]]; then
+  echo "More than 2 tests for split tests got $tests_count"
+  exit 1
+fi


### PR DESCRIPTION
This new macro allows for you to specify a way to "split" an identical bundle into multiple rules with different args for each. To do this you'd specify the different arguments you want to in each split. The suffix of each split will be specified by the key in the dictionary, the different args will be the value. These args will be merged with the ios_test_kwargs specified.

For instance if we have:
`split_ios_test(name = "Foo", split_name_to_kwargs {"MyTestHost1": {"test_host" : //MyTestHost1}, "MyTestHost2": {"test_host": //MyTestHost2}})`

Then target //Foo would have 2 test rules created. 1 named `//Foo_MyTestHost1` and `//Foo_MyTestHost2` and will be packaged together in a test suite of `//Foo`.

**NOTE**
Another possible way to get this similar effect without putting it right in rules_ios is to split out the creation of the test apple library into its own macro which folks could use to create the library and pass it into ios_unit_test