### PR TITLE
Add support for project options in `legacy_xcodeproj`

### DIFF
--- a/rules/legacy_xcodeproj.bzl
+++ b/rules/legacy_xcodeproj.bzl
@@ -475,7 +475,8 @@ def _xcodeproj_project_options_impl(ctx):
     # Accumulate all provided options into a Starlark dict.
     options = {}
     for attr, option in options_map.items():
-        if hasattr(ctx.attr, attr):
+        attr_value = getattr(ctx.attr, attr, None)
+        if attr_value:
             options[option] = getattr(ctx.attr, attr)
     return [_ProjectOptionsInfo(options = options)]
 

--- a/rules/legacy_xcodeproj.bzl
+++ b/rules/legacy_xcodeproj.bzl
@@ -486,7 +486,7 @@ xcodeproj_project_options = rule(
         "indent_width": attr.int(mandatory = False),
         "tab_width": attr.int(mandatory = False),
     },
-    doc = "Rule to change project options",
+    doc = "Rule to change project options, values will fallback to Xcode default if not provided",
 )
 
 def _collect_swift_defines(modules):

--- a/rules/legacy_xcodeproj.bzl
+++ b/rules/legacy_xcodeproj.bzl
@@ -16,6 +16,7 @@ def _get_attr_values_for_name(deps, provider, field):
         if dep and provider in dep
     ]
 
+_ProjectOptionsInfo = provider()
 _TargetInfo = provider()
 _SrcsInfo = provider()
 
@@ -461,6 +462,31 @@ xcodeproj_lldbinit = rule(
         "target_name": attr.string(),
     },
     doc = "Internal testing rule relying on assumptions about the xcodeproj rule above",
+)
+
+def _xcodeproj_project_options_impl(ctx):
+    # Map of the attr name to the options value expected by XcodeGen.
+    options_map = {
+        "uses_tabs": "usesTabs",
+        "indent_width": "indentWidth",
+        "tab_width": "tabWidth",
+    }
+
+    # Accumulate all provided options into a Starlark dict.
+    options = {}
+    for attr, option in options_map.items():
+        if hasattr(ctx.attr, attr):
+            options[option] = getattr(ctx.attr, attr)
+    return [_ProjectOptionsInfo(options = options)]
+
+xcodeproj_project_options = rule(
+    implementation = _xcodeproj_project_options_impl,
+    attrs = {
+        "uses_tabs": attr.bool(mandatory = False),
+        "indent_width": attr.int(mandatory = False),
+        "tab_width": attr.int(mandatory = False),
+    },
+    doc = "Rule to change project options",
 )
 
 def _collect_swift_defines(modules):
@@ -1004,6 +1030,9 @@ def _xcodeproj_impl(ctx):
         "groupSortPosition": "none",
         "settingPresets": "none",
     }
+    if ctx.attr.project_options_overrides:
+        proj_options.update(ctx.attr.project_options_overrides[_ProjectOptionsInfo].options)
+
     proj_settings_base = {}
 
     # User defined macro for Bazel only
@@ -1236,6 +1265,7 @@ Tags for configuration:
         "bazel_path": attr.string(mandatory = False, default = "bazel"),
         "scheme_existing_envvar_overrides": attr.string_dict(allow_empty = True, default = {}, mandatory = False),
         "project_attributes_overrides": attr.string_dict(allow_empty = True, mandatory = False, default = {}, doc = "Overrides for attributes that can be set at the project base level."),
+        "project_options_overrides": attr.label(mandatory = False, providers = [_ProjectOptionsInfo], doc = "Overrides for options that can be set at the project base level. Use 'xcodeproj_project_options'."),
         "additional_scheme_infos": attr.label_list(mandatory = False, allow_empty = True, providers = [], aspects = [], doc = """
         List of additional_scheme_info labels that append scheme information to the generated scheme for a build target.
         Currently supports test actions, and test environment variables.

--- a/tests/ios/xcodeproj/BUILD.bazel
+++ b/tests/ios/xcodeproj/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//rules:xcodeproj.bzl", "xcodeproj")
+load("//rules:legacy_xcodeproj.bzl", "xcodeproj_project_options")
 load("//rules:additional_scheme_info.bzl", "additional_scheme_info")
 
 xcodeproj(
@@ -21,6 +22,7 @@ xcodeproj(
     ],
     include_transitive_targets = True,
     project_attributes_overrides = {"ORGANIZATIONNAME": "rules_ios"},
+    project_options_overrides = ":ProjectOptions",
     deps = [
         "//tests/ios/frameworks/objc:ObjcFramework",
         "//tests/ios/frameworks/objc:ObjcFrameworkTests",
@@ -38,6 +40,10 @@ additional_scheme_info(
         "ENV1": "/tmp/dir",
         "ENV2": "🍌",
     },
+)
+
+xcodeproj_project_options(
+    name = "ProjectOptions",
 )
 
 xcodeproj(

--- a/tests/xcodeproj-tests.sh
+++ b/tests/xcodeproj-tests.sh
@@ -26,7 +26,7 @@ if [[ CLEAN = 1 ]]; then
     bazelisk clean
 fi
 
-bazelisk query 'kind(xcodeproj, tests/macos/xcodeproj/...)' | xargs -n 1 bazelisk run
+bazelisk query 'kind("xcodeproj rule", tests/macos/xcodeproj/...)' | xargs -n 1 bazelisk run
 bazelisk query 'attr(executable, 1, kind(genrule, tests/macos/xcodeproj/...))' | xargs -n 1 bazelisk run
 
 ./tests/macos/xcodeproj/build.sh
@@ -40,7 +40,7 @@ if [[ CLEAN = 1 ]]; then
     bazelisk clean
 fi
 
-bazelisk query 'kind(xcodeproj, tests/ios/xcodeproj/...)' | xargs -n 1 bazelisk run
+bazelisk query 'kind("xcodeproj rule", tests/ios/xcodeproj/...)' | xargs -n 1 bazelisk run
 bazelisk query 'attr(executable, 1, kind(genrule, tests/ios/xcodeproj/...))' | xargs -n 1 bazelisk run
 
 ./tests/ios/xcodeproj/pre_build_check.sh


### PR DESCRIPTION
# Summary
We override the `Text Settings` in our non-`legacy_xcodeproj` XcodeGen config:
```YML
options:
  # Text indent
  usesTabs: false
  indentWidth: 2
  tabWidth: 2
```
Add support for `options` to be overridden via the `project_options_overrides` in `legacy_xcodeproj`. It might seem weird that this requires an entire new `rule` impl but this is done since XcodeGen won’t process `”2”` correctly from a `string_dict` for arguments like `indentWidth` or `tabWidth`. `_ProjectOptionsInfo `, a new provider, allows the values to be forwarded to the JSON payload as the properly encoded `int` and `bool` values as expected by the underlying project gen tool:
```JSON
{
    "options": {
        "createIntermediateGroups": true,
        "defaultConfig": "Debug",
        "groupSortPosition": "none",
        "settingPresets": "none",
        "usesTabs": false,
        "indentWidth": 2,
        "tabWidth": 2
    },
}
```

# Testing
`BUILD.bazel`:
```Starlark
load("@build_bazel_rules_ios//rules:xcodeproj.bzl", "xcodeproj")
load("@build_bazel_rules_ios//rules:legacy_xcodeproj.bzl", "xcodeproj_project_options")

xcodeproj_project_options(
    name = "ProjectOptions",
    uses_tabs = False,
    indent_width = 2,
    tab_width = 2,
)

xcodeproj(
    name = "Project",
    testonly = True,
    generate_schemes_for_product_types = [
        "application",
        "bundle.unit-test",
        "test_suite",
    ],
    project_options_overrides = ":ProjectOptions",
    include_transitive_targets = True,
    deps = [":Foo"],
)
```

|Xcode 13.4.1|
|---|
|<img width="264" alt="Screen Shot 2022-08-30 at 2 06 48 PM" src="https://user-images.githubusercontent.com/5728070/187532955-c6707da8-8b40-49c7-a87e-85b7a911b115.png">|