### PR TITLE
Updating rules_apple to point to the latest on the bazel/5.x branch

### DIFF
--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -62,10 +62,10 @@ def rules_ios_dependencies():
     _maybe(
         github_repo,
         name = "build_bazel_rules_apple",
-        ref = "c17af58765d4903a8878d3d6c8004679de4fe8ab",
+        ref = "f8b14ce7516f9055861f91a9e5ff9d299c9d609f",
         project = "bazelbuild",
         repo = "rules_apple",
-        sha256 = "45846e9da2f055065b99e066fd3e6e438085c81909e6203aedc8c2773819fe90",
+        sha256 = "aa0bbee490c153ae0b16bde3be517b8330ba989692b13b10d5036337ac903934",
     )
 
     _maybe(


### PR DESCRIPTION
When building an `apple_framework` as dynamic, if that framework depends on an `apple_resource_group` or an `apple_resource_bundle` the build will fail because `validate_all_resources_owned` is set to true in rules_apple. This https://github.com/bazelbuild/rules_apple/pull/1747 adds a `default_owner` so the check will pass and the `apple_framework` will build properly. This PR updates updates the rules_apple dependency to the latest on the `bazel/5.x` branch that includes this fix.