### PR TITLE
Forward testonly attribute for all rules

### DIFF
--- a/rules/extension.bzl
+++ b/rules/extension.bzl
@@ -26,12 +26,18 @@ def ios_extension(name, infoplists_by_build_setting = {}, **kwargs):
 
     deps = kwargs.pop("deps", [])
     frameworks = kwargs.pop("frameworks", [])
+    testonly = kwargs.pop("testonly", False)
 
     kwargs["families"] = kwargs.pop("families", ["iphone", "ipad"])
 
     # Setup force loading here - need to process deps and libs
     force_load_name = name + ".force_load_direct_deps"
-    force_load_direct_deps(name = force_load_name, deps = deps, tags = ["manual"])
+    force_load_direct_deps(
+        name = force_load_name,
+        deps = deps,
+        tags = ["manual"],
+        testonly = testonly,
+    )
 
     # Setup framework middlemen - need to process deps and libs
     fw_name = name + ".framework_middleman"
@@ -40,11 +46,17 @@ def ios_extension(name, infoplists_by_build_setting = {}, **kwargs):
         extension_safe = True,
         framework_deps = deps,
         tags = ["manual"],
+        testonly = testonly,
     )
     frameworks = [fw_name] + frameworks
 
     dep_name = name + ".dep_middleman"
-    dep_middleman(name = dep_name, deps = deps, tags = ["manual"])
+    dep_middleman(
+        name = dep_name,
+        deps = deps,
+        tags = ["manual"],
+        testonly = testonly,
+    )
     deps = [dep_name] + [force_load_name]
 
     rules_apple_ios_extension(
@@ -57,5 +69,6 @@ def ios_extension(name, infoplists_by_build_setting = {}, **kwargs):
             infoplists_by_build_setting = infoplists_by_build_setting,
             default_infoplists = kwargs.pop("infoplists", []),
         ),
+        testonly = testonly,
         **kwargs
     )

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -68,7 +68,9 @@ def apple_framework(name, apple_library = apple_library, **kwargs):
         "//conditions:default": None,
     }))
 
-    library = apple_library(name = name, **kwargs)
+    testonly = kwargs.pop("testonly", False)
+
+    library = apple_library(name = name, testonly = testonly, **kwargs)
     framework_deps = []
 
     # Setup force loading here - only for direct deps / direct libs and when `link_dynamic` is set.
@@ -77,7 +79,7 @@ def apple_framework(name, apple_library = apple_library, **kwargs):
         name = force_load_name,
         deps = kwargs.get("deps", []) + library.lib_names,
         should_force_load = framework_packaging_kwargs.get("link_dynamic", False),
-        testonly = kwargs.get("testonly", False),
+        testonly = testonly,
         tags = ["manual"],
     )
     framework_deps.append(force_load_name)
@@ -110,7 +112,7 @@ def apple_framework(name, apple_library = apple_library, **kwargs):
             "@build_bazel_rules_ios//rules/apple_platform:watchos": "watchos",
             "//conditions:default": "",
         }),
-        testonly = kwargs.get("testonly", False),
+        testonly = testonly,
         **framework_packaging_kwargs
     )
 

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -563,6 +563,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
     copts_by_build_setting = copts_by_build_setting_with_defaults(xcconfig, fetch_default_xcconfig, xcconfig_by_build_setting)
     enable_framework_vfs = kwargs.pop("enable_framework_vfs", False) or namespace_is_module_name
     defines = kwargs.pop("defines", [])
+    testonly = kwargs.pop("testonly", False)
 
     for (k, v) in {"momc_copts": momc_copts, "mapc_copts": mapc_copts, "ibtool_copts": ibtool_copts}.items():
         if v:
@@ -575,7 +576,6 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
     # Generate code for `.intentdefinition` source files and forward the original plist as data
     for intent in intent_sources:
         intent_name = "%s_%s_gen" % (name, intent)
-        testonly = kwargs.get("testonly", False)
 
         # Avoid swift_intent_library and objc_intent_library because they wrap the generated code in a new module
         #
@@ -663,7 +663,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
             swiftmodules = import_swiftmodules,
             hdrs = import_headers,
             tags = _MANUAL,
-            testonly = kwargs.get("testonly", False),
+            testonly = testonly,
             extra_search_paths = vfs_root,
         )
         import_vfsoverlays.append(import_name + "_vfs")
@@ -708,7 +708,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
             swiftmodules = import_swiftmodules,
             hdrs = import_headers,
             tags = _MANUAL,
-            testonly = kwargs.get("testonly", False),
+            testonly = testonly,
             extra_search_paths = vfs_root,
         )
         import_vfsoverlays.append(import_name + "_vfs")
@@ -745,7 +745,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
             swiftmodules = import_swiftmodules,
             hdrs = import_headers,
             tags = _MANUAL,
-            testonly = kwargs.get("testonly", False),
+            testonly = testonly,
         )
         import_vfsoverlays.append(import_name + "_vfs")
 
@@ -810,7 +810,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
         private_hdrs = objc_private_hdrs,
         hdrs = objc_hdrs,
         tags = _MANUAL,
-        testonly = kwargs.get("testonly", False),
+        testonly = testonly,
         deps = deps + private_deps + lib_names + import_vfsoverlays,
     )
 
@@ -904,7 +904,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
     if swift_version:
         additional_swift_copts += ["-swift-version", swift_version]
 
-    module_data = library_tools["wrap_resources_in_filegroup"](name = module_name + "_data", srcs = data, testonly = kwargs.get("testonly", False))
+    module_data = library_tools["wrap_resources_in_filegroup"](name = module_name + "_data", srcs = data, testonly = testonly)
 
     if swift_sources:
         additional_swift_copts.extend(("-Xcc", "-I."))
@@ -947,7 +947,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
         private_hdrs = objc_private_hdrs,
         hdrs = objc_hdrs,
         tags = _MANUAL,
-        testonly = kwargs.get("testonly", False),
+        testonly = testonly,
         deps = deps + private_deps + lib_names + import_vfsoverlays,
         #enable_framework_vfs = enable_framework_vfs
     )
@@ -977,6 +977,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
             data = [module_data],
             tags = tags_manual,
             defines = defines + swift_defines,
+            testonly = testonly,
             **kwargs
         )
         lib_names.append(swift_libname)
@@ -989,7 +990,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
             hdrs = [],
             direct_hdr_providers = [swift_libname],
             tags = _MANUAL,
-            testonly = kwargs.get("testonly", False),
+            testonly = testonly,
         )
         private_deps.append(swift_doublequote_hmap_name)
         _append_headermap_copts(swift_doublequote_hmap_name, "-iquote", additional_objc_copts, additional_swift_copts, additional_cc_copts)
@@ -1002,7 +1003,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
             hdrs = [],
             direct_hdr_providers = [swift_libname],
             tags = _MANUAL,
-            testonly = kwargs.get("testonly", False),
+            testonly = testonly,
         )
         private_deps.append(swift_angle_bracket_hmap_name)
         _append_headermap_copts(swift_angle_bracket_hmap_name, "-I", additional_objc_copts, additional_swift_copts, additional_cc_copts)
@@ -1018,7 +1019,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
             deps = deps + private_deps,
             defines = defines,
             tags = tags_manual,
-            testonly = kwargs.get("testonly", False),
+            testonly = testonly,
         )
         lib_names.append(cpp_libname)
 
@@ -1069,6 +1070,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
         data = [] if swift_sources else [module_data],
         tags = tags_manual,
         defines = defines + objc_defines,
+        testonly = testonly,
         **kwargs
     )
     launch_screen_storyboard_name = name + "_launch_screen_storyboard"
@@ -1077,6 +1079,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
         srcs = [module_data],
         output_group = "launch_screen_storyboard",
         tags = _MANUAL,
+        testonly = testonly,
     )
     lib_names.append(objc_libname)
 

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -16,11 +16,12 @@ def xcodeproj(name, **kwargs):
     use_xchammer = kwargs.pop("use_xchammer", False)
     generate_xcode_schemes = kwargs.pop("generate_xcode_schemes", False)
     xcconfig_overrides = kwargs.pop("xcconfig_overrides", {})
+    testonly = kwargs.pop("testonly", False)
 
     if use_xchammer:
         xchammer_xcodeproj(
             name = name,
-            testonly = kwargs.get("testonly", False),
+            testonly = testonly,
             bazel = kwargs.get("bazel_path", "/usr/local/bin/bazel"),
             project_config = project_config(
                 generate_xcode_schemes = generate_xcode_schemes,
@@ -30,4 +31,4 @@ def xcodeproj(name, **kwargs):
             targets = kwargs.get("deps", []),
         )
     else:
-        legacy_xcodeproj(name = name, **kwargs)
+        legacy_xcodeproj(name = name, testonly = testonly, **kwargs)

--- a/tests/ios/app/AppTestOnly/App.swift
+++ b/tests/ios/app/AppTestOnly/App.swift
@@ -1,0 +1,12 @@
+import Foundation
+import SwiftLibrary
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+  var window: UIWindow?
+
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    // Override point for customization after application launch.
+    return true
+  }
+}

--- a/tests/ios/app/BUILD.bazel
+++ b/tests/ios/app/BUILD.bazel
@@ -409,3 +409,30 @@ output_test(
 )
 
 make_tests()
+
+ios_application(
+    name = "AppTestOnly",
+    testonly = True,
+    srcs = ["AppTestOnly/App.swift"],
+    bundle_id = "com.example.app",
+    minimum_os_version = "10.0",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tests/ios/frameworks/testonly:MixedSourceTestLib",
+        "//tests/ios/frameworks/testonly:SwiftLibrary",
+    ],
+)
+
+ios_application(
+    name = "AppTestOnlyWithExtension",
+    testonly = True,
+    srcs = ["AppTestOnly/App.swift"],
+    bundle_id = "com.example.app",
+    extensions = ["//tests/ios/extensions:ExampleExtensionWithTestOnly"],
+    minimum_os_version = "10.0",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tests/ios/frameworks/testonly:MixedSourceTestLib",
+        "//tests/ios/frameworks/testonly:SwiftLibrary",
+    ],
+)

--- a/tests/ios/extensions/BUILD.bazel
+++ b/tests/ios/extensions/BUILD.bazel
@@ -31,3 +31,20 @@ ios_extension(
         "//tests/ios/frameworks/dynamic/a",
     ],
 )
+
+ios_extension(
+    name = "ExampleExtensionWithTestOnly",
+    testonly = True,
+    bundle_id = "com.example.app.example-extension",
+    families = [
+        "iphone",
+    ],
+    infoplists = [
+        "ExampleExtension/Info.plist",
+    ],
+    minimum_os_version = "10.0",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tests/ios/frameworks/testonly:SwiftLibrary",
+    ],
+)

--- a/tests/ios/frameworks/testonly/BUILD.bazel
+++ b/tests/ios/frameworks/testonly/BUILD.bazel
@@ -9,6 +9,7 @@ apple_framework(
         ":TestOnlyFixture",
     ],
     module_name = "SwiftLibrary",
+    platforms = {"ios": "10.0"},
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
## Summary

rules_swift was updated (https://github.com/bazelbuild/rules_swift/pull/868) to require passing `testonly = True` in order to link `XCTest` framework.

`rules_ios` currently doesn't forward the `testonly` arg to the internal rules we create for all cases, this means it's not currently possible to use an updated `rules_swift` with `rules_ios`. 

With this PR the latest `rules_swift` can be used with `rules_ios`. 