### PR TITLE
Change macos-latest to macos-11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   integration_tests:
     name: Build and Test
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode
@@ -31,7 +31,7 @@ jobs:
     # consider merging this feature into the default behavior and can re-align
     # the CI job
     name: Build and Test ( Virtual Frameworks )
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode
@@ -56,7 +56,7 @@ jobs:
 
   build_arm64_simulator:
     name: Build arm64 Simulator
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode
@@ -83,7 +83,7 @@ jobs:
 
   buildifier:
     name: Check Starlark and Docs
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode
@@ -95,7 +95,7 @@ jobs:
         run: bazelisk run docs && git diff --exit-code docs
   xcodeproj_tests_xcode_12_5_1:
     name: .xcodeproj Tests on Xcode 12.5.1
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode 12.5.1
@@ -110,7 +110,7 @@ jobs:
 
   lldb_ios_tests_xcode_12_5_1:
     name: LLDB tests on Xcode 12.5.1
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode 12.5.1
@@ -124,7 +124,7 @@ jobs:
           path: bazel-testlogs
   multi_arch_support:
     name: Build iOS App for Multiple Architecture
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode


### PR DESCRIPTION
`macos-latest` has been / will be bumped to match `macos-12`, and our CI is still using Xcode 12.5.1.

Was running into this issue here: https://github.com/bazel-ios/rules_ios/actions/runs/3348628738/jobs/5547932746

Don't know if this is a temporary issue (rollout wasn't supposed to happen for a couple more weeks), but this should unblock CI. See https://github.com/actions/runner-images/issues/6384 for details on the change.

https://github.com/bazel-ios/rules_ios/pull/580 is my WIP on upgrading to the newer image. Could even go crazy and add the `macos-13` image once it's ready 😄 

