### PR TITLE
Bump xchammer and xcbuildkit (2)

### DIFF
--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -136,8 +136,8 @@ swift_binary(
             name = "xchammer",
             remote = "https://github.com/bazel-ios/xchammer.git",
             # XCHammer dev branch: bazel-ios/rules-ios-xchammer
-            commit = "7199f6d968ae6e053174c76014b70421101085a7",
-            shallow_since = "1668108655 -0500",
+            commit = "359ef1983ea5abbf4ad2f171d039522b23f1f23d",
+            shallow_since = "1668445956 -0500",
         )
     xchammer_dependencies()
 

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -144,7 +144,7 @@ swift_binary(
     if not native.existing_rule("xcbuildkit"):
         git_repository(
             name = "xcbuildkit",
-            commit = "d471b11ddd9872467e4850ba7d3ec432c5151445",
+            commit = "2de1d41bdd4b9eea60764800af1ed7fcd62eeed3",
             remote = "https://github.com/jerrymarino/xcbuildkit.git",
         )
 

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -136,15 +136,15 @@ swift_binary(
             name = "xchammer",
             remote = "https://github.com/bazel-ios/xchammer.git",
             # XCHammer dev branch: bazel-ios/rules-ios-xchammer
-            commit = "7ef4e81dbd37926b5c30fc20636d080b3dfabfd6",
-            shallow_since = "1667594979 -0400",
+            commit = "7199f6d968ae6e053174c76014b70421101085a7",
+            shallow_since = "1668108655 -0500",
         )
     xchammer_dependencies()
 
     if not native.existing_rule("xcbuildkit"):
         git_repository(
             name = "xcbuildkit",
-            commit = "4c366afb48cb78caed268d483e3cdb308dfc1794",
+            commit = "d471b11ddd9872467e4850ba7d3ec432c5151445",
             remote = "https://github.com/jerrymarino/xcbuildkit.git",
         )
 

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -46,8 +46,8 @@ def xcodeproj(name, **kwargs):
                 generate_xcode_schemes = generate_xcode_schemes,
                 paths = ["**"],
                 xcconfig_overrides = xcconfig_overrides,
-                bazel_build_service_config = bazel_build_service_config,
             ),
+            bazel_build_service_config = bazel_build_service_config,
             targets = kwargs.get("deps", []),
         )
     else:

--- a/tests/ios/xcodeproj/BUILD.bazel
+++ b/tests/ios/xcodeproj/BUILD.bazel
@@ -225,9 +225,6 @@ xcodeproj(
 xcodeproj(
     name = "App-XCHammerWithXCBuildKit",
     bazel_build_service_config = bazel_build_service_config(
-        bep_path = "/tmp/bep.bep",
-        index_store_path = "$SRCROOT/%s" % GLOBAL_INDEX_STORE_PATH,
-        indexing_data_dir = "/tmp/xcbuildkit-data/indexing",
         indexing_enabled = True,
         progress_bar_enabled = True,
     ),

--- a/tests/ios/xcodeproj/BUILD.bazel
+++ b/tests/ios/xcodeproj/BUILD.bazel
@@ -1,6 +1,5 @@
 load("//rules:xcodeproj.bzl", "xcodeproj")
 load("//rules:legacy_xcodeproj.bzl", "xcodeproj_project_options")
-load("//rules:library.bzl", "GLOBAL_INDEX_STORE_PATH")
 load("//rules:additional_scheme_info.bzl", "additional_scheme_info")
 load("@xchammer//:BazelExtensions/xchammerconfig.bzl", "bazel_build_service_config")
 


### PR DESCRIPTION
Same as https://github.com/bazel-ios/rules_ios/pull/597 that was merged by mistake and it's now ready to be merged for real.

Requires:
* https://github.com/jerrymarino/xcbuildkit/pull/51
* https://github.com/bazel-ios/xchammer/pull/34

Besides the bumps moves `bazel_build_service_config` to be a "top level" attr since it's not part of `project_config` anymore.

- [x] Bump `xchammer` and `xcbuildkit` to `master` before landing