### PR TITLE
Add substitution support for Info.plist and XCConfigs

### DIFF
--- a/docs/plists_doc.md
+++ b/docs/plists_doc.md
@@ -1,25 +1,58 @@
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 
 
+Defines macros for working with plist files.
 
-<a id="info_plists_by_setting"></a>
 
-## info_plists_by_setting
+<a id="process_infoplists"></a>
+
+## process_infoplists
 
 <pre>
-info_plists_by_setting(<a href="#info_plists_by_setting-name">name</a>, <a href="#info_plists_by_setting-infoplists_by_build_setting">infoplists_by_build_setting</a>, <a href="#info_plists_by_setting-default_infoplists">default_infoplists</a>)
+process_infoplists(<a href="#process_infoplists-name">name</a>, <a href="#process_infoplists-infoplists">infoplists</a>, <a href="#process_infoplists-infoplists_by_build_setting">infoplists_by_build_setting</a>, <a href="#process_infoplists-xcconfig">xcconfig</a>,
+                   <a href="#process_infoplists-xcconfig_by_build_setting">xcconfig_by_build_setting</a>)
 </pre>
 
-
+    Constructs substituted_plists by substituting build settings from an xcconfig dict into the variables of a plist.
 
 **PARAMETERS**
 
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="info_plists_by_setting-name"></a>name |  <p align="center"> - </p>   |  none |
-| <a id="info_plists_by_setting-infoplists_by_build_setting"></a>infoplists_by_build_setting |  <p align="center"> - </p>   |  none |
-| <a id="info_plists_by_setting-default_infoplists"></a>default_infoplists |  <p align="center"> - </p>   |  none |
+| <a id="process_infoplists-name"></a>name |  The name of the target that the plist is being generated for.   |  none |
+| <a id="process_infoplists-infoplists"></a>infoplists |  The plist files to be manipulated   |  none |
+| <a id="process_infoplists-infoplists_by_build_setting"></a>infoplists_by_build_setting |  A dictionary of infoplists keyed by config_setting, merged with infoplists created here.   |  none |
+| <a id="process_infoplists-xcconfig"></a>xcconfig |  the default build settings to expand the infoplists with   |  none |
+| <a id="process_infoplists-xcconfig_by_build_setting"></a>xcconfig_by_build_setting |  the build settings grouped by config_setting to expand the infoplists with   |  none |
+
+**RETURNS**
+
+A selectable dict of the substituted_plists grouped by config_setting
+
+
+<a id="substituted_plist"></a>
+
+## substituted_plist
+
+<pre>
+substituted_plist(<a href="#substituted_plist-name">name</a>, <a href="#substituted_plist-plist">plist</a>, <a href="#substituted_plist-xcconfig">xcconfig</a>)
+</pre>
+
+    Substitutes build settings from an xcconfig dict into the variables of a plist.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="substituted_plist-name"></a>name |  The name of the plist.   |  none |
+| <a id="substituted_plist-plist"></a>plist |  The plist file to substitute into.   |  none |
+| <a id="substituted_plist-xcconfig"></a>xcconfig |  The xcconfig variables for substitution.   |  none |
+
+**RETURNS**
+
+The plist target with the substituted variables.
 
 
 <a id="write_info_plists_if_needed"></a>
@@ -43,5 +76,9 @@ dict, and will add a default app Info.plist if no non-dict plists are passed.
 | :------------- | :------------- | :------------- |
 | <a id="write_info_plists_if_needed-name"></a>name |  The name of the bundle target these infoplists are for.   |  none |
 | <a id="write_info_plists_if_needed-plists"></a>plists |  A list of either labels or dicts.   |  none |
+
+**RETURNS**
+
+A list of labels to the generated Info.plist files.
 
 

--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -1,6 +1,6 @@
 load("@build_bazel_rules_apple//apple:ios.bzl", rules_apple_ios_application = "ios_application")
 load("//rules:library.bzl", "apple_library")
-load("//rules:plists.bzl", "info_plists_by_setting")
+load("//rules:plists.bzl", "process_infoplists")
 load("//rules:force_load_direct_deps.bzl", "force_load_direct_deps")
 load("//rules/internal:framework_middleman.bzl", "dep_middleman", "framework_middleman")
 
@@ -96,12 +96,20 @@ def ios_application(name, apple_library = apple_library, infoplists_by_build_set
     )
     deps = [dep_name] + [force_load_name]
 
+    processed_infoplists = process_infoplists(
+        name = name,
+        infoplists = application_kwargs.pop("infoplists", []),
+        infoplists_by_build_setting = infoplists_by_build_setting,
+        xcconfig = kwargs.get("xcconfig", {}),
+        xcconfig_by_build_setting = kwargs.get("xcconfig_by_build_setting", {}),
+    )
+
     rules_apple_ios_application(
         name = name,
         deps = deps,
         frameworks = frameworks,
         output_discriminator = None,
-        infoplists = info_plists_by_setting(name = name, infoplists_by_build_setting = infoplists_by_build_setting, default_infoplists = application_kwargs.pop("infoplists", [])),
+        infoplists = select(processed_infoplists),
         testonly = testonly,
         **application_kwargs
     )

--- a/rules/extension.bzl
+++ b/rules/extension.bzl
@@ -1,5 +1,5 @@
 load("@build_bazel_rules_apple//apple:ios.bzl", rules_apple_ios_extension = "ios_extension")
-load("//rules:plists.bzl", "info_plists_by_setting")
+load("//rules:plists.bzl", "process_infoplists")
 load("//rules:force_load_direct_deps.bzl", "force_load_direct_deps")
 load("//rules/internal:framework_middleman.bzl", "dep_middleman", "framework_middleman")
 
@@ -59,16 +59,20 @@ def ios_extension(name, infoplists_by_build_setting = {}, **kwargs):
     )
     deps = [dep_name] + [force_load_name]
 
+    processed_infoplists = process_infoplists(
+        name = name,
+        infoplists = kwargs.pop("infoplists", []),
+        infoplists_by_build_setting = infoplists_by_build_setting,
+        xcconfig = kwargs.get("xcconfig", {}),
+        xcconfig_by_build_setting = kwargs.get("xcconfig_by_build_setting", {}),
+    )
+
     rules_apple_ios_extension(
         name = name,
         deps = deps,
         frameworks = frameworks,
         output_discriminator = None,
-        infoplists = info_plists_by_setting(
-            name = name,
-            infoplists_by_build_setting = infoplists_by_build_setting,
-            default_infoplists = kwargs.pop("infoplists", []),
-        ),
+        infoplists = select(processed_infoplists),
         testonly = testonly,
         **kwargs
     )

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -3,7 +3,7 @@
 load("//rules/framework:vfs_overlay.bzl", "VFSOverlayInfo", "make_vfsoverlay")
 load("//rules:features.bzl", "feature_names")
 load("//rules:library.bzl", "PrivateHeadersInfo", "apple_library")
-load("//rules:plists.bzl", "info_plists_by_setting")
+load("//rules:plists.bzl", "process_infoplists")
 load("//rules:providers.bzl", "AvoidDepsInfo", "FrameworkInfo")
 load("//rules:transition_support.bzl", "transition_support")
 load("//rules/internal:objc_provider_utils.bzl", "objc_provider_utils")
@@ -55,11 +55,13 @@ def apple_framework(name, apple_library = apple_library, **kwargs):
     default_infoplists = kwargs.pop("infoplists", [])
     infoplists = None
     if len(infoplists_by_build_setting.values()) > 0 or len(default_infoplists) > 0:
-        infoplists = info_plists_by_setting(
+        infoplists = select(process_infoplists(
             name = name,
+            infoplists = default_infoplists,
             infoplists_by_build_setting = infoplists_by_build_setting,
-            default_infoplists = default_infoplists,
-        )
+            xcconfig = kwargs.get("xcconfig", {}),
+            xcconfig_by_build_setting = kwargs.get("xcconfig_by_build_setting", {}),
+        ))
     environment_plist = kwargs.pop("environment_plist", select({
         "@build_bazel_rules_ios//rules/apple_platform:ios": "@build_bazel_rules_apple//apple/internal:environment_plist_ios",
         "@build_bazel_rules_ios//rules/apple_platform:macos": "@build_bazel_rules_apple//apple/internal:environment_plist_macos",

--- a/rules/plists.bzl
+++ b/rules/plists.bzl
@@ -1,6 +1,92 @@
+"""
+Defines macros for working with plist files.
+"""
+
 load("@bazel_skylib//lib:types.bzl", "types")
+load("@bazel_skylib//lib:sets.bzl", "sets")
+load("@build_bazel_rules_ios//rules:substitute_build_settings.bzl", "substitute_build_settings")
 load("//rules:library.bzl", "write_file")
-load("//rules/library:xcconfig.bzl", "build_setting_name")
+load("//rules/library:xcconfig.bzl", "build_setting_name", "merge_xcconfigs")
+
+def process_infoplists(name, infoplists, infoplists_by_build_setting, xcconfig, xcconfig_by_build_setting):
+    """
+    Constructs substituted_plists by substituting build settings from an xcconfig dict into the variables of a plist.
+
+    Args:
+        name: The name of the target that the plist is being generated for.
+        infoplists: The plist files to be manipulated
+        infoplists_by_build_setting: A dictionary of infoplists keyed by config_setting, merged with infoplists created here.
+        xcconfig: the default build settings to expand the infoplists with
+        xcconfig_by_build_setting: the build settings grouped by config_setting to expand the infoplists with
+
+    Returns:
+        A selectable dict of the substituted_plists grouped by config_setting
+    """
+    infoplists_by_build_setting = dict(infoplists_by_build_setting)
+    xcconfig_by_build_setting = dict(xcconfig_by_build_setting)
+
+    # Final substituted infoplists_by_build_setting dict
+    substituted_infoplists_by_build_setting = {}
+
+    # Default infoplists are any defined in `infoplists` OR in `infoplists_by_build_setting` with the key `//conditions:default`
+    default_infoplists = infoplists_by_build_setting.pop("//conditions:default", infoplists)
+
+    # Default xcconfig is the one defined in `xcconfig` OR in `xcconfig_by_build_setting` with the key `//conditions:default`
+    default_xcconfig = xcconfig_by_build_setting.pop("//conditions:default", xcconfig)
+
+    # Substitute the default infoplists
+    substituted_infoplists_by_build_setting["//conditions:default"] = [
+        substituted_plist(
+            name = "%s.%s.infoplist_substituted" % (name, idx),
+            plist = plist,
+            xcconfig = default_xcconfig,
+        )
+        for idx, plist in enumerate(write_info_plists_if_needed(name = name, plists = default_infoplists))
+    ]
+
+    # Collect a set of config settings to iterate over
+    config_setting_names = sets.make(infoplists_by_build_setting.keys() + xcconfig_by_build_setting.keys())
+
+    # Substitute the infoplists_by_build_setting
+    for config_setting_name in sets.to_list(config_setting_names):
+        name_suffix = build_setting_name(config_setting_name)
+        infoplists_for_build_setting = infoplists_by_build_setting.get(config_setting_name, default_infoplists)
+        xccconfig_for_build_setting = xcconfig_by_build_setting.get(config_setting_name, {})
+        xcconfig_for_plist = merge_xcconfigs(default_xcconfig, xccconfig_for_build_setting)
+
+        # Substitute the build settings into the plists for this config_setting
+        substituted_infoplists_by_build_setting[config_setting_name] = [
+            substituted_plist(
+                name = "%s.%s.%s.infoplist_substituted" % (name, name_suffix, idx),
+                plist = plist,
+                xcconfig = xcconfig_for_plist,
+            )
+            for idx, plist in enumerate(write_info_plists_if_needed(name = "%s.%s" % (name, name_suffix), plists = infoplists_for_build_setting))
+        ]
+
+    return substituted_infoplists_by_build_setting
+
+def substituted_plist(name, plist, xcconfig):
+    """
+    Substitutes build settings from an xcconfig dict into the variables of a plist.
+
+    Args:
+      name: The name of the plist.
+      plist: The plist file to substitute into.
+      xcconfig: The xcconfig variables for substitution.
+
+    Returns:
+        The plist target with the substituted variables.
+    """
+    if not plist:
+        return None
+
+    sub_plist = _substitute_plist_vars(name, plist, xcconfig)
+
+    if sub_plist:
+        return sub_plist
+    else:
+        return plist
 
 def write_info_plists_if_needed(name, plists):
     """
@@ -12,6 +98,9 @@ def write_info_plists_if_needed(name, plists):
     Args:
         name: The name of the bundle target these infoplists are for.
         plists: A list of either labels or dicts.
+
+    Returns:
+        A list of labels to the generated Info.plist files.
     """
     already_written_plists = []
     written_plists = []
@@ -32,13 +121,28 @@ def write_info_plists_if_needed(name, plists):
 
     return already_written_plists + written_plists
 
-def info_plists_by_setting(*, name, infoplists_by_build_setting, default_infoplists):
-    infoplists_by_build_setting = dict(infoplists_by_build_setting)
-    for (build_setting, plists) in infoplists_by_build_setting.items():
-        name_suffix = build_setting_name(build_setting)
-        infoplists_by_build_setting[build_setting] = write_info_plists_if_needed(name = "%s.%s" % (name, name_suffix), plists = plists)
+def _substitute_plist_vars(name, plist, xcconfig):
+    """
+    Expands build settings in the given plist file with variables from the given xcconfig.
 
-    default_infoplists = infoplists_by_build_setting.get("//conditions:default", default_infoplists)
-    infoplists_by_build_setting["//conditions:default"] = write_info_plists_if_needed(name = name, plists = default_infoplists)
+    Args:
+        name: the name of the generated plist.
+        plist: the plist file to be substituted.
+        xcconfig: the build settings to expand against.
+    Returns:
+        The name of the substituted plist
+    """
 
-    return select(infoplists_by_build_setting)
+    variables = {k: v for (k, v) in xcconfig.items() if types.is_string(v)}
+
+    if len(variables) == 0:
+        return None
+
+    substitute_build_settings(
+        name = name,
+        source = plist,
+        variables = variables,
+        tags = ["manual"],
+    )
+
+    return name

--- a/rules/plists_test.bzl
+++ b/rules/plists_test.bzl
@@ -1,0 +1,176 @@
+"""
+Tests for the defines.bzl file.
+"""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("//rules:plists.bzl", "process_infoplists")
+
+def _test_process_infoplists_impl(ctx):
+    env = analysistest.begin(ctx)
+    expected_substitutions = ctx.attr.expected_substitutions
+
+    expand_action = analysistest.target_actions(env)[0]
+    actual_substitutions = expand_action.substitutions
+
+    asserts.equals(env, expected_substitutions, actual_substitutions)
+
+    return analysistest.end(env)
+
+process_infoplists_test = analysistest.make(
+    _test_process_infoplists_impl,
+    attrs = {
+        "expected_substitutions": attr.string_dict(),
+    },
+)
+
+def process_infoplists_test_suite(name):
+    """
+    Test suite for process_infoplists.
+
+    Args:
+        name: Name of the test suite.
+    Returns:
+        Labels of the created tests.
+    """
+
+    # Given default xcconfigs
+    xcconfig = {
+        "CUSTOM_PRODUCT_VERSION": "9.9.9",
+    }
+
+    # Given xcconfigs by build setting
+    xcconfig_by_build_setting = {
+        "//:debug": {
+            "CUSTOM_PRODUCT_VERSION": "7.7.7",
+        },
+        "//:release": {
+            "CUSTOM_PRODUCT_VERSION": "8.8.8",
+        },
+        "//:recursive": {
+            "RECURSIVE_CUSTOM_PRODUCT_VERSION": "$(CUSTOM_PRODUCT_VERSION).RECURSIVE",
+        },
+    }
+
+    # Given this infoplist
+    infoplist = {
+        "CFBundleShortVersionString": "$(CUSTOM_PRODUCT_VERSION)",
+    }
+
+    # Given this infoplists_by_build_setting
+    infoplists_by_build_setting = {
+        "//:debug": [{
+            "CFBundleName": "Debug.$(CUSTOM_PRODUCT_VERSION)",
+        }],
+        "//:release": [{
+            "CFBundleName": "Release.$(CUSTOM_PRODUCT_VERSION)",
+        }],
+        "//:other": [{
+            "CFBundleName": "Other.$(CUSTOM_PRODUCT_VERSION)",
+        }],
+        "//:recursive": [{
+            "CFBundleName": "Recusrive.$(RECURSIVE_CUSTOM_PRODUCT_VERSION)",
+        }],
+    }
+
+    # When process the plist
+    processed_plists = process_infoplists(
+        name = name,
+        infoplists = [infoplist],
+        infoplists_by_build_setting = infoplists_by_build_setting,
+        xcconfig = xcconfig,
+        xcconfig_by_build_setting = xcconfig_by_build_setting,
+    )
+
+    # Then expect substitutions are correct per config_setting based on xcconfig & xcconfig_by_build_setting
+    expected_default_substitutions = {
+        "${CUSTOM_PRODUCT_VERSION}": "9.9.9",
+        "$(CUSTOM_PRODUCT_VERSION)": "9.9.9",
+    }
+    expected_debug_substitutions = {
+        "${CUSTOM_PRODUCT_VERSION}": "7.7.7",
+        "$(CUSTOM_PRODUCT_VERSION)": "7.7.7",
+    }
+    expected_release_substitutions = {
+        "${CUSTOM_PRODUCT_VERSION}": "8.8.8",
+        "$(CUSTOM_PRODUCT_VERSION)": "8.8.8",
+    }
+    expected_recursive_substitutions = {
+        "${CUSTOM_PRODUCT_VERSION}": "9.9.9",
+        "$(CUSTOM_PRODUCT_VERSION)": "9.9.9",
+        "${RECURSIVE_CUSTOM_PRODUCT_VERSION}": "9.9.9.RECURSIVE",
+        "$(RECURSIVE_CUSTOM_PRODUCT_VERSION)": "9.9.9.RECURSIVE",
+    }
+
+    # Then test the default plist is correct
+    default_infoplist = processed_plists["//conditions:default"][1]
+    process_infoplists_test(
+        name = "default_%s" % name,
+        target_under_test = default_infoplist,
+        expected_substitutions = expected_default_substitutions,
+    )
+
+    # Then test the debug default plist is correct
+    default_debug_infoplist = processed_plists["//:debug"][1]
+    process_infoplists_test(
+        name = "default_debug_%s" % name,
+        target_under_test = default_debug_infoplist,
+        expected_substitutions = expected_debug_substitutions,
+    )
+
+    # Then test the release default plist is correct
+    default_release_infoplist = processed_plists["//:release"][1]
+    process_infoplists_test(
+        name = "default_release_%s" % name,
+        target_under_test = default_release_infoplist,
+        expected_substitutions = expected_release_substitutions,
+    )
+
+    # Then test the debug infoplist is correct
+    debug_infoplist = processed_plists["//:debug"][1]
+    process_infoplists_test(
+        name = "debug_%s" % name,
+        target_under_test = debug_infoplist,
+        expected_substitutions = expected_debug_substitutions,
+    )
+
+    # Then test the release infoplist is correct
+    release_infoplist = processed_plists["//:release"][1]
+    process_infoplists_test(
+        name = "release_%s" % name,
+        target_under_test = release_infoplist,
+        expected_substitutions = expected_release_substitutions,
+    )
+
+    # Then test the plist without build settings is correct
+    other_infoplist = processed_plists["//:other"][0]
+    process_infoplists_test(
+        name = "other_%s" % name,
+        target_under_test = other_infoplist,
+        expected_substitutions = expected_default_substitutions,
+    )
+
+    # Then test the plist with xcconfigs that reference other variables is substituted correctly
+    recursive_infoplist = processed_plists["//:recursive"][0]
+    process_infoplists_test(
+        name = "recursive_%s" % name,
+        target_under_test = recursive_infoplist,
+        expected_substitutions = expected_recursive_substitutions,
+    )
+
+    return [
+        "default_%s" % name,
+        "default_debug_%s" % name,
+        "default_release_%s" % name,
+        "debug_%s" % name,
+        "release_%s" % name,
+        "other_%s" % name,
+        "recursive_%s" % name,
+    ]
+
+def plists_test_suite(name):
+    process_infoplists_tests = process_infoplists_test_suite("process_infoplists_test")
+
+    native.test_suite(
+        name = name,
+        tests = process_infoplists_tests,
+    )

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,3 +1,6 @@
 load("//rules/library:xcconfig_test.bzl", "xcconfig_test_suite")
+load("//rules:plists_test.bzl", "plists_test_suite")
 
 xcconfig_test_suite(name = "xcconfig_test")
+
+plists_test_suite(name = "plists_test")

--- a/tests/ios/xcconfig/BUILD.bazel
+++ b/tests/ios/xcconfig/BUILD.bazel
@@ -27,7 +27,8 @@ _XCCONFIG = {
     "OTHER_SWIFT_FLAGS": [
         "-DNMACRO_H",
     ],
-    "CUSTOM_PLIST_VAR": "CUSTOM_PLIST_VALUE",
+    "CUSTOM_XCCONFIG_1": "VALUE_1",
+    "CUSTOM_XCCONFIG_2": "VALUE_2",
 }
 
 _XCCONFIG_BY_BUILD_SETTING = {
@@ -49,6 +50,7 @@ _XCCONFIG_BY_BUILD_SETTING = {
             "-DMACRO_L",
             "-DNMACRO_M",
         ],
+        "CUSTOM_XCCONFIG_3": "VALUE_3+$(CUSTOM_XCCONFIG_1)",
     },
     "//tests/ios/xcconfig:red": {
         "GCC_PREPROCESSOR_DEFINITIONS": [
@@ -84,6 +86,23 @@ ios_application(
     srcs = ["App/main.m"],
     bundle_id = "com.example.app",
     infoplists = ["Info.plist"],
+    minimum_os_version = "10.0",
+    visibility = ["//visibility:public"],
+    xcconfig = _XCCONFIG,
+    xcconfig_by_build_setting = _XCCONFIG_BY_BUILD_SETTING,
+    deps = [
+        ":WithDefinesObjc",
+        ":WithDefinesSwift",
+    ],
+)
+
+ios_application(
+    name = "AppWithInfoPlistsByBuildSetting",
+    srcs = ["App/main.m"],
+    bundle_id = "com.example.app",
+    infoplists_by_build_setting = {
+        "//tests/ios/xcconfig:blue": ["Info.plist"],
+    },
     minimum_os_version = "10.0",
     visibility = ["//visibility:public"],
     xcconfig = _XCCONFIG,

--- a/tests/ios/xcconfig/Info.plist
+++ b/tests/ios/xcconfig/Info.plist
@@ -25,5 +25,11 @@
         <key>NSAllowsArbitraryLoads</key>
         <true/>
     </dict>
+    <key>CustonXCConfig1</key>
+    <string>${CUSTOM_XCCONFIG_1}</string>
+    <key>CustonXCConfig2</key>
+    <string>$(CUSTOM_XCCONFIG_2)</string>
+    <key>CustonXCConfig3</key>
+    <string>$(CUSTOM_XCCONFIG_3)</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

This PR adds support for substituting values in `xcconfig` into `infoplists` and `xcconfig_by_build_setting` in to `infoplists_by_build_setting`. 

In the current rules we have most of what is required to allow substitution of xcconfigs into the plist files but users must create their own macros to do this. Since this is a very common use-case for xcconfigs, and given that `rules_ios` directly supports `xcconfig` and `xcconfig_by_build_setting` it would be a better user experience to automatically performing this variable substitution for users of `rules_ios`


### Problem

Given an `Info.plist`:

```xml
<plist version="1.0">
<dict>
    <key>CFBundleIdentifier</key>
    <string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
    ...
    <key>CustonXCConfig1</key>
    <string>${CUSTOM_XCCONFIG_1}</string>
    <key>CustonXCConfig2</key>
    <string>$(CUSTOM_XCCONFIG_2)</string>
</dict>
</plist>
```

Given a `BUILD.bazel`:

```python
ios_application(
    name = "App",
    xcconfig = {
      "CUSTOM_XCCONFIG_1": "VALUE_1",
      "CUSTOM_XCCONFIG_2": "VALUE_2",
    },
    ...
)
```

It would be expected that we end up with a final `Info.plist`:

```xml
<plist version="1.0">
<dict>
    <key>CFBundleIdentifier</key>
    <string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
    ...
    <key>CustonXCConfig1</key>
    <string>VALUE_1</string>
    <key>CustonXCConfig2</key>
    <string>VALUE_2</string>
</dict>
</plist>
```

However, we currently receive an Info.plist merge error:

```shell
ERROR: In target "//tests/ios/xcconfig:App"; unknown variable reference "${CUSTOM_XCCONFIG_1}" while merging plists (key: "CustonXCConfig1", value: "${CUSTOM_XCCONFIG_1}").
ERROR: /Users/lpadron/Development/rules_ios/tests/ios/xcconfig/BUILD.bazel:81:16 Bundling App failed: (Exit 1): plisttool failed: error executing command 
  (cd /private/var/tmp/_bazel_lpadron/7c5e30dd733c097d91026d4bca2f7997/sandbox/darwin-sandbox/1137/execroot/build_bazel_rules_ios && \
  exec env - \
    APPLE_SDK_PLATFORM=iPhoneSimulator \
    APPLE_SDK_VERSION_OVERRIDE=15.5 \
    XCODE_VERSION_OVERRIDE=13.4.1.13F100 \
  bazel-out/darwin_arm64-opt-exec-2B5CBBC6-ST-dedf359489b7/bin/external/build_bazel_rules_apple/tools/plisttool/plisttool bazel-out/applebin_ios-ios_sim_arm64-dbg-ST-2dd91a95bcfe/bin/tests/ios/xcconfig/App-intermediates/Info.plist-root-control)
# Configuration: ee2650817cf108ae590de90e920dc3ebc71f739bfdb185cc497e135b023391fc
# Execution platform: @local_config_platform//:host
```

### Solution

The solution to the above is to use the existing tools in `rules` to perform variable substitution into the `infoplists` and `infoplists_by_build_setting`. 

We use `write_info_plist_if_needed` and `substitute_build_setting` along with the `xcconfig` and `xcconfig_by_build_setting` attributes provided to the rules to construct a dict of `infoplists_by_build_setting`. This dict is then `select`ed and passed as the `infoplists` attribute the relevant `rules_apple` rules which handle merging the plists.

### Depends on

- https://github.com/bazel-ios/rules_ios/pull/590

### Related

- https://github.com/bazelbuild/rules_apple/issues/226