### PR TITLE
Cancel old PR CI jobs when PR is updated

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,11 @@ on:
     branches:
       - master
 
+# One active job per PR, cancel older ones on push
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   integration_tests:
     name: Build and Test


### PR DESCRIPTION
This should reduce load on CI when people like me keep pushing small changes to PRs and using up all the mac capacity.

Cribbed from:
https://docs.github.com/en/actions/using-jobs/using-concurrency