### PR TITLE
Correct `AppleBundleInfo.infoplist` value

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -817,7 +817,7 @@ def _bundle_static_framework(ctx, is_extension_safe, outputs):
             bundle_name = ctx.attr.framework_name,
             bundle_extension = ctx.attr.bundle_extension,
             entitlements = None,
-            infoplist = outputs.infoplist,
+            infoplist = outputs.infoplist[0] if outputs.infoplist else None,
             minimum_os_version = str(current_apple_platform.target_os_version),
             minimum_deployment_os_version = ctx.attr.minimum_deployment_os_version,
             platform_type = str(current_apple_platform.platform.platform_type),


### PR DESCRIPTION
Ensure the `AppleBundleInfo.infoplist` value is a single `File` instead of a list like `rules_apple` wants:

https://github.com/bazelbuild/rules_apple/blob/4f2b1f840db65ba567f86e1e4b51d19612db2f57/apple/providers.bzl#L72-L74

This was introduced in https://github.com/bazel-ios/rules_ios/pull/607.