### PR TITLE
Supports exported_symbols_lists in apple_framework

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -37,6 +37,7 @@ _APPLE_FRAMEWORK_PACKAGING_KWARGS = [
     "bundle_id",
     "skip_packaging",
     "link_dynamic",
+    "exported_symbols_lists",
 ]
 
 def apple_framework(name, apple_library = apple_library, **kwargs):


### PR DESCRIPTION
It's already supported in the apple_framework_packaging rule. We need to pass it from apple_framework to apple_framework_packaging.