### PR TITLE
Use bazel-ios/rules_apple

### DIFF
--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -62,10 +62,10 @@ def rules_ios_dependencies():
     _maybe(
         github_repo,
         name = "build_bazel_rules_apple",
-        ref = "c628b0e4b3261b4627bcd4e9f91e75b4e5eb0e1a",
+        ref = "b43c7f60b584d68d7d187c236d4328162ba2e806",
         project = "bazelbuild",
         repo = "rules_apple",
-        sha256 = "495ffc13769b81e401d108a47925885c43f9dfccfbb229d4418d509c6cea14be",
+        sha256 = "d3e8549c0c8966ba0e547a02f5601440be25a0b8143bd57ab5834b65b02c22be",
     )
 
     _maybe(


### PR DESCRIPTION
Uses the bazel-ios/rules_apple fork which has updates that need to be upstreamed before we can go back to using bazel's rules_apple