### PR TITLE
Align swiftc flags between Bazel and Xcode in XCHammer

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -21,7 +21,7 @@ PrivateHeadersInfo = provider(
     },
 )
 
-GLOBAL_INDEX_STORE_PATH = "bazel-out/rules_ios_global_index_store.indexstore"
+GLOBAL_INDEX_STORE_PATH = "bazel-out/_global_index_store"
 
 _MANUAL = ["manual"]
 

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -136,15 +136,15 @@ swift_binary(
             name = "xchammer",
             remote = "https://github.com/bazel-ios/xchammer.git",
             # XCHammer dev branch: bazel-ios/rules-ios-xchammer
-            commit = "9808c48bb8d9762dcdd5ef45021e0f0167bc8ab4",
-            shallow_since = "1670521130 -0500",
+            commit = "fffd8033bed79e61a908ca1a72acff867a5b5825",
+            shallow_since = "1670600984 -0500",
         )
     xchammer_dependencies()
 
     if not native.existing_rule("xcbuildkit"):
         git_repository(
             name = "xcbuildkit",
-            commit = "c5ad8ab7cd83a70678532dbc7b2397347d24deae",
+            commit = "18a2b0e73d2e0cba759d5b4da24e47af106922d7",
             remote = "https://github.com/jerrymarino/xcbuildkit.git",
         )
 

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -136,15 +136,15 @@ swift_binary(
             name = "xchammer",
             remote = "https://github.com/bazel-ios/xchammer.git",
             # XCHammer dev branch: bazel-ios/rules-ios-xchammer
-            commit = "265dfdc7bbe4ad178d3c480c0383623a7f876775",
-            shallow_since = "1670359292 -0500",
+            commit = "9808c48bb8d9762dcdd5ef45021e0f0167bc8ab4",
+            shallow_since = "1670521130 -0500",
         )
     xchammer_dependencies()
 
     if not native.existing_rule("xcbuildkit"):
         git_repository(
             name = "xcbuildkit",
-            commit = "358d90a4a5c01ea5f8de3fda334c9c6375cb0073",
+            commit = "c5ad8ab7cd83a70678532dbc7b2397347d24deae",
             remote = "https://github.com/jerrymarino/xcbuildkit.git",
         )
 


### PR DESCRIPTION
Requires: 

* https://github.com/bazel-ios/xchammer/pull/37
* https://github.com/jerrymarino/xcbuildkit/pull/54

Also, changes the global index store path for ObjC to match Swift's. Open to suggestions here if anyone sees this as a potential breaking change, alternative is to conditionally set this when using XCHammer and let the current value be the default.