### PR TITLE
[Bazel6] Add `CcInfo` to `precompiled_apple_resource_bundle`

### DIFF
--- a/rules/precompiled_apple_resource_bundle.bzl
+++ b/rules/precompiled_apple_resource_bundle.bzl
@@ -217,6 +217,7 @@ def _precompiled_apple_resource_bundle_impl(ctx):
         ),
         AppleResourceBundleInfo(),
         apple_common.new_objc_provider(),
+        CcInfo(),
     ]
 
 _precompiled_apple_resource_bundle = rule(


### PR DESCRIPTION
This allows it to pass the `CcInfo` provider requirement for the `objc_library.deps` attribute:

https://github.com/bazelbuild/bazel/blob/7ccc66108f08f7b6c6f6e5229f70f29962ea19ce/src/main/starlark/builtins_bzl/common/objc/attrs.bzl#L88-L91

Release notes associated with the change/attribute:
>RELNOTES[INC]: objc_library now requires CcInfo in its deps.  If this breaks you, add empty CcInfo() to your rule.