### PR TITLE
Increase bazel server startup timeout

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -39,5 +39,8 @@ build:lldb_ios_test --spawn_strategy=standalone --apple_platform_type=ios --defi
 # Delete the VM test suite for github
 build --deleted_packages tests/ios/vmd
 
+# Allow for server to start (GitHub actions can timeout)
+build --local_startup_timeout_secs=240
+
 # Load a user.bazelrc
 try-import %workspace%/user.bazelrc

--- a/.bazelrc
+++ b/.bazelrc
@@ -40,7 +40,7 @@ build:lldb_ios_test --spawn_strategy=standalone --apple_platform_type=ios --defi
 build --deleted_packages tests/ios/vmd
 
 # Allow for server to start (GitHub actions can timeout)
-build --local_startup_timeout_secs=240
+startup --local_startup_timeout_secs=240
 
 # Load a user.bazelrc
 try-import %workspace%/user.bazelrc


### PR DESCRIPTION
Been noticing more actions timing out during waiting for the Bazel server to startup ([1](https://github.com/bazel-ios/rules_ios/actions/runs/3429530372/jobs/5715271970))

This increases the timeout to two minutes, this might be related to #580 due to macos-12 being slower / under heavier load for GitHub.