### PR TITLE
Add bzl target for exporting .bzl files

### DIFF
--- a/rules/BUILD.bazel
+++ b/rules/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 exports_files(
     glob(["*.bzl"]),
     visibility = ["//docs:__pkg__"],
@@ -7,4 +9,18 @@ genrule(
     name = "empty",
     outs = ["empty.swift"],
     cmd = "touch $(OUTS)",
+)
+
+bzl_library(
+    name = "bzl",
+    srcs = [
+        "app.bzl",
+        "extension.bzl",
+        "framework.bzl",
+        "hmap.bzl",
+        "library.bzl",
+        "test.bzl",
+    ],
+    visibility = ["//visibility:public"],
+    deps = ["@build_bazel_rules_apple//apple"],
 )


### PR DESCRIPTION
Adds a `bzl_library` for some of the documented `.bzl` files in the repository.

Why? This is required if dependent macros/rules in other repositories want to generate documentation using stardoc for their internal .bzl files that load `rules_ios`.