### PR TITLE
[WIP] First pass at rules_ios explicit PCM test case 

### DIFF
--- a/rules/pcm/.bazelrc
+++ b/rules/pcm/.bazelrc
@@ -1,0 +1,4 @@
+build --features swift.use_c_modules
+build --features swift.emit_c_module
+build --features swift.use_global_module_cache
+build --override_repository=build_bazel_rules_swift=/Users/jdierksen/Development/rules_swift

--- a/rules/pcm/BUILD.bazel
+++ b/rules/pcm/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
+
+swift_binary(
+    name = "stuff",
+    srcs = ["stuff.swift"],
+    data = ["@here_be_xcodes//:toolchains"],
+    deps = ["@here_be_xcodes//version13_3_1_13E500a/MacOSX/MacOSX:SwiftUI_swift"],
+)

--- a/rules/pcm/apple_framework_pcm.bzl
+++ b/rules/pcm/apple_framework_pcm.bzl
@@ -1,0 +1,64 @@
+load("@build_bazel_rules_swift//swift/internal:swift_common.bzl", "swift_common")
+load("@build_bazel_rules_swift//swift/internal:attrs.bzl", "swift_library_rule_attrs")
+load("@build_bazel_rules_swift//swift/internal:providers.bzl", "SwiftInfo", "SwiftToolchainInfo")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+
+def _impl(ctx):
+    swift_toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
+
+    deps = ctx.attr.deps
+    cc_infos = [dep[CcInfo] for dep in deps]
+    swift_infos = [dep[SwiftInfo] for dep in deps]
+
+    if cc_infos:
+        cc_info = cc_common.merge_cc_infos(cc_infos = cc_infos)
+        compilation_context = cc_info.compilation_context
+    else:
+        cc_info = None
+        compilation_context = cc_common.create_compilation_context()
+
+    feature_configuration = swift_common.configure_features(
+        ctx = ctx,
+        requested_features = ctx.features,
+        swift_toolchain = swift_toolchain,
+    )
+
+    module_map = paths.join(apple_common.apple_toolchain().developer_dir(), ctx.attr.module_map_file)
+    precompiled_module = swift_common.precompile_clang_module(
+        actions = ctx.actions,
+        cc_compilation_context = compilation_context,
+        module_map_file = module_map,
+        module_name = ctx.attr.name,
+        target_name = ctx.attr.name,
+        swift_toolchain = swift_toolchain,
+        feature_configuration = feature_configuration,
+        swift_infos = swift_infos,
+    )
+    module = swift_common.create_clang_module(
+        compilation_context = compilation_context,
+        module_map = module_map,
+        precompiled_module = precompiled_module,
+    )
+    modules = [swift_common.create_module(clang = module, name = ctx.attr.name)]
+
+    return [
+        swift_common.create_swift_info(
+            modules = modules,
+            swift_infos = swift_infos,
+        ),
+        CcInfo(
+            compilation_context = compilation_context,
+        ),
+    ]
+
+apple_framework_pcm = rule(
+    implementation = _impl,
+    attrs = dicts.add(
+        swift_library_rule_attrs(requires_srcs = False),
+        {
+            "module_map_file": attr.string(),
+        },
+    ),
+    fragments = ["cpp"],
+)

--- a/rules/pcm/framework_repos.bzl
+++ b/rules/pcm/framework_repos.bzl
@@ -1,0 +1,96 @@
+load("@bazel_tools//tools/osx:xcode_configure.bzl", "run_xcode_locator")
+
+def _impl(repository_ctx):
+    (xcode_toolchains, _xcodeloc_err) = run_xcode_locator(
+        repository_ctx,
+        repository_ctx.path(Label("@bazel_tools//tools/osx:xcode_locator.m")),
+    )
+
+    repository_ctx.file("toolchains", content = json.encode(xcode_toolchains))
+    repository_ctx.file("BUILD", "exports_files([\"toolchains\"])")
+
+    for toolchain in xcode_toolchains[0:1]:
+        version_name = "version{}".format(toolchain.version.replace(".", "_"))
+        developer_dir_path = repository_ctx.path(toolchain.developer_dir)
+        platform_dir = developer_dir_path.get_child("Platforms")
+        platforms = platform_dir.readdir()
+        sdk_aliases = {}
+        sdk_realpaths = {}
+        for platform in platforms[4:5]:
+            sdk_dir = platform.get_child("Developer").get_child("SDKs")
+            sdks = sdk_dir.readdir()
+            for sdk in sdks:
+                sdk_realpath = sdk.realpath
+                sdk_aliases[sdk] = sdk_realpath
+                if sdk_realpath in sdk_realpaths:
+                    # Skip symlinked sdks
+                    continue
+                output_sdk_path = repository_ctx.path(version_name).get_child(platform.basename.replace(".platform", "")).get_child(sdk_realpath.basename.replace(".sdk", ""))
+
+                frameworks_dir = sdk_realpath.get_child("System").get_child("Library").get_child("Frameworks")
+                if not frameworks_dir.exists:
+                    # Skip things like DriverKit
+                    continue
+                frameworks = frameworks_dir.readdir()
+                all_imported_frameworks = [f.basename.replace(".framework", "") for f in frameworks if f.basename.endswith(".framework") and not f.basename.startswith("_")]
+
+                swift_lib_dir = sdk_realpath.get_child("usr").get_child("lib").get_child("swift")
+                swift_libs = swift_lib_dir.readdir()
+                all_imported_frameworks.extend([s.basename.replace(".swiftmodule", "") for s in swift_libs if s.basename.endswith(".swiftmodule") and not s.basename.startswith("_")])
+
+                import_file_content = "".join(["import {}\n".format(f) for f in all_imported_frameworks])
+                imports_file = output_sdk_path.get_child("imports.swift")
+                repository_ctx.file(imports_file, content = import_file_content)
+                resource_dir = "{}/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift".format(developer_dir_path)
+                repository_ctx.report_progress("Scanning deps for {}".format(imports_file))
+                deps_result = repository_ctx.execute(
+                    [
+                        "swiftc",
+                        "-scan-dependencies",
+                        "-sdk",
+                        sdk_realpath,
+                        "-resource-dir",
+                        resource_dir,
+                        imports_file,
+                    ],
+                )
+                if deps_result.return_code != 0:
+                    fail("Could not scan dependencies for {}\n{}".format(imports_file, deps_result.stderr))
+                scan_deps = json.decode(deps_result.stdout)
+                repository_ctx.file(output_sdk_path.get_child("deps.json"), content = deps_result.stdout)
+                build_file_lines = [
+                    "load(\"@//:apple_framework_pcm.bzl\", \"apple_framework_pcm\")",
+                    "load(\"@build_bazel_rules_swift//swift:swift.bzl\", \"swift_module_alias\")",
+                    "",
+                    "package(default_visibility = [\"//visibility:public\"])",
+                    "",
+                ]
+                for pkg in scan_deps.get("modules", []):
+                    module_name = pkg.get("modulePath", "")
+                    if not module_name:
+                        continue
+                    clang = pkg.get("details", {}).get("clang", {})
+                    if clang:
+                        build_file_lines.append("apple_framework_pcm(")
+                        build_file_lines.append("    name = \"{}\",".format(module_name.replace(".pcm", "")))
+                        module_map_file = clang["moduleMapPath"].replace("{}/".format(developer_dir_path), "")
+                        build_file_lines.append("    module_map_file = \"{}\",".format(module_map_file))
+                    else:
+                        build_file_lines.append("swift_module_alias(")
+                        build_file_lines.append("    name = \"{}\",".format(module_name.replace(".swiftmodule", "_swift")))
+                    deps = pkg.get("directDependencies", [])
+                    clang_deps = [d["clang"] for d in deps if "clang" in d]
+                    swift_deps = [d["swift"] for d in deps if "swift" in d]
+                    if clang_deps or swift_deps:
+                        build_file_lines.append("    deps = [")
+                        for d in clang_deps:
+                            build_file_lines.append("        \":{}\",".format(d))
+                        for d in swift_deps:
+                            build_file_lines.append("        \":{}_swift\",".format(d))
+                        build_file_lines.append("    ],")
+                    build_file_lines.append(")")
+                    build_file_lines.append("")
+                build_file = output_sdk_path.get_child("BUILD.bazel")
+                repository_ctx.file(build_file, "\n".join(build_file_lines))
+
+swift_sdks = repository_rule(implementation = _impl)


### PR DESCRIPTION
The first pass compiles them by calling `cc_common` via a helper they added into `rules_swift` that creates a provider with `cc_common`. Longer term, we may remove the rules_swift dependency here: calling `cc_common` or `SpawnAction` directly 

Putting this into the bazel-ios org so we can cleanly integrate it with our providers, own the code, and test it end to end.

cc @dierksen I've taken a stab at PRing some of the stuff you've added into swift_scratch so we can iterate on it as a team. 
