### PR TITLE
Add SwiftInfo to hmap/vfs rules to suppress module map generation

### DIFF
--- a/rules/framework/vfs_overlay.bzl
+++ b/rules/framework/vfs_overlay.bzl
@@ -1,6 +1,7 @@
 load("//rules:providers.bzl", "FrameworkInfo")
 load("//rules:features.bzl", "feature_names")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_common")
 
 FRAMEWORK_SEARCH_PATH = "/build_bazel_rules_ios/frameworks"
 
@@ -273,6 +274,7 @@ def _framework_vfs_overlay_impl(ctx):
             files = depset([vfs.vfsoverlay_file]),
             vfs_info = vfs.vfs_info,
         ),
+        swift_common.create_swift_info(),
     ]
 
 def _merge_vfs_infos(base, vfs_infos):

--- a/rules/hmap.bzl
+++ b/rules/hmap.bzl
@@ -1,5 +1,7 @@
 """Header Map rules"""
 
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_common")
+
 HeaderMapInfo = provider(
     doc = "Propagates header maps",
     fields = {
@@ -78,6 +80,7 @@ def _make_headermap_impl(ctx):
     providers = [
         apple_common.new_objc_provider(),
         cc_info_provider,
+        swift_common.create_swift_info(),
     ]
 
     hdrs_lists = [l for l in hdrs_lists if l]


### PR DESCRIPTION
Ran `aquery` to verify; the only change on `SwiftCompile` is to remove all the `-Xcc -fmodule-map-file=...` lines for the hmap and vfs files.

Fixes #538.