### PR TITLE
Fix transitive framework import in opt build

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -24,7 +24,7 @@ load("@build_bazel_rules_apple//apple/internal:rule_support.bzl", "rule_support"
 load("@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl", "AppleMacToolsToolchainInfo", "AppleXPlatToolsToolchainInfo")
 load("@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl", "clang_rt_dylibs")
 load("@build_bazel_rules_apple//apple:providers.bzl", "AppleBundleInfo", "IosFrameworkBundleInfo")
-load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo", "swift_common")
+load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo", "swift_clang_module_aspect", "swift_common")
 load(
     "@build_bazel_rules_apple//apple/internal/aspects:resource_aspect.bzl",
     "apple_resource_aspect",
@@ -1118,6 +1118,7 @@ The default behavior bakes this into the top level app. When false, it's statica
 """,
         ),
         "transitive_deps": attr.label_list(
+            aspects = [swift_clang_module_aspect],
             mandatory = True,
             cfg = apple_common.multi_arch_split,
             doc =


### PR DESCRIPTION
This PR fixes https://github.com/bazel-ios/rules_ios/issues/569.

`apple_*_(xc)framework_import` provides `_SwiftInteropInfo` instead of `SwiftInfo`. In `apple_framework_packaging`, when [we merge the SwiftInfo](https://github.com/bazel-ios/rules_ios/blob/b1499fc08a7e4b7a7ba238fb4c9b089e6648ecbd/rules/framework.bzl#L901), the info from the framework import get lost there.

To fix the problem, we can add `swift_clang_module_aspect` to the `transitive_deps` attribute of `apple_framework_packaging`, which converts `_SwiftInteropInfo` to `SwiftInfo`. `swift_library` does this for `deps` as well.