### PR TITLE
Align objc flags between Bazel and Xcode

### DIFF
--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -136,8 +136,8 @@ swift_binary(
             name = "xchammer",
             remote = "https://github.com/bazel-ios/xchammer.git",
             # XCHammer dev branch: bazel-ios/rules-ios-xchammer
-            commit = "898130013a74cd339f9f79b090bc708ca2ae10ba",
-            shallow_since = "1670344207 -0500",
+            commit = "265dfdc7bbe4ad178d3c480c0383623a7f876775",
+            shallow_since = "1670359292 -0500",
         )
     xchammer_dependencies()
 

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -136,15 +136,15 @@ swift_binary(
             name = "xchammer",
             remote = "https://github.com/bazel-ios/xchammer.git",
             # XCHammer dev branch: bazel-ios/rules-ios-xchammer
-            commit = "359ef1983ea5abbf4ad2f171d039522b23f1f23d",
-            shallow_since = "1668445956 -0500",
+            commit = "8f6a9d73de95bfc82173a7120379e08611d9a59a",
+            shallow_since = "1670261369 -0500",
         )
     xchammer_dependencies()
 
     if not native.existing_rule("xcbuildkit"):
         git_repository(
             name = "xcbuildkit",
-            commit = "2de1d41bdd4b9eea60764800af1ed7fcd62eeed3",
+            commit = "d747efbee7d47de67a2f1641b4163f4c11fa0551",
             remote = "https://github.com/jerrymarino/xcbuildkit.git",
         )
 

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -136,15 +136,15 @@ swift_binary(
             name = "xchammer",
             remote = "https://github.com/bazel-ios/xchammer.git",
             # XCHammer dev branch: bazel-ios/rules-ios-xchammer
-            commit = "8f6a9d73de95bfc82173a7120379e08611d9a59a",
-            shallow_since = "1670261369 -0500",
+            commit = "898130013a74cd339f9f79b090bc708ca2ae10ba",
+            shallow_since = "1670344207 -0500",
         )
     xchammer_dependencies()
 
     if not native.existing_rule("xcbuildkit"):
         git_repository(
             name = "xcbuildkit",
-            commit = "d747efbee7d47de67a2f1641b4163f4c11fa0551",
+            commit = "358d90a4a5c01ea5f8de3fda334c9c6375cb0073",
             remote = "https://github.com/jerrymarino/xcbuildkit.git",
         )
 


### PR DESCRIPTION
Bumps `xcbuildkit` and `xchammer` to pick up:

- [x] Bump all deps to main branches before landing

* https://github.com/jerrymarino/xcbuildkit/pull/53
* https://github.com/bazel-ios/xchammer/pull/36
* https://github.com/bazel-ios/xchammer/pull/35