### PR TITLE
Cleanup plist output formulation

### DIFF
--- a/rules/plists.bzl
+++ b/rules/plists.bzl
@@ -37,7 +37,7 @@ def process_infoplists(name, infoplists, infoplists_by_build_setting, xcconfig, 
     # Substitute the default infoplists
     substituted_infoplists_by_build_setting["//conditions:default"] = [
         substituted_plist(
-            name = "%s.%s.infoplist_substituted" % (name, idx),
+            name = "_%s.%s.info" % (name, idx),
             plist = plist,
             xcconfig = default_xcconfig,
         )
@@ -57,7 +57,7 @@ def process_infoplists(name, infoplists, infoplists_by_build_setting, xcconfig, 
         # Substitute the build settings into the plists for this config_setting
         substituted_infoplists_by_build_setting[config_setting_name] = [
             substituted_plist(
-                name = "%s.%s.%s.infoplist_substituted" % (name, name_suffix, idx),
+                name = "_%s.%s.%s.info" % (name, name_suffix, idx),
                 plist = plist,
                 xcconfig = xcconfig_for_plist,
             )

--- a/rules/substitute_build_settings.bzl
+++ b/rules/substitute_build_settings.bzl
@@ -1,4 +1,3 @@
-load("@bazel_skylib//lib:paths.bzl", "paths")
 
 def _substitute_build_settings_impl(ctx):
     substitutions = {}
@@ -16,8 +15,8 @@ def _substitute_build_settings_impl(ctx):
             if key in sub_value:
                 substitutions[sub_key] = sub_value.replace(key, value)
 
-    basename, extension = paths.split_extension(ctx.file.source.basename)
-    output = ctx.actions.declare_file("%s.substituted-%s.%s" % (basename, ctx.label.name, extension))
+    extension = ctx.file.source.extension
+    output = ctx.actions.declare_file("%s.%s" % (ctx.label.name, extension))
     ctx.actions.expand_template(
         template = ctx.file.source,
         output = output,

--- a/rules/substitute_build_settings.bzl
+++ b/rules/substitute_build_settings.bzl
@@ -1,4 +1,3 @@
-
 def _substitute_build_settings_impl(ctx):
     substitutions = {}
     for key in ctx.attr.variables:


### PR DESCRIPTION
Today it formulates too long of files names for me on macOS. The total path size today is:
`(BuildFilePathLength + 2 * RuleNameLength + SuffixLength)`

Given Bazel supports a single rule with a given name per build file, we can safely eliminate this extra layer of namespacing. After the fix, the total path size is:
`(BuildFilePathLength + RuleNameLength + SuffixLength)`

Additionally:
- further reduce generated label / output sizes
- underscore generated rule names with _
- remove issue with ".." name suffix. This also gets us better looking plists names: For instance, a Foo dogfood plist gets you _Foo.dogfood.0.info.plist