### PR TITLE
[Xcode 13.3.1] Flip on in Swift PCH fix

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -975,7 +975,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
                 "//conditions:default": [framework_vfs_overlay_name_swift] if enable_framework_vfs else [],
             }),
             swiftc_inputs = swiftc_inputs,
-            features = ["swift.no_generated_module_map"] + select({
+            features = ["swift.no_generated_module_map", "swift.use_pch_output_dir"] + select({
                 "@build_bazel_rules_ios//:virtualize_frameworks": ["swift.vfsoverlay"],
                 "//conditions:default": [],
             }),


### PR DESCRIPTION
Flips PCH feature to mitigate broken PCH ingestion in some cases as a default. There are issues w/o this even for rules_ios test cases on 13.3.1 and probably apps had to turn that on for this bump. Because there are no known down-sides and it was somewhat involved to debug and create the PCH feature - turn it on a sensible default.