### PR TITLE
Fixing git_repository assumption in xcbuildkit dep

### DIFF
--- a/rules/third_party/xcbuildkit_version.bzl
+++ b/rules/third_party/xcbuildkit_version.bzl
@@ -23,6 +23,8 @@ _repo_info = repository_rule(
 def _get_ref(rule):
     if not rule:
         return None
+    if rule["kind"] != "git_repository":
+        return None
     if rule["commit"]:
         return rule["commit"]
     if rule["tag"]:


### PR DESCRIPTION
The xcbuildkit_version.bzl file contains an assumption that the xcbuildkit repo was pulled via git_repository.  We pull it in via http_archive and as a result the rule has no commit field and bazel crashes during loading phase.

Error message:
```
File "/private/var/tmp/_bazel_egates/c4850d11fbeadd6bd3db71db3a1c0e4d/external/build_bazel_rules_ios/rules/third_party/xcbuildkit_version.bzl", line 26, column 12, in _get_ref
     if rule["commit"]:
Error: key "commit" not found in dictionary