### PR TITLE
set index-import priority to lowest

### DIFF
--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -57,7 +57,7 @@ fi
 
 echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
-$BAZEL_INSTALLERS_DIR/index-import \
+nice -n 20 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \

--- a/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -57,7 +57,7 @@ fi
 
 echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
-$BAZEL_INSTALLERS_DIR/index-import \
+nice -n 20 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -57,7 +57,7 @@ fi
 
 echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
-$BAZEL_INSTALLERS_DIR/index-import \
+nice -n 20 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \

--- a/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -57,7 +57,7 @@ fi
 
 echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
-$BAZEL_INSTALLERS_DIR/index-import \
+nice -n 20 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/_indexstore.sh
@@ -57,7 +57,7 @@ fi
 
 echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
-$BAZEL_INSTALLERS_DIR/index-import \
+nice -n 20 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -57,7 +57,7 @@ fi
 
 echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
-$BAZEL_INSTALLERS_DIR/index-import \
+nice -n 20 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/_indexstore.sh
@@ -57,7 +57,7 @@ fi
 
 echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
-$BAZEL_INSTALLERS_DIR/index-import \
+nice -n 20 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/_indexstore.sh
@@ -57,7 +57,7 @@ fi
 
 echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
-$BAZEL_INSTALLERS_DIR/index-import \
+nice -n 20 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \

--- a/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -57,7 +57,7 @@ fi
 
 echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
-$BAZEL_INSTALLERS_DIR/index-import \
+nice -n 20 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/_indexstore.sh
@@ -57,7 +57,7 @@ fi
 
 echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
-$BAZEL_INSTALLERS_DIR/index-import \
+nice -n 20 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/_indexstore.sh
@@ -57,7 +57,7 @@ fi
 
 echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
-$BAZEL_INSTALLERS_DIR/index-import \
+nice -n 20 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/_indexstore.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/_indexstore.sh
@@ -57,7 +57,7 @@ fi
 
 echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
-$BAZEL_INSTALLERS_DIR/index-import \
+nice -n 20 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \

--- a/tools/xcodeproj_shims/installers/_indexstore.sh
+++ b/tools/xcodeproj_shims/installers/_indexstore.sh
@@ -57,7 +57,7 @@ fi
 
 echo "Running index-import for arch $ARCH and parallel-stride set to $PARALLEL_STRIDE"
 
-$BAZEL_INSTALLERS_DIR/index-import \
+nice -n 20 $BAZEL_INSTALLERS_DIR/index-import \
     -parallel-stride $PARALLEL_STRIDE \
     -incremental \
     -remap "$remote_developer_dir=$local_developer_dir" \


### PR DESCRIPTION
Sometimes when indexing, `index-import` eats all CPU and network resources, then the internet is cut out and the laptop is frozen. 

Setting `index-import` to the lowest priority can help with this problem. The CPU usage is still high but the laptop is responsive.