### PR TITLE
[xcodeproj] Ensure extension targets are created when in schemes

### DIFF
--- a/rules/legacy_xcodeproj.bzl
+++ b/rules/legacy_xcodeproj.bzl
@@ -233,6 +233,8 @@ def _xcodeproj_aspect_impl(target, ctx):
     bazel_bin_subdir = "%s/%s" % (target.label.workspace_root, target.label.package)
 
     if AppleBundleInfo in target:
+        extensions = getattr(ctx.rule.attr, "extensions", [])
+
         swift_objc_header_path = None
         if SwiftInfo in target:
             for h in getattr(target[apple_common.Objc], "direct_headers", []):
@@ -255,12 +257,6 @@ def _xcodeproj_aspect_impl(target, ctx):
             if test_host_target:
                 test_host_appname = test_host_target[_TargetInfo].direct_targets[0].name
 
-        # Collect any extension names associated with this bundle. Schemes are then generated that build both.
-        application_extension_names = []
-        application_extensions = getattr(ctx.rule.attr, "extensions", [])
-        if application_extensions:
-            application_extension_names = [extension[AppleBundleInfo].bundle_name for extension in application_extensions]
-
         framework_includes = depset([], transitive = _get_attr_values_for_name(deps, _SrcsInfo, "framework_includes"))
         info = struct(
             name = bundle_info.bundle_name,
@@ -280,7 +276,7 @@ def _xcodeproj_aspect_impl(target, ctx):
             platform_type = bundle_info.platform_type,
             minimum_os_version = bundle_info.minimum_os_version,
             test_host_appname = test_host_appname,
-            extension_names = depset(application_extension_names),
+            extensions = depset(extensions),
             env_vars = env_vars,
             swift_objc_header_path = swift_objc_header_path,
             swift_module_paths = depset([], transitive = _get_attr_values_for_name(deps, _SrcsInfo, "swift_module_paths")),
@@ -315,8 +311,16 @@ def _xcodeproj_aspect_impl(target, ctx):
             transitive_targets.append(info)
 
         if test_host_target:
-            # Add the test_host_target to the targets to be added to the xcode project
-            test_host_direct_targets = test_host_target[_TargetInfo].direct_targets
+            test_host_direct_targets = []
+
+            for target in test_host_target[_TargetInfo].direct_targets:
+                # Add the test_host_target to the targets to be added to the xcode project
+                test_host_direct_targets.extend([target])
+
+                # Add the test_host_target's extensions to the targets to be added to the xcode project
+                for extension in target.extensions.to_list():
+                    test_host_direct_targets.extend(extension[_TargetInfo].direct_targets)
+
             direct_targets.extend(test_host_direct_targets)
             transitive_targets.extend(test_host_direct_targets)
 
@@ -934,10 +938,11 @@ def _populate_xcodeproj_targets_and_schemes(ctx, targets, src_dot_dots, all_tran
         # By putting under run action, test action will just use them automatically
         xcodeproj_schemes_by_name[target_name]["run"] = scheme_action_details
 
-        if target_info.extension_names:
-            for extension in target_info.extension_names.to_list():
-                _create_scheme_for_target(extension, xcodeproj_schemes_by_name)
-                xcodeproj_schemes_by_name[extension]["build"]["targets"][target_name] = ["run", "test", "profile"]
+        if target_info.extensions:
+            for extension in target_info.extensions.to_list():
+                extension_name = extension[AppleBundleInfo].bundle_name
+                _create_scheme_for_target(extension_name, xcodeproj_schemes_by_name)
+                xcodeproj_schemes_by_name[extension_name]["build"]["targets"][target_name] = ["run", "test", "profile"]
 
         scheme_infos = [target[AdditionalSchemeInfo] for target in ctx.attr.additional_scheme_infos]
         build_target_to_scheme_info = {scheme_info.build_target: scheme_info for scheme_info in scheme_infos}

--- a/tests/ios/unit-test/BUILD.bazel
+++ b/tests/ios/unit-test/BUILD.bazel
@@ -29,7 +29,8 @@ ios_unit_test(
         "empty.swift",
     ],
     minimum_os_version = "12.0",
-    test_host = "//rules/test_host_app:iOS-9.3-AppHost",
+    # Intentionally dependent on app with extensions.
+    test_host = "//tests/ios/app:App",
     # Adding visibility so the xcodeproject tests can depend on this target
     visibility = ["//visibility:public"],
 )

--- a/tests/ios/unit-test/BUILD.bazel
+++ b/tests/ios/unit-test/BUILD.bazel
@@ -29,6 +29,18 @@ ios_unit_test(
         "empty.swift",
     ],
     minimum_os_version = "12.0",
+    test_host = "//rules/test_host_app:iOS-9.3-AppHost",
+    # Adding visibility so the xcodeproject tests can depend on this target
+    visibility = ["//visibility:public"],
+)
+
+ios_unit_test(
+    name = "ExplicitHostedWithAppExtensions",
+    srcs = [
+        "empty.m",
+        "empty.swift",
+    ],
+    minimum_os_version = "12.0",
     # Intentionally dependent on app with extensions.
     test_host = "//tests/ios/app:App",
     # Adding visibility so the xcodeproject tests can depend on this target

--- a/tests/ios/xcodeproj/BUILD.bazel
+++ b/tests/ios/xcodeproj/BUILD.bazel
@@ -113,6 +113,7 @@ xcodeproj(
     project_name = "TestWithHostApp",  # Test that setting a custom project name works as expected
     deps = [
         "//tests/ios/unit-test:ExplicitHosted",
+        "//tests/ios/unit-test:ExplicitHostedWithAppExtensions",
     ],
 )
 

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.pbxproj
@@ -9,38 +9,32 @@
 /* Begin PBXBuildFile section */
 		31AA2C5800D29E42C589B56B /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52FB08B7C929A64386CDFE06 /* empty.swift */; };
 		83CAB78009AF4F0196136FB6 /* empty.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F973C72CDD8C3C263F6A615 /* empty.m */; };
-		90364CB6CB510200E694DB55 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B78B78C06FA82FF60423814 /* main.m */; };
+		DBAF1B7C6B592F06CC4BA7A8 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DB410C7AEEA183BE996E1ED /* main.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		F38C65FC54D7CD052E02657E /* PBXContainerItemProxy */ = {
+		C163F6D13008230C361295BB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 2E45F5FFD4B2FD1997C70862 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 9541626BF2F6C0EE11CA1AD7;
-			remoteInfo = "iOS-9.3-AppHost";
+			remoteGlobalIDString = 2B7DA68C47D629972D1134C8;
+			remoteInfo = App;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		087F3B42D7BE6F86AB8C54F0 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
-		1A670BBD3E8C25AB89221850 /* iOS-9.3-AppHost.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "iOS-9.3-AppHost.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		280A96A1BB45418328EE8F8C /* ExampleExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = ExampleExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		3DB410C7AEEA183BE996E1ED /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		3F973C72CDD8C3C263F6A615 /* empty.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = empty.m; sourceTree = "<group>"; };
-		4B78B78C06FA82FF60423814 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		4C504B1FC1C79ADAEE541422 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
 		52FB08B7C929A64386CDFE06 /* empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = empty.swift; sourceTree = "<group>"; };
 		6AA79D51459F5745C6597549 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
+		8B877778D4F1B40E730E3950 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
 		A7A135B2F45AA4AE95B5C366 /* ExplicitHosted.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = ExplicitHosted.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D6B0D6BD4AF86F9BE813EB4B /* App.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
-		3F0ED6F34AF3A58C237AF38E /* rules */ = {
-			isa = PBXGroup;
-			children = (
-				48EC573E873376EF2328B54F /* test_host_app */,
-			);
-			path = rules;
-			sourceTree = "<group>";
-		};
 		4458650FCF08ECB7D12D6103 = {
 			isa = PBXGroup;
 			children = (
@@ -49,20 +43,29 @@
 			);
 			sourceTree = "<group>";
 		};
-		48EC573E873376EF2328B54F /* test_host_app */ = {
+		45F58BD53C393F0DABB4D530 /* app */ = {
 			isa = PBXGroup;
 			children = (
-				087F3B42D7BE6F86AB8C54F0 /* BUILD.bazel */,
-				4B78B78C06FA82FF60423814 /* main.m */,
+				EB779FFB9EA472BA6943847B /* App */,
+				4C504B1FC1C79ADAEE541422 /* BUILD.bazel */,
 			);
-			path = test_host_app;
+			path = app;
+			sourceTree = "<group>";
+		};
+		512C182CEE334BD83EC15E18 /* extensions */ = {
+			isa = PBXGroup;
+			children = (
+				8B877778D4F1B40E730E3950 /* BUILD.bazel */,
+			);
+			path = extensions;
 			sourceTree = "<group>";
 		};
 		80B743DAD4870A59BE6681A5 /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				D6B0D6BD4AF86F9BE813EB4B /* App.app */,
+				280A96A1BB45418328EE8F8C /* ExampleExtension.appex */,
 				A7A135B2F45AA4AE95B5C366 /* ExplicitHosted.xctest */,
-				1A670BBD3E8C25AB89221850 /* iOS-9.3-AppHost.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -80,6 +83,8 @@
 		A00021A91B77EC95CF688BAA /* ios */ = {
 			isa = PBXGroup;
 			children = (
+				45F58BD53C393F0DABB4D530 /* app */,
+				512C182CEE334BD83EC15E18 /* extensions */,
 				9A72A8B989632B31533CCF07 /* unit-test */,
 			);
 			path = ios;
@@ -96,16 +101,55 @@
 		E0A6B3D7DB2877F8279F72D1 /* build_bazel_rules_ios */ = {
 			isa = PBXGroup;
 			children = (
-				3F0ED6F34AF3A58C237AF38E /* rules */,
 				DCBB2E5ECC3355E25E5F9E3F /* tests */,
 			);
 			name = build_bazel_rules_ios;
 			path = ../../..;
 			sourceTree = "<group>";
 		};
+		EB779FFB9EA472BA6943847B /* App */ = {
+			isa = PBXGroup;
+			children = (
+				3DB410C7AEEA183BE996E1ED /* main.m */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		2B7DA68C47D629972D1134C8 /* App */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 41A9251A97487D5CAF321CF7 /* Build configuration list for PBXNativeTarget "App" */;
+			buildPhases = (
+				E019CEE69A0872FD43E28FC4 /* Build with bazel */,
+				CC6C3F2B46FB4A187B87EA49 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = App;
+			productName = App;
+			productReference = D6B0D6BD4AF86F9BE813EB4B /* App.app */;
+			productType = "com.apple.product-type.application";
+		};
+		2C3A627878C5E65865D4B494 /* ExampleExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FB0B1956FA6AF1F0FD6A8E54 /* Build configuration list for PBXNativeTarget "ExampleExtension" */;
+			buildPhases = (
+				E6D48AE7FB41DE61D85277FF /* Build with bazel */,
+				6C510F7426AE770D548F77CB /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ExampleExtension;
+			productName = ExampleExtension;
+			productReference = 280A96A1BB45418328EE8F8C /* ExampleExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		5AE0FC080FA6A17C35721D0C /* ExplicitHosted */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = B36500A688AD337FE657A850 /* Build configuration list for PBXNativeTarget "ExplicitHosted" */;
@@ -116,28 +160,12 @@
 			buildRules = (
 			);
 			dependencies = (
-				7B117CC3FAAB21A99FD3F683 /* PBXTargetDependency */,
+				58F134BEB00FD529DE54AD2C /* PBXTargetDependency */,
 			);
 			name = ExplicitHosted;
 			productName = ExplicitHosted;
 			productReference = A7A135B2F45AA4AE95B5C366 /* ExplicitHosted.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		9541626BF2F6C0EE11CA1AD7 /* iOS-9.3-AppHost */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 85B0F18E389439629F1AEA96 /* Build configuration list for PBXNativeTarget "iOS-9.3-AppHost" */;
-			buildPhases = (
-				911B498434C94010071D5767 /* Build with bazel */,
-				65484997632584E56344A3A2 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "iOS-9.3-AppHost";
-			productName = "iOS-9.3-AppHost";
-			productReference = 1A670BBD3E8C25AB89221850 /* iOS-9.3-AppHost.app */;
-			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
 
@@ -161,8 +189,9 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				2B7DA68C47D629972D1134C8 /* App */,
+				2C3A627878C5E65865D4B494 /* ExampleExtension */,
 				5AE0FC080FA6A17C35721D0C /* ExplicitHosted */,
-				9541626BF2F6C0EE11CA1AD7 /* iOS-9.3-AppHost */,
 			);
 		};
 /* End PBXProject section */
@@ -186,7 +215,25 @@
 			shellPath = /bin/sh;
 			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\nexport BAZEL_PROFILE_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-profile-$DATE_SUFFIX.log\"\nenv -u RUBYOPT -u RUBY_HOME -u GEM_HOME $BAZEL_BUILD_EXEC $BAZEL_BUILD_TARGET_LABEL\n$BAZEL_INSTALLER\n";
 		};
-		911B498434C94010071D5767 /* Build with bazel */ = {
+		E019CEE69A0872FD43E28FC4 /* Build with bazel */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Build with bazel";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\nexport BAZEL_PROFILE_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-profile-$DATE_SUFFIX.log\"\nenv -u RUBYOPT -u RUBY_HOME -u GEM_HOME $BAZEL_BUILD_EXEC $BAZEL_BUILD_TARGET_LABEL\n$BAZEL_INSTALLER\n";
+		};
+		E6D48AE7FB41DE61D85277FF /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -207,11 +254,18 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		65484997632584E56344A3A2 /* Sources */ = {
+		6C510F7426AE770D548F77CB /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				90364CB6CB510200E694DB55 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CC6C3F2B46FB4A187B87EA49 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DBAF1B7C6B592F06CC4BA7A8 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -227,14 +281,64 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		7B117CC3FAAB21A99FD3F683 /* PBXTargetDependency */ = {
+		58F134BEB00FD529DE54AD2C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 9541626BF2F6C0EE11CA1AD7 /* iOS-9.3-AppHost */;
-			targetProxy = F38C65FC54D7CD052E02657E /* PBXContainerItemProxy */;
+			target = 2B7DA68C47D629972D1134C8 /* App */;
+			targetProxy = C163F6D13008230C361295BB /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		0133580578F13E6149786A81 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BIN_SUBDIR = /tests/ios/extensions;
+				BAZEL_BUILD_TARGET_LABEL = "tests/ios/extensions:ExampleExtension";
+				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
+				BAZEL_LLDB_INIT_FILE = $CONFIGURATION_TEMP_DIR/ExampleExtension.lldbinit;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
+				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
+				INFOPLIST_FILE = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MACH_O_TYPE = "$(inherited)";
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.app.example-extension";
+				PRODUCT_NAME = ExampleExtension;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		134C2E63EA38C5C25745056F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BIN_SUBDIR = /tests/ios/app;
+				BAZEL_BUILD_TARGET_LABEL = "tests/ios/app:App";
+				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
+				BAZEL_LLDB_INIT_FILE = $CONFIGURATION_TEMP_DIR/App.lldbinit;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
+				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW2\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/OnlySources\"";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
+				INFOPLIST_FILE = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MACH_O_TYPE = "$(inherited)";
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.app;
+				PRODUCT_NAME = App;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		267CDF14370121BE5F884778 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -272,51 +376,26 @@
 			};
 			name = Debug;
 		};
-		5F1F0A8FCB049380CBA75C41 /* Release */ = {
+		2895AAB529758C44D4562A36 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BAZEL_BIN_SUBDIR = /rules/test_host_app;
-				BAZEL_BUILD_TARGET_LABEL = "rules/test_host_app:iOS-9.3-AppHost";
+				BAZEL_BIN_SUBDIR = /tests/ios/app;
+				BAZEL_BUILD_TARGET_LABEL = "tests/ios/app:App";
 				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
-				BAZEL_LLDB_INIT_FILE = "$CONFIGURATION_TEMP_DIR/iOS-9.3-AppHost.lldbinit";
+				BAZEL_LLDB_INIT_FILE = $CONFIGURATION_TEMP_DIR/App.lldbinit;
 				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
 				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW2\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/OnlySources\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				INFOPLIST_FILE = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACH_O_TYPE = "$(inherited)";
 				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.example.ios-app-host-9.3";
-				PRODUCT_NAME = "iOS-9.3-AppHost";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Release;
-		};
-		676421DD17502BB445A7A830 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BAZEL_BIN_SUBDIR = /rules/test_host_app;
-				BAZEL_BUILD_TARGET_LABEL = "rules/test_host_app:iOS-9.3-AppHost";
-				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
-				BAZEL_LLDB_INIT_FILE = "$CONFIGURATION_TEMP_DIR/iOS-9.3-AppHost.lldbinit";
-				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
-				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
-				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
-				INFOPLIST_FILE = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
-				MACH_O_TYPE = "$(inherited)";
-				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.example.ios-app-host-9.3";
-				PRODUCT_NAME = "iOS-9.3-AppHost";
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.app;
+				PRODUCT_NAME = App;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -357,6 +436,31 @@
 			};
 			name = Release;
 		};
+		E820AD8661CFA7F4D4F5D642 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BIN_SUBDIR = /tests/ios/extensions;
+				BAZEL_BUILD_TARGET_LABEL = "tests/ios/extensions:ExampleExtension";
+				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
+				BAZEL_LLDB_INIT_FILE = $CONFIGURATION_TEMP_DIR/ExampleExtension.lldbinit;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
+				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
+				INFOPLIST_FILE = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MACH_O_TYPE = "$(inherited)";
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.app.example-extension";
+				PRODUCT_NAME = ExampleExtension;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
 		F3E3860302C8B303E0690262 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -377,7 +481,7 @@
 				PRODUCT_NAME = ExplicitHosted;
 				SUPPORTS_MACCATALYST = 0;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOS-9.3-AppHost.app/iOS-9.3-AppHost";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App.app/App";
 			};
 			name = Debug;
 		};
@@ -401,13 +505,22 @@
 				PRODUCT_NAME = ExplicitHosted;
 				SUPPORTS_MACCATALYST = 0;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOS-9.3-AppHost.app/iOS-9.3-AppHost";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App.app/App";
 			};
 			name = Release;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		41A9251A97487D5CAF321CF7 /* Build configuration list for PBXNativeTarget "App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2895AAB529758C44D4562A36 /* Debug */,
+				134C2E63EA38C5C25745056F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		513AB10B3BA24602609F76A5 /* Build configuration list for PBXProject "TestWithHostApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -417,20 +530,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		85B0F18E389439629F1AEA96 /* Build configuration list for PBXNativeTarget "iOS-9.3-AppHost" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				676421DD17502BB445A7A830 /* Debug */,
-				5F1F0A8FCB049380CBA75C41 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
 		B36500A688AD337FE657A850 /* Build configuration list for PBXNativeTarget "ExplicitHosted" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				F3E3860302C8B303E0690262 /* Debug */,
 				FC00DAA2FE113CF025F03701 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		FB0B1956FA6AF1F0FD6A8E54 /* Build configuration list for PBXNativeTarget "ExampleExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0133580578F13E6149786A81 /* Debug */,
+				E820AD8661CFA7F4D4F5D642 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.pbxproj
@@ -7,34 +7,56 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F9C7A237281769B16354A44 /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52FB08B7C929A64386CDFE06 /* empty.swift */; };
 		31AA2C5800D29E42C589B56B /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52FB08B7C929A64386CDFE06 /* empty.swift */; };
 		83CAB78009AF4F0196136FB6 /* empty.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F973C72CDD8C3C263F6A615 /* empty.m */; };
+		90364CB6CB510200E694DB55 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B78B78C06FA82FF60423814 /* main.m */; };
 		DBAF1B7C6B592F06CC4BA7A8 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DB410C7AEEA183BE996E1ED /* main.m */; };
+		F7A8C565DBE2C1D3FE326524 /* empty.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F973C72CDD8C3C263F6A615 /* empty.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		C163F6D13008230C361295BB /* PBXContainerItemProxy */ = {
+		1D895677763B4065F359335E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 2E45F5FFD4B2FD1997C70862 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 2B7DA68C47D629972D1134C8;
 			remoteInfo = App;
 		};
+		F38C65FC54D7CD052E02657E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2E45F5FFD4B2FD1997C70862 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9541626BF2F6C0EE11CA1AD7;
+			remoteInfo = "iOS-9.3-AppHost";
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		087F3B42D7BE6F86AB8C54F0 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
+		1A670BBD3E8C25AB89221850 /* iOS-9.3-AppHost.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "iOS-9.3-AppHost.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		280A96A1BB45418328EE8F8C /* ExampleExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = ExampleExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		3DB410C7AEEA183BE996E1ED /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		3F973C72CDD8C3C263F6A615 /* empty.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = empty.m; sourceTree = "<group>"; };
+		4B78B78C06FA82FF60423814 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		4C504B1FC1C79ADAEE541422 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
 		52FB08B7C929A64386CDFE06 /* empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = empty.swift; sourceTree = "<group>"; };
 		6AA79D51459F5745C6597549 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
 		8B877778D4F1B40E730E3950 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
 		A7A135B2F45AA4AE95B5C366 /* ExplicitHosted.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = ExplicitHosted.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C5009185C598753F8C31B6F6 /* ExplicitHostedWithAppExtensions.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = ExplicitHostedWithAppExtensions.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D6B0D6BD4AF86F9BE813EB4B /* App.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
+		3F0ED6F34AF3A58C237AF38E /* rules */ = {
+			isa = PBXGroup;
+			children = (
+				48EC573E873376EF2328B54F /* test_host_app */,
+			);
+			path = rules;
+			sourceTree = "<group>";
+		};
 		4458650FCF08ECB7D12D6103 = {
 			isa = PBXGroup;
 			children = (
@@ -52,6 +74,15 @@
 			path = app;
 			sourceTree = "<group>";
 		};
+		48EC573E873376EF2328B54F /* test_host_app */ = {
+			isa = PBXGroup;
+			children = (
+				087F3B42D7BE6F86AB8C54F0 /* BUILD.bazel */,
+				4B78B78C06FA82FF60423814 /* main.m */,
+			);
+			path = test_host_app;
+			sourceTree = "<group>";
+		};
 		512C182CEE334BD83EC15E18 /* extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -66,6 +97,8 @@
 				D6B0D6BD4AF86F9BE813EB4B /* App.app */,
 				280A96A1BB45418328EE8F8C /* ExampleExtension.appex */,
 				A7A135B2F45AA4AE95B5C366 /* ExplicitHosted.xctest */,
+				C5009185C598753F8C31B6F6 /* ExplicitHostedWithAppExtensions.xctest */,
+				1A670BBD3E8C25AB89221850 /* iOS-9.3-AppHost.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -101,6 +134,7 @@
 		E0A6B3D7DB2877F8279F72D1 /* build_bazel_rules_ios */ = {
 			isa = PBXGroup;
 			children = (
+				3F0ED6F34AF3A58C237AF38E /* rules */,
 				DCBB2E5ECC3355E25E5F9E3F /* tests */,
 			);
 			name = build_bazel_rules_ios;
@@ -160,11 +194,44 @@
 			buildRules = (
 			);
 			dependencies = (
-				58F134BEB00FD529DE54AD2C /* PBXTargetDependency */,
+				7B117CC3FAAB21A99FD3F683 /* PBXTargetDependency */,
 			);
 			name = ExplicitHosted;
 			productName = ExplicitHosted;
 			productReference = A7A135B2F45AA4AE95B5C366 /* ExplicitHosted.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		9541626BF2F6C0EE11CA1AD7 /* iOS-9.3-AppHost */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 85B0F18E389439629F1AEA96 /* Build configuration list for PBXNativeTarget "iOS-9.3-AppHost" */;
+			buildPhases = (
+				911B498434C94010071D5767 /* Build with bazel */,
+				65484997632584E56344A3A2 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "iOS-9.3-AppHost";
+			productName = "iOS-9.3-AppHost";
+			productReference = 1A670BBD3E8C25AB89221850 /* iOS-9.3-AppHost.app */;
+			productType = "com.apple.product-type.application";
+		};
+		A66AE4DA1051F1DAB24B0FB2 /* ExplicitHostedWithAppExtensions */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 950ED89760E7C50BBDF68501 /* Build configuration list for PBXNativeTarget "ExplicitHostedWithAppExtensions" */;
+			buildPhases = (
+				77B3F00D2A9D11AFE1F7AC1B /* Build with bazel */,
+				33FCA56F48E8BB16DC986460 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D3229F57C9937AC425CB58C3 /* PBXTargetDependency */,
+			);
+			name = ExplicitHostedWithAppExtensions;
+			productName = ExplicitHostedWithAppExtensions;
+			productReference = C5009185C598753F8C31B6F6 /* ExplicitHostedWithAppExtensions.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -192,12 +259,50 @@
 				2B7DA68C47D629972D1134C8 /* App */,
 				2C3A627878C5E65865D4B494 /* ExampleExtension */,
 				5AE0FC080FA6A17C35721D0C /* ExplicitHosted */,
+				A66AE4DA1051F1DAB24B0FB2 /* ExplicitHostedWithAppExtensions */,
+				9541626BF2F6C0EE11CA1AD7 /* iOS-9.3-AppHost */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
 		14EF484B9911CED9E8CEB705 /* Build with bazel */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Build with bazel";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\nexport BAZEL_PROFILE_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-profile-$DATE_SUFFIX.log\"\nenv -u RUBYOPT -u RUBY_HOME -u GEM_HOME $BAZEL_BUILD_EXEC $BAZEL_BUILD_TARGET_LABEL\n$BAZEL_INSTALLER\n";
+		};
+		77B3F00D2A9D11AFE1F7AC1B /* Build with bazel */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Build with bazel";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\nexport BAZEL_PROFILE_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-profile-$DATE_SUFFIX.log\"\nenv -u RUBYOPT -u RUBY_HOME -u GEM_HOME $BAZEL_BUILD_EXEC $BAZEL_BUILD_TARGET_LABEL\n$BAZEL_INSTALLER\n";
+		};
+		911B498434C94010071D5767 /* Build with bazel */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -254,6 +359,23 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		33FCA56F48E8BB16DC986460 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F7A8C565DBE2C1D3FE326524 /* empty.m in Sources */,
+				1F9C7A237281769B16354A44 /* empty.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65484997632584E56344A3A2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				90364CB6CB510200E694DB55 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		6C510F7426AE770D548F77CB /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -281,10 +403,15 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		58F134BEB00FD529DE54AD2C /* PBXTargetDependency */ = {
+		7B117CC3FAAB21A99FD3F683 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9541626BF2F6C0EE11CA1AD7 /* iOS-9.3-AppHost */;
+			targetProxy = F38C65FC54D7CD052E02657E /* PBXContainerItemProxy */;
+		};
+		D3229F57C9937AC425CB58C3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 2B7DA68C47D629972D1134C8 /* App */;
-			targetProxy = C163F6D13008230C361295BB /* PBXContainerItemProxy */;
+			targetProxy = 1D895677763B4065F359335E /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -325,7 +452,7 @@
 				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW2\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/OnlySources\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-4b1594d0781e/bin/tests/ios/app/FW\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-4b1594d0781e/bin/tests/ios/app/FW2\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-4b1594d0781e/bin/tests/ios/app/OnlySources\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				INFOPLIST_FILE = "";
@@ -387,7 +514,7 @@
 				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW2\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/OnlySources\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-4b1594d0781e/bin/tests/ios/app/FW\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-4b1594d0781e/bin/tests/ios/app/FW2\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-4b1594d0781e/bin/tests/ios/app/OnlySources\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				INFOPLIST_FILE = "";
@@ -396,6 +523,80 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.app;
 				PRODUCT_NAME = App;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		51D8E2D0F8AD19F227D56320 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test";
+				BAZEL_BUILD_TARGET_LABEL = "tests/ios/unit-test:ExplicitHostedWithAppExtensions";
+				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
+				BAZEL_LLDB_INIT_FILE = $CONFIGURATION_TEMP_DIR/ExplicitHostedWithAppExtensions.lldbinit;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
+				BAZEL_SWIFTMODULEFILES_TO_COPY = "bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-84e06abcb3f0/bin/tests/ios/unit-test/ExplicitHostedWithAppExtensions.swiftmodule bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-84e06abcb3f0/bin/tests/ios/unit-test/ExplicitHostedWithAppExtensions.swiftdoc bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-84e06abcb3f0/bin/tests/ios/unit-test/ExplicitHostedWithAppExtensions.swiftsourceinfo";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MACH_O_TYPE = "$(inherited)";
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = ExplicitHostedWithAppExtensions;
+				SUPPORTS_MACCATALYST = 0;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App.app/App";
+			};
+			name = Release;
+		};
+		5F1F0A8FCB049380CBA75C41 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BIN_SUBDIR = /rules/test_host_app;
+				BAZEL_BUILD_TARGET_LABEL = "rules/test_host_app:iOS-9.3-AppHost";
+				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
+				BAZEL_LLDB_INIT_FILE = "$CONFIGURATION_TEMP_DIR/iOS-9.3-AppHost.lldbinit";
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
+				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
+				INFOPLIST_FILE = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MACH_O_TYPE = "$(inherited)";
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.ios-app-host-9.3";
+				PRODUCT_NAME = "iOS-9.3-AppHost";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		676421DD17502BB445A7A830 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BIN_SUBDIR = /rules/test_host_app;
+				BAZEL_BUILD_TARGET_LABEL = "rules/test_host_app:iOS-9.3-AppHost";
+				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
+				BAZEL_LLDB_INIT_FILE = "$CONFIGURATION_TEMP_DIR/iOS-9.3-AppHost.lldbinit";
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
+				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
+				INFOPLIST_FILE = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MACH_O_TYPE = "$(inherited)";
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.ios-app-host-9.3";
+				PRODUCT_NAME = "iOS-9.3-AppHost";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -435,6 +636,30 @@
 				USE_HEADERMAP = 0;
 			};
 			name = Release;
+		};
+		A2EBC68178D9C068393555A4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_BIN_SUBDIR = "/tests/ios/unit-test";
+				BAZEL_BUILD_TARGET_LABEL = "tests/ios/unit-test:ExplicitHostedWithAppExtensions";
+				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
+				BAZEL_LLDB_INIT_FILE = $CONFIGURATION_TEMP_DIR/ExplicitHostedWithAppExtensions.lldbinit;
+				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
+				BAZEL_SWIFTMODULEFILES_TO_COPY = "bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-84e06abcb3f0/bin/tests/ios/unit-test/ExplicitHostedWithAppExtensions.swiftmodule bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-84e06abcb3f0/bin/tests/ios/unit-test/ExplicitHostedWithAppExtensions.swiftdoc bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-84e06abcb3f0/bin/tests/ios/unit-test/ExplicitHostedWithAppExtensions.swiftsourceinfo";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MACH_O_TYPE = "$(inherited)";
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = ExplicitHostedWithAppExtensions;
+				SUPPORTS_MACCATALYST = 0;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App.app/App";
+			};
+			name = Debug;
 		};
 		E820AD8661CFA7F4D4F5D642 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -481,7 +706,7 @@
 				PRODUCT_NAME = ExplicitHosted;
 				SUPPORTS_MACCATALYST = 0;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App.app/App";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOS-9.3-AppHost.app/iOS-9.3-AppHost";
 			};
 			name = Debug;
 		};
@@ -505,7 +730,7 @@
 				PRODUCT_NAME = ExplicitHosted;
 				SUPPORTS_MACCATALYST = 0;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App.app/App";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOS-9.3-AppHost.app/iOS-9.3-AppHost";
 			};
 			name = Release;
 		};
@@ -526,6 +751,24 @@
 			buildConfigurations = (
 				267CDF14370121BE5F884778 /* Debug */,
 				79BE8DD7D742DF533736517C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		85B0F18E389439629F1AEA96 /* Build configuration list for PBXNativeTarget "iOS-9.3-AppHost" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				676421DD17502BB445A7A830 /* Debug */,
+				5F1F0A8FCB049380CBA75C41 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		950ED89760E7C50BBDF68501 /* Build configuration list for PBXNativeTarget "ExplicitHostedWithAppExtensions" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A2EBC68178D9C068393555A4 /* Debug */,
+				51D8E2D0F8AD19F227D56320 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/project.pbxproj
@@ -452,7 +452,7 @@
 				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-4b1594d0781e/bin/tests/ios/app/FW\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-4b1594d0781e/bin/tests/ios/app/FW2\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-4b1594d0781e/bin/tests/ios/app/OnlySources\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW2\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/OnlySources\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				INFOPLIST_FILE = "";
@@ -514,7 +514,7 @@
 				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-4b1594d0781e/bin/tests/ios/app/FW\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-4b1594d0781e/bin/tests/ios/app/FW2\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-4b1594d0781e/bin/tests/ios/app/OnlySources\"";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW2\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/OnlySources\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				INFOPLIST_FILE = "";
@@ -536,7 +536,7 @@
 				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
 				BAZEL_LLDB_INIT_FILE = $CONFIGURATION_TEMP_DIR/ExplicitHostedWithAppExtensions.lldbinit;
 				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
-				BAZEL_SWIFTMODULEFILES_TO_COPY = "bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-84e06abcb3f0/bin/tests/ios/unit-test/ExplicitHostedWithAppExtensions.swiftmodule bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-84e06abcb3f0/bin/tests/ios/unit-test/ExplicitHostedWithAppExtensions.swiftdoc bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-84e06abcb3f0/bin/tests/ios/unit-test/ExplicitHostedWithAppExtensions.swiftsourceinfo";
+				BAZEL_SWIFTMODULEFILES_TO_COPY = "bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-41567f1bc2e5/bin/tests/ios/unit-test/ExplicitHostedWithAppExtensions.swiftmodule bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-41567f1bc2e5/bin/tests/ios/unit-test/ExplicitHostedWithAppExtensions.swiftdoc bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-41567f1bc2e5/bin/tests/ios/unit-test/ExplicitHostedWithAppExtensions.swiftsourceinfo";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
@@ -645,7 +645,7 @@
 				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
 				BAZEL_LLDB_INIT_FILE = $CONFIGURATION_TEMP_DIR/ExplicitHostedWithAppExtensions.lldbinit;
 				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
-				BAZEL_SWIFTMODULEFILES_TO_COPY = "bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-84e06abcb3f0/bin/tests/ios/unit-test/ExplicitHostedWithAppExtensions.swiftmodule bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-84e06abcb3f0/bin/tests/ios/unit-test/ExplicitHostedWithAppExtensions.swiftdoc bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-84e06abcb3f0/bin/tests/ios/unit-test/ExplicitHostedWithAppExtensions.swiftsourceinfo";
+				BAZEL_SWIFTMODULEFILES_TO_COPY = "bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-41567f1bc2e5/bin/tests/ios/unit-test/ExplicitHostedWithAppExtensions.swiftmodule bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-41567f1bc2e5/bin/tests/ios/unit-test/ExplicitHostedWithAppExtensions.swiftdoc bazel-out/ios-x86_64-min12.0-applebin_ios-ios_x86_64-dbg-ST-41567f1bc2e5/bin/tests/ios/unit-test/ExplicitHostedWithAppExtensions.swiftsourceinfo";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/xcshareddata/xcschemes/App.xcscheme
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/xcshareddata/xcschemes/App.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9541626BF2F6C0EE11CA1AD7"
-               BuildableName = "iOS-9.3-AppHost.app"
-               BlueprintName = "iOS-9.3-AppHost"
+               BlueprintIdentifier = "2B7DA68C47D629972D1134C8"
+               BuildableName = "App.app"
+               BlueprintName = "App"
                ReferencedContainer = "container:TestWithHostApp.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -33,9 +33,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "9541626BF2F6C0EE11CA1AD7"
-            BuildableName = "iOS-9.3-AppHost.app"
-            BlueprintName = "iOS-9.3-AppHost"
+            BlueprintIdentifier = "2B7DA68C47D629972D1134C8"
+            BuildableName = "App.app"
+            BlueprintName = "App"
             ReferencedContainer = "container:TestWithHostApp.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -50,14 +50,14 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
-      customLLDBInitFile = "$CONFIGURATION_TEMP_DIR/iOS-9.3-AppHost.lldbinit">
+      customLLDBInitFile = "$CONFIGURATION_TEMP_DIR/App.lldbinit">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "9541626BF2F6C0EE11CA1AD7"
-            BuildableName = "iOS-9.3-AppHost.app"
-            BlueprintName = "iOS-9.3-AppHost"
+            BlueprintIdentifier = "2B7DA68C47D629972D1134C8"
+            BuildableName = "App.app"
+            BlueprintName = "App"
             ReferencedContainer = "container:TestWithHostApp.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -74,9 +74,9 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "9541626BF2F6C0EE11CA1AD7"
-            BuildableName = "iOS-9.3-AppHost.app"
-            BlueprintName = "iOS-9.3-AppHost"
+            BlueprintIdentifier = "2B7DA68C47D629972D1134C8"
+            BuildableName = "App.app"
+            BlueprintName = "App"
             ReferencedContainer = "container:TestWithHostApp.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/xcshareddata/xcschemes/ExampleExtension.xcscheme
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/xcshareddata/xcschemes/ExampleExtension.xcscheme
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1200"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2B7DA68C47D629972D1134C8"
+               BuildableName = "App.app"
+               BlueprintName = "App"
+               ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2C3A627878C5E65865D4B494"
+               BuildableName = "ExampleExtension.appex"
+               BlueprintName = "ExampleExtension"
+               ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2B7DA68C47D629972D1134C8"
+            BuildableName = "App.app"
+            BlueprintName = "App"
+            ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2B7DA68C47D629972D1134C8"
+            BuildableName = "App.app"
+            BlueprintName = "App"
+            ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2B7DA68C47D629972D1134C8"
+            BuildableName = "App.app"
+            BlueprintName = "App"
+            ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/xcshareddata/xcschemes/ExplicitHostedWithAppExtensions.xcscheme
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/xcshareddata/xcschemes/ExplicitHostedWithAppExtensions.xcscheme
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1200"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A66AE4DA1051F1DAB24B0FB2"
+               BuildableName = "ExplicitHostedWithAppExtensions.xctest"
+               BlueprintName = "ExplicitHostedWithAppExtensions"
+               ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      customLLDBInitFile = "$CONFIGURATION_TEMP_DIR/ExplicitHostedWithAppExtensions.lldbinit">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A66AE4DA1051F1DAB24B0FB2"
+               BuildableName = "ExplicitHostedWithAppExtensions.xctest"
+               BlueprintName = "ExplicitHostedWithAppExtensions"
+               ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A66AE4DA1051F1DAB24B0FB2"
+            BuildableName = "ExplicitHostedWithAppExtensions.xctest"
+            BlueprintName = "ExplicitHostedWithAppExtensions"
+            ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      customLLDBInitFile = "$CONFIGURATION_TEMP_DIR/ExplicitHostedWithAppExtensions.lldbinit">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A66AE4DA1051F1DAB24B0FB2"
+            BuildableName = "ExplicitHostedWithAppExtensions.xctest"
+            BlueprintName = "ExplicitHostedWithAppExtensions"
+            ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A66AE4DA1051F1DAB24B0FB2"
+            BuildableName = "ExplicitHostedWithAppExtensions.xctest"
+            BlueprintName = "ExplicitHostedWithAppExtensions"
+            ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/xcshareddata/xcschemes/iOS-9.3-AppHost.xcscheme
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/xcshareddata/xcschemes/iOS-9.3-AppHost.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1200"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9541626BF2F6C0EE11CA1AD7"
+               BuildableName = "iOS-9.3-AppHost.app"
+               BlueprintName = "iOS-9.3-AppHost"
+               ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9541626BF2F6C0EE11CA1AD7"
+            BuildableName = "iOS-9.3-AppHost.app"
+            BlueprintName = "iOS-9.3-AppHost"
+            ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      customLLDBInitFile = "$CONFIGURATION_TEMP_DIR/iOS-9.3-AppHost.lldbinit">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9541626BF2F6C0EE11CA1AD7"
+            BuildableName = "iOS-9.3-AppHost.app"
+            BlueprintName = "iOS-9.3-AppHost"
+            ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9541626BF2F6C0EE11CA1AD7"
+            BuildableName = "iOS-9.3-AppHost.app"
+            BlueprintName = "iOS-9.3-AppHost"
+            ReferencedContainer = "container:TestWithHostApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Ensure that when extension schemes are created that they have corresponding targets as well.

Fixes https://github.com/bazel-ios/rules_ios/issues/637.