### PR TITLE
[RFC] Basic aspect to  _just compile_ a subset

### DIFF
--- a/tools/compile_only_aspect.bzl
+++ b/tools/compile_only_aspect.bzl
@@ -1,0 +1,35 @@
+"""
+Helper aspect to do objc and swift compilation only for fast iteration cycles on
+big mono-repo refactors.
+
+In a mono-repo a developer will change much objc and swift source code. We don't
+want to link or codesign the intermediates. This program collects the relevate
+compile actions 
+
+bazel build -s tests/ios/app:App  --aspects rules/compile_only_aspect.bzl%compile_only_aspect --output_groups=compiles
+"""
+
+def _compile_only_aspect_impl(target, ctx):
+    outs = depset([])
+
+    # Consider in Swift compilation how to only generate the intefaces
+    # through the feature of interface splitting
+    if ctx.rule.kind == "swift_library":
+        for action in target.actions:
+            if action.mnemonic == "SwiftCompile":
+                outs = action.outputs
+                break
+    elif ctx.rule.kind == "objc_library":
+        for action in target.actions:
+            if action.mnemonic == "ObjcCompile":
+                outs = action.outputs
+                break
+    deps = getattr(ctx.rule.attr, "deps", [])
+    transitive = [dep[OutputGroupInfo].compiles for dep in deps if OutputGroupInfo in dep]
+    compile_set = depset([], transitive = [outs] + transitive)
+    return [OutputGroupInfo(compiles = compile_set)]
+
+compile_only_aspect = aspect(
+    implementation = _compile_only_aspect_impl,
+    attr_aspects = ["deps"],
+)


### PR DESCRIPTION
In a big repo I'd like to compile the tree to vet refactoring. However, in the face of #542 we need more changes to fix disk growth. That aside, I generally don't want need to link, codesign, or bundle, so this gets an elemental subset of compiling only with a quick and dirty aspect.

It's useful for CLI development only and wouldn't be part of the core rules.

@congt  I think we can use this to some sort of "type checking" the build as well: just asserting it will compile for something like a merge queue