### PR TITLE
Fix incorrectly forwarding `xcconfig` to extension

### DIFF
--- a/rules/extension.bzl
+++ b/rules/extension.bzl
@@ -63,8 +63,8 @@ def ios_extension(name, infoplists_by_build_setting = {}, **kwargs):
         name = name,
         infoplists = kwargs.pop("infoplists", []),
         infoplists_by_build_setting = infoplists_by_build_setting,
-        xcconfig = kwargs.get("xcconfig", {}),
-        xcconfig_by_build_setting = kwargs.get("xcconfig_by_build_setting", {}),
+        xcconfig = kwargs.pop("xcconfig", {}),
+        xcconfig_by_build_setting = kwargs.pop("xcconfig_by_build_setting", {}),
     )
 
     rules_apple_ios_extension(


### PR DESCRIPTION
We were forwarding the `xcconfig` and `xcconfig_by_build_setting` to the `rules_apple` rule which leads to an error.  Instead we should pop it from kwargs and use it as needed.