### PR TITLE
Bump xchammer and xcbuildkit

### DIFF
--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -136,15 +136,15 @@ swift_binary(
             name = "xchammer",
             remote = "https://github.com/bazel-ios/xchammer.git",
             # XCHammer dev branch: bazel-ios/rules-ios-xchammer
-            commit = "7ef4e81dbd37926b5c30fc20636d080b3dfabfd6",
-            shallow_since = "1667594979 -0400",
+            commit = "7199f6d968ae6e053174c76014b70421101085a7",
+            shallow_since = "1668108655 -0500",
         )
     xchammer_dependencies()
 
     if not native.existing_rule("xcbuildkit"):
         git_repository(
             name = "xcbuildkit",
-            commit = "4c366afb48cb78caed268d483e3cdb308dfc1794",
+            commit = "d471b11ddd9872467e4850ba7d3ec432c5151445",
             remote = "https://github.com/jerrymarino/xcbuildkit.git",
         )
 

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -46,8 +46,8 @@ def xcodeproj(name, **kwargs):
                 generate_xcode_schemes = generate_xcode_schemes,
                 paths = ["**"],
                 xcconfig_overrides = xcconfig_overrides,
-                bazel_build_service_config = bazel_build_service_config,
             ),
+            bazel_build_service_config = bazel_build_service_config,
             targets = kwargs.get("deps", []),
         )
     else:


### PR DESCRIPTION
Requires:
* https://github.com/jerrymarino/xcbuildkit/pull/51
* https://github.com/bazel-ios/xchammer/pull/34

Besides the bumps moves `bazel_build_service_config` to be a "top level" attr since it's not part of `project_config` anymore.

- [ ] Bump `xchammer` and `xcbuildkit` to `master` before landing