### PR TITLE
Enables C++ support in srcs

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -1022,14 +1022,15 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
         _append_headermap_copts(swift_angle_bracket_hmap_name, "-I", additional_objc_copts, additional_swift_copts, additional_cc_copts)
 
     # Note: this line is intentionally disabled
-    if cpp_sources and False:
+    if cpp_sources:
         additional_cc_copts.append("-I.")
-        native.cc_library(
+        native.objc_library(
             name = cpp_libname,
-            srcs = cpp_sources + objc_private_hdrs,
+            srcs = cpp_sources + objc_private_hdrs + objc_non_exported_hdrs,
             hdrs = objc_hdrs,
             copts = copts_by_build_setting.cc_copts + cc_copts + additional_cc_copts,
-            deps = deps,
+            deps = deps + private_deps,
+            defines = defines,
             tags = tags_manual,
             testonly = kwargs.get("testonly", False),
         )

--- a/tests/ios/frameworks/objcpp/BUILD.bazel
+++ b/tests/ios/frameworks/objcpp/BUILD.bazel
@@ -1,0 +1,56 @@
+load("//rules:framework.bzl", "apple_framework")
+load("//rules:test.bzl", "ios_unit_test")
+
+apple_framework(
+    name = "ObjCppMixedLib",
+    srcs = glob(
+        [
+            "ObjCppMixedLib/*.mm",
+            "ObjCppMixedLib/*.cpp",
+        ],
+    ),
+    objc_copts = [
+        "-fmodules",
+        "-fcxx-modules",
+    ],
+    platforms = {"ios": "10.0"},
+    public_headers = glob(
+        [
+            "ObjCppMixedLib/A.h",
+            "ObjCppMixedLib/B.hpp",
+        ],
+    ),
+    visibility = ["//visibility:public"],
+)
+
+apple_framework(
+    name = "ObjCLib",
+    srcs = glob(
+        [
+            "ObjCLib/*.m",
+        ],
+    ),
+    platforms = {"ios": "10.0"},
+    public_headers = glob(
+        [
+            "ObjCLib/C.h",
+        ],
+    ),
+    visibility = ["//visibility:public"],
+    deps = [":ObjCppMixedLib"],
+)
+
+ios_unit_test(
+    name = "ObjCppMixedLibTests",
+    srcs = glob(
+        [
+            "ObjCppMixedLibTests/*.m",
+        ],
+    ),
+    minimum_os_version = "10.0",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":ObjCLib",
+        ":ObjCppMixedLib",
+    ],
+)

--- a/tests/ios/frameworks/objcpp/ObjCLib/C.h
+++ b/tests/ios/frameworks/objcpp/ObjCLib/C.h
@@ -1,0 +1,5 @@
+@import Foundation;
+
+@interface C : NSObject
+
+@end

--- a/tests/ios/frameworks/objcpp/ObjCLib/C.m
+++ b/tests/ios/frameworks/objcpp/ObjCLib/C.m
@@ -1,0 +1,16 @@
+@import ObjCppMixedLib;
+#import "C.h"
+
+@implementation C
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        A *a = [A new];
+        [a foo];
+    }
+    return self;
+}
+
+@end

--- a/tests/ios/frameworks/objcpp/ObjCppMixedLib/A.h
+++ b/tests/ios/frameworks/objcpp/ObjCppMixedLib/A.h
@@ -1,0 +1,7 @@
+@import Foundation;
+
+@interface A : NSObject
+
+- (void)foo;
+
+@end

--- a/tests/ios/frameworks/objcpp/ObjCppMixedLib/A.mm
+++ b/tests/ios/frameworks/objcpp/ObjCppMixedLib/A.mm
@@ -1,0 +1,21 @@
+#import "A.h"
+#import "B.hpp"
+
+using namespace dummy;
+
+@implementation A
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        dummy::bar();
+    }
+    return self;
+}
+
+- (void)foo
+{
+}
+
+@end

--- a/tests/ios/frameworks/objcpp/ObjCppMixedLib/B.cpp
+++ b/tests/ios/frameworks/objcpp/ObjCppMixedLib/B.cpp
@@ -1,0 +1,6 @@
+namespace dummy
+{
+    void bar()
+    {
+    }
+}

--- a/tests/ios/frameworks/objcpp/ObjCppMixedLib/B.hpp
+++ b/tests/ios/frameworks/objcpp/ObjCppMixedLib/B.hpp
@@ -1,0 +1,13 @@
+#ifndef _DUMMY_H
+#define _DUMMY_H
+
+#ifdef __cplusplus
+
+namespace dummy
+{
+    void bar();
+}
+
+#endif // __cplusplus
+
+#endif // DUMMY_H

--- a/tests/ios/frameworks/objcpp/ObjCppMixedLibTests/ObjCppMIxedLibTests.m
+++ b/tests/ios/frameworks/objcpp/ObjCppMixedLibTests/ObjCppMIxedLibTests.m
@@ -1,0 +1,18 @@
+@import ObjCppMixedLib;
+@import ObjCLib;
+@import XCTest;
+
+@interface ObjCppMixedLibTests : XCTestCase
+@end
+
+@implementation ObjCppMixedLibTests
+
+- (void)test_objcMixedLib
+{
+    A *a = [A new];
+    XCTAssertNotNil(a);
+    C *c = [C new];
+    XCTAssertNotNil(c);
+}
+
+@end


### PR DESCRIPTION
An alternative to https://github.com/bazel-ios/rules_ios/pull/304 that enables the existing C++ target.  Resolves https://github.com/bazel-ios/rules_ios/issues/537.

- Sends C++ sources into a separate target instead of the existing Obj-C target to enable different `copt` values for each.
- Re-uses the same mixed Obj-C and C++ test fixture, thanks @ivan-golub!