### PR TITLE
Have LIBTOOL use the ld stub as well

### DIFF
--- a/rules/legacy_xcodeproj.bzl
+++ b/rules/legacy_xcodeproj.bzl
@@ -1061,7 +1061,7 @@ def _xcodeproj_impl(ctx):
         "CXX": "$CC",
         "CLANG_ANALYZER_EXEC": "$CC",
         "LD": "$BAZEL_STUBS_DIR/ld-stub",
-        "LIBTOOL": "/usr/bin/true",
+        "LIBTOOL": "$BAZEL_STUBS_DIR/ld-stub",
         "SWIFT_USE_INTEGRATED_DRIVER": "NO",
         "SWIFT_EXEC": "$BAZEL_STUBS_DIR/swiftc-stub",
         # LD isn't used for all use cases - direct it to use this LD

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
@@ -426,7 +426,7 @@
 				FORCE_X86_SIM = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -508,7 +508,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				FORCE_X86_SIM = 0;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
@@ -568,7 +568,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				FORCE_X86_SIM = 0;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
@@ -627,7 +627,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				FORCE_X86_SIM = 0;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";

--- a/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/project.pbxproj
@@ -366,7 +366,7 @@
 				FORCE_X86_SIM = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -540,7 +540,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				FORCE_X86_SIM = 0;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/project.pbxproj
@@ -298,7 +298,7 @@
 				FORCE_X86_SIM = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -334,7 +334,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				FORCE_X86_SIM = 0;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";

--- a/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/project.pbxproj
@@ -217,7 +217,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				FORCE_X86_SIM = 0;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
@@ -275,7 +275,7 @@
 				FORCE_X86_SIM = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/project.pbxproj
@@ -511,7 +511,7 @@
 				FORCE_X86_SIM = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -688,7 +688,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				FORCE_X86_SIM = 0;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/project.pbxproj
@@ -439,7 +439,7 @@
 				FORCE_X86_SIM = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -522,7 +522,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				FORCE_X86_SIM = 0;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/project.pbxproj
@@ -608,7 +608,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				FORCE_X86_SIM = 0;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
@@ -691,7 +691,7 @@
 				FORCE_X86_SIM = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.pbxproj
@@ -260,7 +260,7 @@
 				FORCE_X86_SIM = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -346,7 +346,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				FORCE_X86_SIM = 0;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";

--- a/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/project.pbxproj
@@ -217,7 +217,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				FORCE_X86_SIM = 0;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
@@ -275,7 +275,7 @@
 				FORCE_X86_SIM = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/project.pbxproj
@@ -362,7 +362,7 @@
 				FORCE_X86_SIM = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -398,7 +398,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				FORCE_X86_SIM = 0;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/project.pbxproj
@@ -334,7 +334,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				FORCE_X86_SIM = 0;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
@@ -443,7 +443,7 @@
 				FORCE_X86_SIM = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/project.pbxproj
@@ -552,7 +552,7 @@
 				DONT_RUN_SWIFT_STDLIB_TOOL = 1;
 				FORCE_X86_SIM = 0;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_EXEC = "$BAZEL_STUBS_DIR/swiftc-stub";
@@ -638,7 +638,7 @@
 				FORCE_X86_SIM = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				LD = "$BAZEL_STUBS_DIR/ld-stub";
-				LIBTOOL = /usr/bin/true;
+				LIBTOOL = "$BAZEL_STUBS_DIR/ld-stub";
 				OTHER_LDFLAGS = "-fuse-ld=$BAZEL_STUBS_DIR/ld-stub";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;


### PR DESCRIPTION
It looks like in Xcode 14, it is now passing a `-dependency_info` arg to libtool. Without this change, Xcode 14 generates an error when trying to find the `*_libtool_dependency_info.dat ` output file for creating static library targets. I've confirmed that this change works for both Xcode 13 & Xcode 14.