### PR TITLE
Add ability to configure build service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ user.bazelrc
 external
 *-XCHammer*.xcodeproj
 xchammer-includes
+xcbuildkit-data

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ user.bazelrc
 external
 *-XCHammer*.xcodeproj
 xchammer-includes
-xcbuildkit-data

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -21,6 +21,8 @@ PrivateHeadersInfo = provider(
     },
 )
 
+GLOBAL_INDEX_STORE_PATH = "bazel-out/rules_ios_global_index_store.indexstore"
+
 _MANUAL = ["manual"]
 
 def _private_headers_impl(ctx):
@@ -1037,7 +1039,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
             # Checkout the task roadmap for future improvements:
             # Docs/index_while_building.md
             "-index-store-path",
-            "bazel-out/rules_ios_global_index_store.indexstore",
+            GLOBAL_INDEX_STORE_PATH,
         ],
         "//conditions:default": [
             "-index-store-path",

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -136,8 +136,8 @@ swift_binary(
             name = "xchammer",
             remote = "https://github.com/bazel-ios/xchammer.git",
             # XCHammer dev branch: bazel-ios/rules-ios-xchammer
-            commit = "01efb200049f3933e4d51f9a354ecbd0ab78848a",
-            shallow_since = "1667582336 -0400",
+            commit = "95eea020f7d0bd6ffb3155f0cbb6df4c0209aaec",
+            shallow_since = "1667588608 -0400",
         )
     xchammer_dependencies()
 

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -136,15 +136,15 @@ swift_binary(
             name = "xchammer",
             remote = "https://github.com/bazel-ios/xchammer.git",
             # XCHammer dev branch: bazel-ios/rules-ios-xchammer
-            commit = "95eea020f7d0bd6ffb3155f0cbb6df4c0209aaec",
-            shallow_since = "1667588608 -0400",
+            commit = "7ef4e81dbd37926b5c30fc20636d080b3dfabfd6",
+            shallow_since = "1667594979 -0400",
         )
     xchammer_dependencies()
 
     if not native.existing_rule("xcbuildkit"):
         git_repository(
             name = "xcbuildkit",
-            commit = "1eb4ed9f2026b35cece333308ba9623acede90f3",
+            commit = "4c366afb48cb78caed268d483e3cdb308dfc1794",
             remote = "https://github.com/jerrymarino/xcbuildkit.git",
         )
 

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -136,15 +136,15 @@ swift_binary(
             name = "xchammer",
             remote = "https://github.com/bazel-ios/xchammer.git",
             # XCHammer dev branch: bazel-ios/rules-ios-xchammer
-            commit = "4caec7bae6f5cb99c5cf29cefd0b345967bdd61b",
-            shallow_since = "1656517476 -0500",
+            commit = "43ce6ea91be03b8a1b2572db7fb4beb8a522ed8f",
+            shallow_since = "1667406433 -0400",
         )
     xchammer_dependencies()
 
     if not native.existing_rule("xcbuildkit"):
         git_repository(
             name = "xcbuildkit",
-            commit = "1e1155dc4aa9d7dc4260fb5c287acc0b299bbd76",
+            commit = "a03d9c7c5efb961b317f5efb95cbfcf7471b683e",
             remote = "https://github.com/jerrymarino/xcbuildkit.git",
         )
 

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -136,15 +136,15 @@ swift_binary(
             name = "xchammer",
             remote = "https://github.com/bazel-ios/xchammer.git",
             # XCHammer dev branch: bazel-ios/rules-ios-xchammer
-            commit = "43ce6ea91be03b8a1b2572db7fb4beb8a522ed8f",
-            shallow_since = "1667406433 -0400",
+            commit = "01efb200049f3933e4d51f9a354ecbd0ab78848a",
+            shallow_since = "1667582336 -0400",
         )
     xchammer_dependencies()
 
     if not native.existing_rule("xcbuildkit"):
         git_repository(
             name = "xcbuildkit",
-            commit = "a03d9c7c5efb961b317f5efb95cbfcf7471b683e",
+            commit = "1eb4ed9f2026b35cece333308ba9623acede90f3",
             remote = "https://github.com/jerrymarino/xcbuildkit.git",
         )
 

--- a/rules/third_party/xchammer_repositories.bzl
+++ b/rules/third_party/xchammer_repositories.bzl
@@ -267,8 +267,8 @@ def xchammer_dependencies():
         # release, then adds changes to this tag for the Bazel release in
         # question
         # Persisted on github tag=rules_ios-5.0.0,
-        commit = "0dd73ce2950b81934c2bb67bbad09332dbabdee9",
-        shallow_since = "1656108309 -0500",
+        commit = "a90a2925d24cc02174188a9365bc84f9c2cb37f4",
+        shallow_since = "1667236334 -0400",
     )
 
     namespaced_new_git_repository(

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -14,11 +14,11 @@ def _patch_bazel_build_service_config(kwargs_bazel_build_service_config):
     """
     if kwargs_bazel_build_service_config:
         return bazel_build_service_config(
-            bep_path = kwargs_bazel_build_service_config.bepPath,
+            bep_path = kwargs_bazel_build_service_config.bepPath if kwargs_bazel_build_service_config.bepPath else "/tmp/bep.bep",
             index_store_path = "$SRCROOT/%s" % GLOBAL_INDEX_STORE_PATH,
-            indexing_data_dir = "$SRCROOT/xcbuildkit-data/indexing",
-            indexing_enabled = kwargs_bazel_build_service_config.indexingEnabled,
-            progress_bar_enabled = kwargs_bazel_build_service_config.progressBarEnabled,
+            indexing_data_dir = kwargs_bazel_build_service_config.indexingDataDir if kwargs_bazel_build_service_config.indexingDataDir else "/tmp/xcbuildkit-data/indexing",
+            indexing_enabled = kwargs_bazel_build_service_config.indexingEnabled if kwargs_bazel_build_service_config.indexingEnabled else False,
+            progress_bar_enabled = kwargs_bazel_build_service_config.progressBarEnabled if kwargs_bazel_build_service_config.progressBarEnabled else False,
         )
     return None
 

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -2,7 +2,25 @@
 
 load("//rules:legacy_xcodeproj.bzl", legacy_xcodeproj = "xcodeproj")
 load("@xchammer//:BazelExtensions/xcodeproject.bzl", xchammer_xcodeproj = "xcode_project")
-load("@xchammer//:BazelExtensions/xchammerconfig.bzl", "project_config")
+load("@xchammer//:BazelExtensions/xchammerconfig.bzl", "bazel_build_service_config", "project_config")
+load("//rules:library.bzl", "GLOBAL_INDEX_STORE_PATH")
+
+def _patch_bazel_build_service_config(kwargs_bazel_build_service_config):
+    """Overriding to set some default values for now.
+
+    We need to better expose the option to
+    customize `GLOBAL_INDEX_STORE_PATH` and expecting to iterate a bit on `indexing_data_dir`
+    and run some tests, once it's battle tested will revert this and allow customers to fully configure
+    """
+    if kwargs_bazel_build_service_config:
+        return bazel_build_service_config(
+            bep_path = kwargs_bazel_build_service_config.bepPath,
+            index_store_path = "$SRCROOT/%s" % GLOBAL_INDEX_STORE_PATH,
+            indexing_data_dir = "$SRCROOT/xcbuildkit-data/indexing",
+            indexing_enabled = kwargs_bazel_build_service_config.indexingEnabled,
+            progress_bar_enabled = kwargs_bazel_build_service_config.progressBarEnabled,
+        )
+    return None
 
 def xcodeproj(name, **kwargs):
     """Macro that allows one to declare one of 'legacy_xcodeproj', 'xchammer_xcodeproj' depending on value of 'use_xchammer' flag
@@ -12,11 +30,12 @@ def xcodeproj(name, **kwargs):
       **kwargs: Arguments to propagate, the XCHammer specific ones are going to be removed before declaring the legacy rule
     """
 
-    # Pop XCHammer specific attributes so these don't get propagated
+    # Pop XCHammer specific attributes so these don't get propagated to `legacy_xcodeproj`
     use_xchammer = kwargs.pop("use_xchammer", False)
     generate_xcode_schemes = kwargs.pop("generate_xcode_schemes", False)
     xcconfig_overrides = kwargs.pop("xcconfig_overrides", {})
     testonly = kwargs.pop("testonly", False)
+    bazel_build_service_config = _patch_bazel_build_service_config(kwargs.pop("bazel_build_service_config", None))
 
     if use_xchammer:
         xchammer_xcodeproj(
@@ -27,6 +46,7 @@ def xcodeproj(name, **kwargs):
                 generate_xcode_schemes = generate_xcode_schemes,
                 paths = ["**"],
                 xcconfig_overrides = xcconfig_overrides,
+                bazel_build_service_config = bazel_build_service_config,
             ),
             targets = kwargs.get("deps", []),
         )

--- a/tests/ios/app/App/main.m
+++ b/tests/ios/app/App/main.m
@@ -2,5 +2,6 @@
 @import OnlySources;
 
 int main(int argc, char **argv) {
+    [[FW alloc] foo];
     return UIApplicationMain(argc, argv, nil, nil);
 }

--- a/tests/ios/app/App/main.m
+++ b/tests/ios/app/App/main.m
@@ -2,6 +2,6 @@
 @import OnlySources;
 
 int main(int argc, char **argv) {
-    [[FW alloc] foo];
+    [[[FW alloc] init] foo];
     return UIApplicationMain(argc, argv, nil, nil);
 }

--- a/tests/ios/app/FW/FW.h
+++ b/tests/ios/app/FW/FW.h
@@ -1,4 +1,8 @@
 @import Foundation;
 
 @interface FW: NSObject
+
+/// Foo
+- (void)foo;
+
 @end

--- a/tests/ios/app/FW/FW.m
+++ b/tests/ios/app/FW/FW.m
@@ -4,7 +4,6 @@
 @implementation FW
 
 - (void)foo {
-    NSLog(@"foo");
 }
 
 @end

--- a/tests/ios/app/FW/FW.m
+++ b/tests/ios/app/FW/FW.m
@@ -3,6 +3,7 @@
 
 @implementation FW
 
+/// Foo
 - (void)foo {
 }
 

--- a/tests/ios/app/FW/FW.m
+++ b/tests/ios/app/FW/FW.m
@@ -3,4 +3,8 @@
 
 @implementation FW
 
+- (void)foo {
+    NSLog(@"foo");
+}
+
 @end

--- a/tests/ios/xcodeproj/BUILD.bazel
+++ b/tests/ios/xcodeproj/BUILD.bazel
@@ -1,6 +1,8 @@
 load("//rules:xcodeproj.bzl", "xcodeproj")
 load("//rules:legacy_xcodeproj.bzl", "xcodeproj_project_options")
+load("//rules:library.bzl", "GLOBAL_INDEX_STORE_PATH")
 load("//rules:additional_scheme_info.bzl", "additional_scheme_info")
+load("@xchammer//:BazelExtensions/xchammerconfig.bzl", "bazel_build_service_config")
 
 xcodeproj(
     name = "Single-Static-Framework-Project",
@@ -212,6 +214,23 @@ xcodeproj(
 
 xcodeproj(
     name = "App-XCHammer",
+    use_xchammer = True,
+    deps = [
+        "//tests/ios/app:App",
+        "//tests/ios/extensions:ExampleExtension",
+        "//tests/ios/frameworks/with-bundle-id:FrameworkWithBundleId",
+    ],
+)
+
+xcodeproj(
+    name = "App-XCHammerWithXCBuildKit",
+    bazel_build_service_config = bazel_build_service_config(
+        bep_path = "/tmp/bep.bep",
+        index_store_path = "$SRCROOT/%s" % GLOBAL_INDEX_STORE_PATH,
+        indexing_data_dir = "$SRCROOT/xcbuildkit-data/indexing",
+        indexing_enabled = True,
+        progress_bar_enabled = True,
+    ),
     use_xchammer = True,
     deps = [
         "//tests/ios/app:App",

--- a/tests/ios/xcodeproj/BUILD.bazel
+++ b/tests/ios/xcodeproj/BUILD.bazel
@@ -227,7 +227,7 @@ xcodeproj(
     bazel_build_service_config = bazel_build_service_config(
         bep_path = "/tmp/bep.bep",
         index_store_path = "$SRCROOT/%s" % GLOBAL_INDEX_STORE_PATH,
-        indexing_data_dir = "$SRCROOT/xcbuildkit-data/indexing",
+        indexing_data_dir = "/tmp/xcbuildkit-data/indexing",
         indexing_enabled = True,
         progress_bar_enabled = True,
     ),


### PR DESCRIPTION
Requires:
* https://github.com/jerrymarino/xcbuildkit/pull/49 
* https://github.com/bazel-ios/xchammer/pull/33 

TL;DR:
* Adds `xcbuildkit-data` to `.gitignore` since `xcbuildkit` will use this dir to cache indexing cache
* Load current path to global index store from symbol `GLOBAL_INDEX_STORE_PATH`
* Bump `xcbuildkit`, `xchammer` to pick up changes above and `Tulsi` to pick up lates fixes ([this](https://github.com/bazel-ios/tulsi/pull/7), [this](https://github.com/bazel-ios/tulsi/pull/8))
* `xcodeproj` now accepts `bazel_build_service_config` to configura the build service, for now overriding some paths to allow me to experiment with this for some time before making it fully configurable for customers. Also, adds a test case for this.

- [x] Bump `xcbuildkit` and `xchammer` to main branches before landing