### PR TITLE
Fix analysis failure for targets that define `features`

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -568,6 +568,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
     enable_framework_vfs = kwargs.pop("enable_framework_vfs", False) or namespace_is_module_name
     defines = kwargs.pop("defines", [])
     testonly = kwargs.pop("testonly", False)
+    features = kwargs.pop("features", [])
 
     for (k, v) in {"momc_copts": momc_copts, "mapc_copts": mapc_copts, "ibtool_copts": ibtool_copts}.items():
         if v:
@@ -978,7 +979,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
                 "//conditions:default": [framework_vfs_overlay_name_swift] if enable_framework_vfs else [],
             }),
             swiftc_inputs = swiftc_inputs,
-            features = ["swift.no_generated_module_map", "swift.use_pch_output_dir"] + select({
+            features = features + ["swift.no_generated_module_map", "swift.use_pch_output_dir"] + select({
                 "@build_bazel_rules_ios//:virtualize_frameworks": ["swift.vfsoverlay"],
                 "//conditions:default": [],
             }),
@@ -1028,6 +1029,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
             defines = defines,
             tags = tags_manual,
             testonly = testonly,
+            features = features,
         )
         lib_names.append(cpp_libname)
 
@@ -1079,6 +1081,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
         tags = tags_manual,
         defines = defines + objc_defines,
         testonly = testonly,
+        features = features,
         **kwargs
     )
     launch_screen_storyboard_name = name + "_launch_screen_storyboard"

--- a/tests/ios/unit-test/BUILD.bazel
+++ b/tests/ios/unit-test/BUILD.bazel
@@ -70,3 +70,13 @@ ios_unit_test(
     infoplists = [{"NSPrincipalClass": "TestSuiteObserver"}],
     minimum_os_version = "11.0",
 )
+
+ios_unit_test(
+    name = "ExplicitFeatures",
+    srcs = [
+        "empty.m",
+        "empty.swift",
+    ],
+    features = ["apple.skip_codesign_simulator_bundles"],
+    minimum_os_version = "11.0",
+)


### PR DESCRIPTION
Fix issue where targets that define `features` would not get merged with the internal `swift_library`'s `features` causing an analysis failure:

```
File "/private/var/tmp/_bazel_jszumski/ed7e7efa198ffcfaf8285220a74bc6f4/external/build_bazel_rules_ios/rules/test.bzl", line 142, column 14, in ios_unit_test
	_ios_test(name, rules_apple_ios_unit_test, rules_apple_ios_unit_test_suite, apple_library, **kwargs)
File "/private/var/tmp/_bazel_jszumski/ed7e7efa198ffcfaf8285220a74bc6f4/external/build_bazel_rules_ios/rules/test.bzl", line 62, column 28, in _ios_test
	library = apple_library(name = name, namespace_is_module_name = False, platforms = {"ios": ios_test_kwargs.get("minimum_os_version")}, testonly = testonly, **kwargs)
File "/Users/jszumski/Development/cash-ios/Tools/Rules/library.bzl", line 46, column 25, in cash_library
	return apple_library(
File "/private/var/tmp/_bazel_jszumski/ed7e7efa198ffcfaf8285220a74bc6f4/external/build_bazel_rules_ios/rules/library.bzl", line 964, column 22, in apple_library
	swift_library(
Error in swift_library: rule(...) got multiple values for parameter 'features'
```