### PR TITLE
Remove `--experimental_worker_allow_json_protocol`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,7 +19,6 @@ build --compilation_mode=dbg
 
 # Use 'worker' strategy for swift compilation
 build --strategy=SwiftCompile=worker
-build --experimental_worker_allow_json_protocol
 
 # This flips enable_global_index_store - see docs/index_while_building.md for a
 # detailed summary


### PR DESCRIPTION
Handle https://github.com/bazelbuild/bazel/pull/14679 to prepare for Bazel 6.0.0.