### PR TITLE
Fix Xcode 14 missing `libXCTestBundleInject.dylib` when running tests

### DIFF
--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/install.sh
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/installer
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/install.sh
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/installer
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/install.sh
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/installer
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/install.sh
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/installer
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/install.sh
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/installer
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/install.sh
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/installer
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/install.sh
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/installer
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/install.sh
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/installer
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/install.sh
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/installer
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/install.sh
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/installer
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/install.sh
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/installer
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/install.sh
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/installer
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 

--- a/tools/xcodeproj_shims/install.sh
+++ b/tools/xcodeproj_shims/install.sh
@@ -92,6 +92,7 @@ for input in "${input_options[@]}"; do
     else
         rsync \
             --recursive --chmod=u+w --delete --copy-links \
+            --exclude 'Frameworks/libXCTestBundleInject.dylib' \
             "$input" "$output" >"$BAZEL_DIAGNOSTICS_DIR"/rsync-stdout-"$DATE_SUFFIX".log 2>"$BAZEL_DIAGNOSTICS_DIR"/rsync-stderr-"$DATE_SUFFIX".log
     fi
 


### PR DESCRIPTION
Xcode 14 no longer supports the legacy build system, so we're silently
being upgraded to using the new build system. One issue that surfaces
from this is that the `libXCTestBundleInject.dylib` starts being
injected into the test host app as a step in building the *app host*
instead of in building the *test bundle* (as it used to). This is
problematic, because we `rsync --delete` the app bundle as part of the
Bazel install script after the dylib is copied, and thus it gets purged.

One interesting finding is that even without this fix, it works fine in
Xcode 14 with iOS 15/16 simulators. This appears to be due to some
difference in dyld behavior between sims, where it is able to successfully
fall back and load this library from the SDK dir instead of embedded in
the host app, even though the xctest run explicitly contains
DYLD_INSERT_LIBRARIES w/ `__TESTHOST__/Frameworks/libXCTestBundleInject.dylib`.

We could go about ensuring `libXCTestBundleInject.dylib` is present in a
couple ways:
* Let Xcode copy the dylib into the output directory from the 'Copy
  libXCTestBundleInject.dylib' task and assume Xcode's will always place
  it there when needed. This avoids duplicative copying and is a simple
  change.
* Add `libXCTestBundleInject.dylib` as a dependency of the app host in
  the build rules, but presumably only when we're building for testing.
  Maybe we'd need a test app host wrapper for applications rules that
  test targets would take a dependency on.
* See if there is some way to get dyld to behave differently on iOS 14
  to allow loading the library from the SDK path.

For this change, we've opted to go the first route. If this build rule
were going to be longer lived (instead of being replaced) and there was
more logic we'd want to run specifically for the case of test app hosts,
I'd consider going with the second approach.