### PR TITLE
Revert "Fix issue merging xcconfig values that are lists (#590)"

### DIFF
--- a/rules/library/xcconfig.bzl
+++ b/rules/library/xcconfig.bzl
@@ -329,11 +329,7 @@ def copts_by_build_setting_with_defaults(xcconfig = {}, fetch_default_xcconfig =
 def merge_xcconfigs(*xcconfigs):
     """Merges a list of xcconfigs into a single dictionary
 
-    Uses some heuristics to merge xcconfigs in a way that is compatible with Xcode's behavior:
-
-    - If a key is present in multiple xcconfigs
-        - If the value is a list, the values are concatenated
-        - If the value is a string, the last xcconfig value is used
+    Overrides keys from the first xcconfig with the values from the latest one if they match.
 
     Args:
         *xcconfigs: A list of dictionaries of Xcode build settings
@@ -343,9 +339,6 @@ def merge_xcconfigs(*xcconfigs):
     merged_xcconfig = {}
     for xcconfig in xcconfigs:
         for (key, value) in dict(xcconfig).items():
-            if types.is_list(merged_xcconfig.get(key, None)) and types.is_list(value):
-                merged_xcconfig[key] = merged_xcconfig[key] + value
-            else:
-                merged_xcconfig[key] = value
+            merged_xcconfig[key] = value
 
     return merged_xcconfig

--- a/rules/library/xcconfig_test.bzl
+++ b/rules/library/xcconfig_test.bzl
@@ -28,13 +28,12 @@ def _test_merge_xcconfigs_impl(ctx):
     # When we merge them
     merged = merge_xcconfigs(xcconfig_a, xcconfig_b)
 
-    # Then expect that the string values are overriden in later xcconfigs
-    # and that list values are concatenated
+    # Then expect that the string & list values are overriden in later xcconfigs
     asserts.equals(env, merged["VALUE_1"], "overriden")
     asserts.equals(env, merged["VALUE_2"], "b")
     asserts.equals(env, merged["VALUE_3"], ["c"])
     asserts.equals(env, merged["VALUE_4"], "d")
-    asserts.equals(env, merged["LIST_VALUE_1"], ["a", "b", "added"])
+    asserts.equals(env, merged["LIST_VALUE_1"], ["added"])
     asserts.equals(env, merged["LIST_VALUE_2"], ["d"])
 
     return unittest.end(env)

--- a/tests/ios/xcconfig/BUILD.bazel
+++ b/tests/ios/xcconfig/BUILD.bazel
@@ -22,19 +22,10 @@ string_flag(
 
 _XCCONFIG = {
     "GCC_PREPROCESSOR_DEFINITIONS": [
-        "MACRO_B=1",
-        "MACRO_C=0",
-        "MACRO_D=1",
-        "MACRO_E=1",
-        "MACRO_F=0",
-        "MACRO_G=1",
+        "MACRO_A=0",
     ],
     "OTHER_SWIFT_FLAGS": [
-        "-DMACRO_I",
-        "-DNMACRO_J",
-        "-DMACRO_K",
-        "-DMACRO_L",
-        "-DNMACRO_M",
+        "-DNMACRO_H",
     ],
     "CUSTOM_PLIST_VAR": "CUSTOM_PLIST_VALUE",
 }
@@ -43,9 +34,20 @@ _XCCONFIG_BY_BUILD_SETTING = {
     "//tests/ios/xcconfig:blue": {
         "GCC_PREPROCESSOR_DEFINITIONS": [
             "MACRO_A=1",
+            "MACRO_B=1",
+            "MACRO_C=0",
+            "MACRO_D=1",
+            "MACRO_E=1",
+            "MACRO_F=0",
+            "MACRO_G=1",
         ],
         "OTHER_SWIFT_FLAGS": [
             "-DMACRO_H",
+            "-DMACRO_I",
+            "-DNMACRO_J",
+            "-DMACRO_K",
+            "-DMACRO_L",
+            "-DNMACRO_M",
         ],
     },
     "//tests/ios/xcconfig:red": {


### PR DESCRIPTION
This reverts commit f304c3721b23c426a37b33ceb8e739586c8219f1.

This mixes other kinds of semantics and would suggest to keep "import" semenatics of thses.

Ideally something like cocoapods "concat" is handled elsewhere: fixing the BUILD file generator / cocoapods-bazel to do `$(inherited)` or other merging. For instance if you need to concat or do inheritance of 2 settings - you'd have to concatenate out of this program:

```
xcconfig = { debug: [A] } <- optimization would be to remove this
xcconfig_by_build_setting = {
   debug: [A] + [B]
   release: [A] + [C]
}
```