### PR TITLE
[Bazel6] Handle removal of `ObjcProvider.direct_headers`

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -410,7 +410,7 @@ def _get_direct_public_headers(provider, dep):
             return []
         return dep[provider].compilation_context.direct_public_headers
     elif provider == apple_common.Objc:
-        return dep[provider].direct_headers
+        return getattr(dep[provider], "direct_headers", [])
     else:
         fail("Unknown provider " + provider + " only CcInfo and Objc supported")
 

--- a/rules/hmap.bzl
+++ b/rules/hmap.bzl
@@ -55,7 +55,7 @@ def _make_headermap_impl(ctx):
 
     for provider in ctx.attr.direct_hdr_providers:
         if apple_common.Objc in provider:
-            hdrs_lists.append(provider[apple_common.Objc].direct_headers)
+            hdrs_lists.append(getattr(provider[apple_common.Objc], "direct_headers", []))
         if CcInfo in provider:
             hdrs_lists.append(provider[CcInfo].compilation_context.direct_headers)
 

--- a/rules/legacy_xcodeproj.bzl
+++ b/rules/legacy_xcodeproj.bzl
@@ -235,7 +235,7 @@ def _xcodeproj_aspect_impl(target, ctx):
     if AppleBundleInfo in target:
         swift_objc_header_path = None
         if SwiftInfo in target:
-            for h in target[apple_common.Objc].direct_headers:
+            for h in getattr(target[apple_common.Objc], "direct_headers", []):
                 if h.path.endswith("-Swift.h"):
                     swift_objc_header_path = h.path
 


### PR DESCRIPTION
Handle https://github.com/bazelbuild/bazel/issues/14559 (https://github.com/bazelbuild/bazel/commit/8a2b711a2700740575904682066dbe1e5c9f6d02) to prepare for Bazel 6 but still work in Bazel 5.