### PR TITLE
static vendored lib missing include paths

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -851,6 +851,10 @@ def _apple_framework_packaging_impl(ctx):
         direct = [],
         transitive = [getattr(dep[CcInfo].compilation_context, "defines") for dep in deps if CcInfo in dep],
     ))
+    objc_provider_utils.add_to_dict_if_present(compilation_context_fields, "includes", depset(
+        direct = [],
+        transitive = [getattr(dep[CcInfo].compilation_context, "includes") for dep in deps if CcInfo in dep],
+    ))
 
     # Compute cc_info and swift_info
     virtualize_frameworks = feature_names.virtualize_frameworks in ctx.features

--- a/rules/import_middleman.bzl
+++ b/rules/import_middleman.bzl
@@ -198,9 +198,9 @@ def _file_collector_rule_impl(ctx):
     replaced_imported_libraries = _replace_inputs(ctx, exisiting_imported_libraries, input_imported_libraries, _update_lib).inputs
     objc_provider_fields["imported_library"] = depset(_deduplicate_test_deps(test_linker_deps[1], replaced_imported_libraries))
 
-    exisiting_static_framework = objc_provider_fields.get("static_framework_file", depset([]))
+    existing_static_framework = objc_provider_fields.get("static_framework_file", depset([]))
 
-    deduped_static_framework = depset(_deduplicate_test_deps(test_linker_deps[0], exisiting_static_framework.to_list()))
+    deduped_static_framework = depset(_deduplicate_test_deps(test_linker_deps[0], existing_static_framework.to_list()))
     replaced_static_framework = _replace_inputs(ctx, deduped_static_framework, input_static_frameworks, _update_framework)
     objc_provider_fields["static_framework_file"] = depset(replaced_static_framework.inputs)
 

--- a/rules/internal/objc_provider_utils.bzl
+++ b/rules/internal/objc_provider_utils.bzl
@@ -57,6 +57,8 @@ def _merge_dynamic_framework_providers(dynamic_framework_providers):
 
 def _merge_cc_info_providers(cc_info_providers, merge_keys = [
     "headers",
+    "includes",
+    "defines",
 ]):
     fields = {}
     for key in merge_keys:

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -97,7 +97,7 @@ extend_modulemap = rule(
     doc = "Extends a modulemap with a Swift submodule",
 )
 
-def _write_modulemap(name, umbrella_header = None, module_name = None, framework = False):
+def _write_modulemap(name, library_tools, umbrella_header = None, public_headers = [], private_headers = [], module_name = None, framework = False, **kwargs):
     basename = "{}.modulemap".format(name)
     destination = paths.join(name + "-modulemap", basename)
     if not module_name:
@@ -560,7 +560,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
     platforms = kwargs.pop("platforms", None)
     private_deps = [] + kwargs.pop("private_deps", [])
     lib_names = []
-    fetch_default_xcconfig = library_tools["fetch_default_xcconfig"](name, default_xcconfig_name) if default_xcconfig_name else {}
+    fetch_default_xcconfig = library_tools["fetch_default_xcconfig"](name, default_xcconfig_name, **kwargs) if default_xcconfig_name else {}
     copts_by_build_setting = copts_by_build_setting_with_defaults(xcconfig, fetch_default_xcconfig, xcconfig_by_build_setting)
     enable_framework_vfs = kwargs.pop("enable_framework_vfs", False) or namespace_is_module_name
     defines = kwargs.pop("defines", [])
@@ -798,9 +798,13 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
                 objc_hdrs.append(umbrella_header)
             module_map = library_tools["modulemap_generator"](
                 name = name,
+                library_tools = library_tools,
                 umbrella_header = paths.basename(umbrella_header),
+                public_headers = objc_hdrs,
+                private_headers = objc_private_hdrs,
                 module_name = module_name,
                 framework = True,
+                **kwargs
             )
 
     framework_vfs_overlay(

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -304,11 +304,12 @@ def _xcframework_slice(*, xcframework_name, identifier, platform, platform_varia
         # We need the path to the top-level slice directory so we can find headers, modulemaps and swiftmodules.
         slice_dir = paths.dirname(path)
         import_headers, import_module_map, import_swiftmodules = _xcframework_slice_imports(slice_dir)
+        includes = [paths.dirname(f) for f in import_headers]
         native.objc_import(
             name = resolved_target_name,
             archives = [path],
             hdrs = import_headers,
-            includes = ["%s/Headers" % slice_dir],
+            includes = includes,
             tags = _MANUAL,
         )
         _make_xcframework_vfs(import_headers, import_module_map, import_swiftmodules, static = True)

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -304,7 +304,7 @@ def _xcframework_slice(*, xcframework_name, identifier, platform, platform_varia
         # We need the path to the top-level slice directory so we can find headers, modulemaps and swiftmodules.
         slice_dir = paths.dirname(path)
         import_headers, import_module_map, import_swiftmodules = _xcframework_slice_imports(slice_dir)
-        includes = [paths.dirname(f) for f in import_headers]
+        includes = [paths.dirname(f) for f in import_headers] + ["%s/Headers" % slice_dir]
         native.objc_import(
             name = resolved_target_name,
             archives = [path],

--- a/tests/ios/xcframeworks/StaticLib/BUILD.bazel
+++ b/tests/ios/xcframeworks/StaticLib/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_ios//rules:app.bzl", "ios_application")
+load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
 
 ios_application(
     name = "StaticLibApp",
@@ -6,6 +7,16 @@ ios_application(
     bundle_id = "com.example.app",
     minimum_os_version = "10.0",
     provisioning_profile = "@build_bazel_rules_ios//tests/ios:integration-test.mobileprovision",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tests/ios/xcframeworks/StaticLib/ObjcLib",
+    ],
+)
+
+apple_framework(
+    name = "StaticLibFW",
+    srcs = glob(["StaticLibFW/*"]),
+    platforms = {"ios": "11.0"},
     visibility = ["//visibility:public"],
     deps = [
         "//tests/ios/xcframeworks/StaticLib/ObjcLib",

--- a/tests/ios/xcframeworks/StaticLib/StaticLibFW/StaticLibFW.h
+++ b/tests/ios/xcframeworks/StaticLib/StaticLibFW/StaticLibFW.h
@@ -1,0 +1,4 @@
+@import Foundation;
+
+@interface StaticLibFW: NSObject
+@end

--- a/tests/ios/xcframeworks/StaticLib/StaticLibFW/StaticLibFW.m
+++ b/tests/ios/xcframeworks/StaticLib/StaticLibFW/StaticLibFW.m
@@ -1,0 +1,7 @@
+#import <StaticLibFW/StaticLibFW.h>
+// If things are wired up correctly we should be able to #import this _without_ adding the module name, i.e., <ObjcLib/Foo.h>
+#import <Foo.h>
+
+@implementation StaticLibFW
+
+@end


### PR DESCRIPTION
The `includes` attr of `objc_import` is supposed to propagate to targets that depend on it (see [docs](https://bazel.build/reference/be/objective-c#objc_import)) but the layers we have in `rules_ios` (`import_middleman` and `apple_framework_packaging`) were not doing that properly. 

This prevents depending on vendored static libs that might have `#include` statements that don't specify the module name, e.g., `#include <Foo.h>` instead of `#include <FooName/Foo.h>`. In many cases it's not an option to ask the vendor to change their code.

Regarding it's just incorrect to not propagate these includes and effectively break the `objc_import` intended behaviour. Additionally added one test case for this scenario. 

ps: Changes to `fetch_default_xcconfig` and `modulemap_generator` are meant to continue to allow consumers to specify custom attrs and also put back the public/private headers default values in `modulemap_generator`. I believe this is a regression introduced here: https://github.com/bazel-ios/rules_ios/pull/572 (cc @dierksen)