### PR TITLE
[Bazel6] Avoid copying in `.h` directories into `Foo.framework/Headers`

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -162,15 +162,7 @@ def _framework_packaging(ctx, action, inputs, outputs, manifest = None):
     if action in ctx.attr.skip_packaging:
         return []
     action_inputs = [manifest] + inputs if manifest else inputs
-
-    # Use the input to determine whether to use `declare_directory` or `declare_file`
-    # since it'll need to match in the downstream symlink action.
-    outputs_by_index = {index: outputs[index] for index in range(len(outputs))}
-    outputs = [
-        ctx.actions.declare_directory(output) if inputs[index].is_directory else ctx.actions.declare_file(output)
-        for (index, output) in outputs_by_index.items()
-    ]
-
+    outputs = [ctx.actions.declare_file(f) for f in outputs]
     framework_name = ctx.attr.framework_name
     framework_dir = _find_framework_dir(outputs)
     args = ctx.actions.args().use_param_file("@%s").set_param_file_format("multiline")

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -331,7 +331,7 @@ def _get_framework_files(ctx, deps):
         for provider in [CcInfo, apple_common.Objc]:
             if provider in dep:
                 for hdr in _get_direct_public_headers(provider, dep):
-                    if hdr.path.endswith((".h", ".hh", ".hpp")):
+                    if not hdr.is_directory and hdr.path.endswith((".h", ".hh", ".hpp")):
                         has_header = True
                         header_in.append(hdr)
                         destination = paths.join(framework_dir, "Headers", hdr.basename)

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -162,7 +162,15 @@ def _framework_packaging(ctx, action, inputs, outputs, manifest = None):
     if action in ctx.attr.skip_packaging:
         return []
     action_inputs = [manifest] + inputs if manifest else inputs
-    outputs = [ctx.actions.declare_file(f) for f in outputs]
+
+    # Use the input to determine whether to use `declare_directory` or `declare_file`
+    # since it'll need to match in the downstream symlink action.
+    outputs_by_index = {index: outputs[index] for index in range(len(outputs))}
+    outputs = [
+        ctx.actions.declare_directory(output) if inputs[index].is_directory else ctx.actions.declare_file(output)
+        for (index, output) in outputs_by_index.items()
+    ]
+
     framework_name = ctx.attr.framework_name
     framework_dir = _find_framework_dir(outputs)
     args = ctx.actions.args().use_param_file("@%s").set_param_file_format("multiline")


### PR DESCRIPTION
Fix the following mismatch between the declared output and the `symlink`’d input:
```
$ bazelisk test --local_test_jobs=1 --apple_platform_type=ios --deleted_packages='' -- //tests/ios/...
…
ERROR: /Users/matt.robinson/Developer/rules_ios/rules_ios/tests/ios/frameworks/intentdefinition/BUILD.bazel:3:16: in apple_framework_packaging rule //tests/ios/frameworks/intentdefinition:ObjCIntentConsumer:
Traceback (most recent call last):
	File "/Users/matt.robinson/Developer/rules_ios/rules_ios/rules/framework.bzl", line 854, column 43, in _apple_framework_packaging_impl
		framework_files = _get_framework_files(ctx, deps)
	File "/Users/matt.robinson/Developer/rules_ios/rules_ios/rules/framework.bzl", line 383, column 38, in _get_framework_files
		header_out = _framework_packaging(ctx, "header", header_in, header_out, framework_manifest)
	File "/Users/matt.robinson/Developer/rules_ios/rules_ios/rules/framework.bzl", line 185, column 45, in _framework_packaging
		_framework_packaging_symlink_headers(ctx, inputs, outputs)
	File "/Users/matt.robinson/Developer/rules_ios/rules_ios/rules/framework.bzl", line 150, column 28, in _framework_packaging_symlink_headers
		ctx.actions.symlink(output = output, target_file = input)
Error in symlink: symlink() with "target_file" directory param requires that "output" be declared as a directory (did you mean to use declare_directory() instead of declare_file()?)
ERROR: /Users/matt.robinson/Developer/rules_ios/rules_ios/tests/ios/frameworks/intentdefinition/BUILD.bazel:3:16: Analysis of target '//tests/ios/frameworks/intentdefinition:ObjCIntentConsumer' failed
```
If we `declare_directory`/`declare_file` correctly for the symlink'd outputs then we still run into an issue where there's a conflict on what's seemingly an incremental build:
```
ERROR: /Users/matt.robinson/Developer/rules_ios/rules_ios/tests/ios/frameworks/intentdefinition/BUILD.bazel:3:16: Creating symlink bazel-out/applebin_ios-ios_sim_arm64-dbg-ST-8e9d4392bc2b/bin/tests/ios/frameworks/intentdefinition/ObjCIntentConsumer/ObjCIntentConsumer.framework/Headers/ObjCIntentConsumer_Intents.intentdefinition_gen.hdrs.h failed: failed to create symbolic link 'tests/ios/frameworks/intentdefinition/ObjCIntentConsumer/ObjCIntentConsumer.framework/Headers/ObjCIntentConsumer_Intents.intentdefinition_gen.hdrs.h' to 'tests/ios/frameworks/intentdefinition/ObjCIntentConsumer_Intents.intentdefinition_gen.hdrs.h' due to I/O error: /private/var/tmp/_bazel_matt.robinson/0e64031a9efbb95e4728094ee9457143/execroot/build_bazel_rules_ios/bazel-out/applebin_ios-ios_sim_arm64-dbg-ST-8e9d4392bc2b/bin/tests/ios/frameworks/intentdefinition/ObjCIntentConsumer/ObjCIntentConsumer.framework/Headers/ObjCIntentConsumer_Intents.intentdefinition_gen.hdrs.h (File exists)
```
It makes little sense to add `.h` “files” to `Foo.framework/Headers` that are actually directories so stop adding them to the resulting frameworks `Headers` directory unless they're files.