### PR TITLE
Copy runfiles from index-import variants

### DIFF
--- a/rules/legacy_xcodeproj.bzl
+++ b/rules/legacy_xcodeproj.bzl
@@ -1145,6 +1145,7 @@ def _xcodeproj_impl(ctx):
     )
     installer_runfile_paths = [i.short_path for i in ctx.attr.installer[DefaultInfo].default_runfiles.files.to_list()]
     build_wrapper_runfile_paths = [i.short_path for i in ctx.attr.build_wrapper[DefaultInfo].default_runfiles.files.to_list()]
+    index_import_runfiles_paths = [i.short_path for i in ctx.attr.index_import[DefaultInfo].default_runfiles.files.to_list()]
 
     # In order to be runnable, the print_json_leaf_nodes script needs to live
     # next to a print_json_leaf_nodes.runfiles directory that contains its runfiles.
@@ -1169,6 +1170,7 @@ def _xcodeproj_impl(ctx):
             "$(installer_short_path)": ctx.executable.installer.short_path,
             "$(clang_stub_short_path)": ctx.executable.clang_stub.short_path,
             "$(index_import_short_path)": ctx.executable.index_import.short_path,
+            "$(index_import_runfiles_paths)": " ".join(index_import_runfiles_paths),
             "$(clang_stub_ld_path)": ctx.executable.ld_stub.short_path,
             "$(clang_stub_swiftc_path)": ctx.executable.swiftc_stub.short_path,
             "$(print_json_leaf_nodes_path)": ctx.executable.print_json_leaf_nodes.short_path,
@@ -1201,6 +1203,7 @@ def _xcodeproj_impl(ctx):
                          ctx.files.output_processor,
                 transitive = [
                     ctx.attr.build_wrapper[DefaultInfo].default_runfiles.files,
+                    ctx.attr.index_import[DefaultInfo].default_runfiles.files,
                     ctx.attr.installer[DefaultInfo].default_runfiles.files,
                     ctx.attr.print_json_leaf_nodes[DefaultInfo].default_runfiles.files,
                 ],

--- a/tools/xcodeproj_shims/xcodeproj-installer.sh
+++ b/tools/xcodeproj_shims/xcodeproj-installer.sh
@@ -42,6 +42,15 @@ do
   cp -LR "$BUILD_WRAPPER_PATH" "${stubs_dir}/"
 done
 
+index_import_runfiles_paths="$(index_import_runfiles_paths)"
+index_import_runfiles_dest="${installers_dir}/index-import.runfiles"
+mkdir -p "${installers_dir}/index-import.runfiles"
+for RUNFILE_PATH in $index_import_runfiles_paths
+do
+  # coreutils cp must have -L to follow symlinks (mac's cp will do it with -r).
+  cp -LR "$RUNFILE_PATH" "${index_import_runfiles_dest}"
+done
+
 cp "$(clang_stub_short_path)" "${stubs_dir}/clang-stub"
 cp "$(clang_stub_ld_path)" "${stubs_dir}/ld-stub"
 cp "$(clang_stub_swiftc_path)" "${stubs_dir}/swiftc-stub"


### PR DESCRIPTION
In order to capture some usage/timing metrics, I built a wrapper around `index-import`, but I need to make sure that the original binary gets copied into the generated project.

It might be worth making this even more generic so that _all_ the packed-in binaries include runtime dependencies instead of doing it piecemeal.