### PR TITLE
Make the wrap_resources_in_filegroup rule name more unique

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -911,7 +911,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
     if swift_version:
         additional_swift_copts += ["-swift-version", swift_version]
 
-    module_data = library_tools["wrap_resources_in_filegroup"](name = module_name + "_data", srcs = data, testonly = testonly)
+    module_data = library_tools["wrap_resources_in_filegroup"](name = name + "_wrapped_resources_filegroup", srcs = data, testonly = testonly)
 
     if swift_sources:
         additional_swift_copts.extend(("-Xcc", "-I."))


### PR DESCRIPTION
The name is not unique enough and can conflict with other rules.