### PR TITLE
Bump rules_apple, rules_swift, and stardoc

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,9 +46,9 @@ load(
 
 git_repository(
     name = "io_bazel_stardoc",
-    commit = "f4d4b3a965c9ae36feeff5eb3171d6ba17406b84",
+    commit = "6f274e903009158504a9d9130d7f7d5f3e9421ed",
     remote = "https://github.com/bazelbuild/stardoc.git",
-    shallow_since = "1636567136 -0500",
+    shallow_since = "1667581897 -0400",
 )
 
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")

--- a/docs/app_doc.md
+++ b/docs/app_doc.md
@@ -2,7 +2,7 @@
 
 
 
-<a id="#ios_application"></a>
+<a id="ios_application"></a>
 
 ## ios_application
 
@@ -18,7 +18,7 @@ ios_application(<a href="#ios_application-name">name</a>, <a href="#ios_applicat
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="ios_application-name"></a>name |  The name of the iOS application.   |  none |
-| <a id="ios_application-apple_library"></a>apple_library |  The macro used to package sources into a library.   |  <code><function apple_library></code> |
+| <a id="ios_application-apple_library"></a>apple_library |  The macro used to package sources into a library.   |  <code>&lt;function apple_library&gt;</code> |
 | <a id="ios_application-infoplists_by_build_setting"></a>infoplists_by_build_setting |  A dictionary of infoplists grouped by bazel build setting.<br><br>Each value is applied if the respective bazel build setting is resolved during the analysis phase.<br><br>If '//conditions:default' is not set the value in 'infoplists' is set as default.   |  <code>{}</code> |
 | <a id="ios_application-kwargs"></a>kwargs |  Arguments passed to the apple_library and ios_application rules as appropriate.   |  none |
 

--- a/docs/apple_patched_doc.md
+++ b/docs/apple_patched_doc.md
@@ -2,7 +2,7 @@
 
 This file contains drop-in replacements for rules in the rules_apple repository
 
-<a id="#apple_dynamic_framework_import"></a>
+<a id="apple_dynamic_framework_import"></a>
 
 ## apple_dynamic_framework_import
 
@@ -23,7 +23,7 @@ Args: same as the ones of apple_dynamic_framework_import
 | <a id="apple_dynamic_framework_import-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
 
 
-<a id="#apple_static_framework_import"></a>
+<a id="apple_static_framework_import"></a>
 
 ## apple_static_framework_import
 

--- a/docs/framework_builder_doc.md
+++ b/docs/framework_builder_doc.md
@@ -2,7 +2,7 @@
 
 This file contains rules to build framework binaries from your podfile or cartfile
 
-<a id="#build_carthage_frameworks"></a>
+<a id="build_carthage_frameworks"></a>
 
 ## build_carthage_frameworks
 
@@ -28,7 +28,7 @@ build_carthage_frameworks(<a href="#build_carthage_frameworks-name">name</a>, <a
 | <a id="build_carthage_frameworks-verbose"></a>verbose |  if true, it will show the output of running carthage in the command line   |  <code>False</code> |
 
 
-<a id="#build_cocoapods_frameworks"></a>
+<a id="build_cocoapods_frameworks"></a>
 
 ## build_cocoapods_frameworks
 

--- a/docs/framework_doc.md
+++ b/docs/framework_doc.md
@@ -2,7 +2,7 @@
 
 Framework rules
 
-<a id="#apple_framework_packaging"></a>
+<a id="apple_framework_packaging"></a>
 
 ## apple_framework_packaging
 
@@ -21,29 +21,29 @@ Packages compiled code into an Apple .framework package
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="apple_framework_packaging-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="apple_framework_packaging-bundle_extension"></a>bundle_extension |  The extension of the bundle, defaults to "framework".   | String | optional | "framework" |
-| <a id="apple_framework_packaging-bundle_id"></a>bundle_id |  The bundle identifier of the framework. Currently unused.   | String | optional | "" |
-| <a id="apple_framework_packaging-data"></a>data |  Objc or Swift rules to be packed by the framework rule   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="apple_framework_packaging-deps"></a>deps |  Objc or Swift rules to be packed by the framework rule   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
-| <a id="apple_framework_packaging-environment_plist"></a>environment_plist |  An executable file referencing the environment_plist tool. Used to merge infoplists. See https://github.com/bazelbuild/rules_apple/blob/master/apple/internal/environment_plist.bzl#L69   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="apple_framework_packaging-exported_symbols_lists"></a>exported_symbols_lists |     | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="apple_framework_packaging-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="apple_framework_packaging-bundle_extension"></a>bundle_extension |  The extension of the bundle, defaults to "framework".   | String | optional | <code>"framework"</code> |
+| <a id="apple_framework_packaging-bundle_id"></a>bundle_id |  The bundle identifier of the framework. Currently unused.   | String | optional | <code>""</code> |
+| <a id="apple_framework_packaging-data"></a>data |  Objc or Swift rules to be packed by the framework rule   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
+| <a id="apple_framework_packaging-deps"></a>deps |  Objc or Swift rules to be packed by the framework rule   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
+| <a id="apple_framework_packaging-environment_plist"></a>environment_plist |  An executable file referencing the environment_plist tool. Used to merge infoplists. See https://github.com/bazelbuild/rules_apple/blob/master/apple/internal/environment_plist.bzl#L69   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="apple_framework_packaging-exported_symbols_lists"></a>exported_symbols_lists |     | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="apple_framework_packaging-framework_name"></a>framework_name |  Name of the framework, usually the same as the module name   | String | required |  |
-| <a id="apple_framework_packaging-frameworks"></a>frameworks |  A list of framework targets (see [<code>ios_framework</code>](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-ios.md#ios_framework)) that this target depends on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="apple_framework_packaging-infoplists"></a>infoplists |  The infoplists for the framework   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="apple_framework_packaging-library_linkopts"></a>library_linkopts |  Internal - A list of strings representing extra flags that are passed to the linker for the underlying library.   | List of strings | optional | [] |
-| <a id="apple_framework_packaging-link_dynamic"></a>link_dynamic |  Weather or not if this framework is dynamic<br><br>The default behavior bakes this into the top level app. When false, it's statically linked.   | Boolean | optional | False |
-| <a id="apple_framework_packaging-minimum_deployment_os_version"></a>minimum_deployment_os_version |  The bundle identifier of the framework. Currently unused.   | String | optional | "" |
-| <a id="apple_framework_packaging-minimum_os_version"></a>minimum_os_version |  Internal - currently rules_ios the dict <code>platforms</code>   | String | optional | "" |
-| <a id="apple_framework_packaging-platform_type"></a>platform_type |  Internal - currently rules_ios uses the dict <code>platforms</code>   | String | optional | "" |
-| <a id="apple_framework_packaging-platforms"></a>platforms |  A dictionary of platform names to minimum deployment targets. If not given, the framework will be built for the platform it inherits from the target that uses the framework as a dependency.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
-| <a id="apple_framework_packaging-skip_packaging"></a>skip_packaging |  Parts of the framework packaging process to be skipped. Valid values are: - "binary" - "modulemap" - "header" - "private_header" - "swiftmodule" - "swiftdoc"   | List of strings | optional | [] |
-| <a id="apple_framework_packaging-stamp"></a>stamp |  -   | Integer | optional | 0 |
-| <a id="apple_framework_packaging-transitive_deps"></a>transitive_deps |  Deps of the deps   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
-| <a id="apple_framework_packaging-vfs"></a>vfs |  Additional VFS for the framework to export   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="apple_framework_packaging-frameworks"></a>frameworks |  A list of framework targets (see [<code>ios_framework</code>](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-ios.md#ios_framework)) that this target depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
+| <a id="apple_framework_packaging-infoplists"></a>infoplists |  The infoplists for the framework   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
+| <a id="apple_framework_packaging-library_linkopts"></a>library_linkopts |  Internal - A list of strings representing extra flags that are passed to the linker for the underlying library.   | List of strings | optional | <code>[]</code> |
+| <a id="apple_framework_packaging-link_dynamic"></a>link_dynamic |  Weather or not if this framework is dynamic<br><br>The default behavior bakes this into the top level app. When false, it's statically linked.   | Boolean | optional | <code>False</code> |
+| <a id="apple_framework_packaging-minimum_deployment_os_version"></a>minimum_deployment_os_version |  The bundle identifier of the framework. Currently unused.   | String | optional | <code>""</code> |
+| <a id="apple_framework_packaging-minimum_os_version"></a>minimum_os_version |  Internal - currently rules_ios the dict <code>platforms</code>   | String | optional | <code>""</code> |
+| <a id="apple_framework_packaging-platform_type"></a>platform_type |  Internal - currently rules_ios uses the dict <code>platforms</code>   | String | optional | <code>""</code> |
+| <a id="apple_framework_packaging-platforms"></a>platforms |  A dictionary of platform names to minimum deployment targets. If not given, the framework will be built for the platform it inherits from the target that uses the framework as a dependency.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |
+| <a id="apple_framework_packaging-skip_packaging"></a>skip_packaging |  Parts of the framework packaging process to be skipped. Valid values are: - "binary" - "modulemap" - "header" - "private_header" - "swiftmodule" - "swiftdoc"   | List of strings | optional | <code>[]</code> |
+| <a id="apple_framework_packaging-stamp"></a>stamp |  -   | Integer | optional | <code>0</code> |
+| <a id="apple_framework_packaging-transitive_deps"></a>transitive_deps |  Deps of the deps   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
+| <a id="apple_framework_packaging-vfs"></a>vfs |  Additional VFS for the framework to export   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 
 
-<a id="#apple_framework"></a>
+<a id="apple_framework"></a>
 
 ## apple_framework
 
@@ -59,7 +59,7 @@ Builds and packages an Apple framework.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="apple_framework-name"></a>name |  The name of the framework.   |  none |
-| <a id="apple_framework-apple_library"></a>apple_library |  The macro used to package sources into a library.   |  <code><function apple_library></code> |
+| <a id="apple_framework-apple_library"></a>apple_library |  The macro used to package sources into a library.   |  <code>&lt;function apple_library&gt;</code> |
 | <a id="apple_framework-kwargs"></a>kwargs |  Arguments passed to the apple_library and apple_framework_packaging rules as appropriate.   |  none |
 
 

--- a/docs/hmap_doc.md
+++ b/docs/hmap_doc.md
@@ -2,7 +2,7 @@
 
 Header Map rules
 
-<a id="#headermap"></a>
+<a id="headermap"></a>
 
 ## headermap
 
@@ -22,13 +22,13 @@ regardless of the package structure being used.
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="headermap-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="headermap-direct_hdr_providers"></a>direct_hdr_providers |  Targets whose direct headers should be added to the list of hdrs   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="headermap-hdrs"></a>hdrs |  The list of headers included in the headermap   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
-| <a id="headermap-namespace"></a>namespace |  The prefix to be used for header imports   | String | optional | "" |
+| <a id="headermap-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="headermap-direct_hdr_providers"></a>direct_hdr_providers |  Targets whose direct headers should be added to the list of hdrs   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
+| <a id="headermap-hdrs"></a>hdrs |  The list of headers included in the headermap   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
+| <a id="headermap-namespace"></a>namespace |  The prefix to be used for header imports   | String | optional | <code>""</code> |
 
 
-<a id="#HeaderMapInfo"></a>
+<a id="HeaderMapInfo"></a>
 
 ## HeaderMapInfo
 
@@ -46,7 +46,7 @@ Propagates header maps
 | <a id="HeaderMapInfo-files"></a>files |  depset with headermaps    |
 
 
-<a id="#hmap.make_hmap"></a>
+<a id="hmap.make_hmap"></a>
 
 ## hmap.make_hmap
 

--- a/docs/library_doc.md
+++ b/docs/library_doc.md
@@ -2,7 +2,7 @@
 
 Library rules
 
-<a id="#extend_modulemap"></a>
+<a id="extend_modulemap"></a>
 
 ## extend_modulemap
 
@@ -17,14 +17,14 @@ Extends a modulemap with a Swift submodule
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="extend_modulemap-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="extend_modulemap-destination"></a>destination |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional |  |
+| <a id="extend_modulemap-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="extend_modulemap-destination"></a>destination |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  |
 | <a id="extend_modulemap-module_name"></a>module_name |  -   | String | required |  |
-| <a id="extend_modulemap-source"></a>source |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="extend_modulemap-swift_header"></a>swift_header |  -   | String | optional | "" |
+| <a id="extend_modulemap-source"></a>source |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="extend_modulemap-swift_header"></a>swift_header |  -   | String | optional | <code>""</code> |
 
 
-<a id="#write_file"></a>
+<a id="write_file"></a>
 
 ## write_file
 
@@ -39,12 +39,12 @@ Writes out a file verbatim
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="write_file-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="write_file-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="write_file-content"></a>content |  -   | String | required |  |
-| <a id="write_file-destination"></a>destination |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="write_file-destination"></a>destination |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 
 
-<a id="#PrivateHeadersInfo"></a>
+<a id="PrivateHeadersInfo"></a>
 
 ## PrivateHeadersInfo
 
@@ -62,7 +62,7 @@ Propagates private headers, so they can be accessed if necessary
 | <a id="PrivateHeadersInfo-headers"></a>headers |  Private headers    |
 
 
-<a id="#apple_library"></a>
+<a id="apple_library"></a>
 
 ## apple_library
 

--- a/docs/plists_doc.md
+++ b/docs/plists_doc.md
@@ -2,7 +2,7 @@
 
 
 
-<a id="#info_plists_by_setting"></a>
+<a id="info_plists_by_setting"></a>
 
 ## info_plists_by_setting
 
@@ -22,7 +22,7 @@ info_plists_by_setting(<a href="#info_plists_by_setting-name">name</a>, <a href=
 | <a id="info_plists_by_setting-default_infoplists"></a>default_infoplists |  <p align="center"> - </p>   |  none |
 
 
-<a id="#write_info_plists_if_needed"></a>
+<a id="write_info_plists_if_needed"></a>
 
 ## write_info_plists_if_needed
 

--- a/docs/precompiled_apple_resource_bundle_doc.md
+++ b/docs/precompiled_apple_resource_bundle_doc.md
@@ -8,7 +8,7 @@ https://github.com/bazelbuild/rules_apple/issues/319
 if this is ever fixed in bazel it should be removed
 
 
-<a id="#precompiled_apple_resource_bundle"></a>
+<a id="precompiled_apple_resource_bundle"></a>
 
 ## precompiled_apple_resource_bundle
 

--- a/docs/substitute_build_settings_doc.md
+++ b/docs/substitute_build_settings_doc.md
@@ -2,7 +2,7 @@
 
 
 
-<a id="#substitute_build_settings"></a>
+<a id="substitute_build_settings"></a>
 
 ## substitute_build_settings
 
@@ -18,8 +18,8 @@ Does Xcode-style build setting substitutions into the given source file.
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="substitute_build_settings-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="substitute_build_settings-source"></a>source |  The file to be expanded   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
-| <a id="substitute_build_settings-variables"></a>variables |  A mapping of settings to their values to be expanded. The setting names should not include <code>$</code>s   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
+| <a id="substitute_build_settings-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="substitute_build_settings-source"></a>source |  The file to be expanded   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="substitute_build_settings-variables"></a>variables |  A mapping of settings to their values to be expanded. The setting names should not include <code>$</code>s   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |
 
 

--- a/docs/test_doc.md
+++ b/docs/test_doc.md
@@ -2,7 +2,7 @@
 
 
 
-<a id="#ios_ui_test"></a>
+<a id="ios_ui_test"></a>
 
 ## ios_ui_test
 
@@ -18,11 +18,11 @@ ios_ui_test(<a href="#ios_ui_test-name">name</a>, <a href="#ios_ui_test-apple_li
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="ios_ui_test-name"></a>name |  The name of the UI test.   |  none |
-| <a id="ios_ui_test-apple_library"></a>apple_library |  The macro used to package sources into a library.   |  <code><function apple_library></code> |
+| <a id="ios_ui_test-apple_library"></a>apple_library |  The macro used to package sources into a library.   |  <code>&lt;function apple_library&gt;</code> |
 | <a id="ios_ui_test-kwargs"></a>kwargs |  Arguments passed to the apple_library and ios_ui_test rules as appropriate.   |  none |
 
 
-<a id="#ios_unit_test"></a>
+<a id="ios_unit_test"></a>
 
 ## ios_unit_test
 
@@ -38,7 +38,7 @@ ios_unit_test(<a href="#ios_unit_test-name">name</a>, <a href="#ios_unit_test-ap
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="ios_unit_test-name"></a>name |  The name of the unit test.   |  none |
-| <a id="ios_unit_test-apple_library"></a>apple_library |  The macro used to package sources into a library.   |  <code><function apple_library></code> |
+| <a id="ios_unit_test-apple_library"></a>apple_library |  The macro used to package sources into a library.   |  <code>&lt;function apple_library&gt;</code> |
 | <a id="ios_unit_test-kwargs"></a>kwargs |  Arguments passed to the apple_library and ios_unit_test rules as appropriate.   |  none |
 
 

--- a/docs/transition_support_doc.md
+++ b/docs/transition_support_doc.md
@@ -2,7 +2,7 @@
 
 Starlark transition support for Apple rules.
 
-<a id="#transition_support.current_apple_platform"></a>
+<a id="transition_support.current_apple_platform"></a>
 
 ## transition_support.current_apple_platform
 

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -54,18 +54,18 @@ def rules_ios_dependencies():
         github_repo,
         name = "build_bazel_rules_swift",
         project = "bazel-ios",
-        ref = "e0272df7d98a563c07aa2e78722cd8ce62549864",
+        ref = "a25aed4e75893a55c1c98524201451c05f66ab89",
         repo = "rules_swift",
-        sha256 = "006743d481c477928796ad985ba32b591f5926cd590d32b207e018049b569594",
+        sha256 = "9f13f4be00dfd6a37d9338e49ebbc337445361134a4bcc668658b96fdbdeaae4",
     )
 
     _maybe(
         github_repo,
         name = "build_bazel_rules_apple",
-        ref = "f8b14ce7516f9055861f91a9e5ff9d299c9d609f",
+        ref = "f99c3cb7e472ecd68b81ea8dab97609a4b75db06",
         project = "bazelbuild",
         repo = "rules_apple",
-        sha256 = "aa0bbee490c153ae0b16bde3be517b8330ba989692b13b10d5036337ac903934",
+        sha256 = "5e82a98a591efda772a5ee96ed17bcad38338aafeba6055daab04a5d6c13ea50",
     )
 
     _maybe(

--- a/tests/ios/frameworks/core-data-resource-bundle/BUILD.bazel
+++ b/tests/ios/frameworks/core-data-resource-bundle/BUILD.bazel
@@ -16,6 +16,7 @@ apple_framework(
 
 apple_framework(
     name = "CoreDataExampleTestsLib",
+    testonly = 1,
     srcs = glob(["CoreDataExampleTests/**/*.swift"]),
     platforms = {"ios": "11.0"},
     visibility = ["//visibility:public"],

--- a/tests/ios/frameworks/core-data-resource-bundle/BUILD.bazel
+++ b/tests/ios/frameworks/core-data-resource-bundle/BUILD.bazel
@@ -16,7 +16,7 @@ apple_framework(
 
 apple_framework(
     name = "CoreDataExampleTestsLib",
-    testonly = 1,
+    testonly = True,
     srcs = glob(["CoreDataExampleTests/**/*.swift"]),
     platforms = {"ios": "11.0"},
     visibility = ["//visibility:public"],

--- a/tests/ios/frameworks/mixed-source/only-source/BUILD.bazel
+++ b/tests/ios/frameworks/mixed-source/only-source/BUILD.bazel
@@ -28,6 +28,7 @@ apple_framework(
 
 apple_framework(
     name = "MixedSourceTestLib",
+    testonly = True,
     srcs = glob(
         [
             "MixedSourceTest/**/*.h",

--- a/tests/ios/frameworks/sources-with-prebuilt-binaries/BUILD.bazel
+++ b/tests/ios/frameworks/sources-with-prebuilt-binaries/BUILD.bazel
@@ -43,7 +43,7 @@ apple_framework(
 
 apple_framework(
     name = "MixedSourceFrameworkTestLib",
-    testonly = 1,
+    testonly = True,
     srcs = glob(["MixedSourceFrameworkTests/**/*.swift"]),
     visibility = ["//visibility:public"],
     deps = [

--- a/tests/ios/frameworks/sources-with-prebuilt-binaries/BUILD.bazel
+++ b/tests/ios/frameworks/sources-with-prebuilt-binaries/BUILD.bazel
@@ -43,6 +43,7 @@ apple_framework(
 
 apple_framework(
     name = "MixedSourceFrameworkTestLib",
+    testonly = 1,
     srcs = glob(["MixedSourceFrameworkTests/**/*.swift"]),
     visibility = ["//visibility:public"],
     deps = [

--- a/tests/ios/frameworks/target-xib-resource-bundle/BUILD.bazel
+++ b/tests/ios/frameworks/target-xib-resource-bundle/BUILD.bazel
@@ -13,6 +13,7 @@ apple_framework(
 
 apple_framework(
     name = "TargetXIBTestsLib",
+    testonly = 1,
     srcs = glob(["TargetXIBTests/**/*.swift"]),
     platforms = {"ios": "11.0"},
     visibility = ["//visibility:public"],

--- a/tests/ios/frameworks/target-xib-resource-bundle/BUILD.bazel
+++ b/tests/ios/frameworks/target-xib-resource-bundle/BUILD.bazel
@@ -13,7 +13,7 @@ apple_framework(
 
 apple_framework(
     name = "TargetXIBTestsLib",
-    testonly = 1,
+    testonly = True,
     srcs = glob(["TargetXIBTests/**/*.swift"]),
     platforms = {"ios": "11.0"},
     visibility = ["//visibility:public"],

--- a/tests/ios/frameworks/target-xib/BUILD.bazel
+++ b/tests/ios/frameworks/target-xib/BUILD.bazel
@@ -11,7 +11,7 @@ apple_framework(
 
 apple_framework(
     name = "TargetXIBTestsLib",
-    testonly = 1,
+    testonly = True,
     srcs = glob(["TargetXIBTests/**/*.swift"]),
     platforms = {"ios": "11.0"},
     visibility = ["//visibility:public"],

--- a/tests/ios/frameworks/target-xib/BUILD.bazel
+++ b/tests/ios/frameworks/target-xib/BUILD.bazel
@@ -11,6 +11,7 @@ apple_framework(
 
 apple_framework(
     name = "TargetXIBTestsLib",
+    testonly = 1,
     srcs = glob(["TargetXIBTests/**/*.swift"]),
     platforms = {"ios": "11.0"},
     visibility = ["//visibility:public"],


### PR DESCRIPTION
The first two are necessary to pull in some changes for explicit module compilation, but then proto changes required a bump to stardoc, and then I needed to regenerate the docs, and then libraries depending on XCTest now have to be testonly. 🪒 🐂 