### PR TITLE
Add support for product version in `--xcode_version`

### DIFF
--- a/tools/toolchains/xcode_configure/xcode_locator.m
+++ b/tools/toolchains/xcode_configure/xcode_locator.m
@@ -29,17 +29,21 @@
 #import <Foundation/Foundation.h>
 
 // Simple data structure for tracking a version of Xcode (i.e. 6.4) with an URL
-// to the appplication.
+// to the application.
 @interface XcodeVersionEntry : NSObject
 @property(readonly) NSString *version;
+@property(readonly) NSString *productVersion;
 @property(readonly) NSURL *url;
 @end
 
 @implementation XcodeVersionEntry
 
-- (id)initWithVersion:(NSString *)version url:(NSURL *)url {
+- (id)initWithVersion:(NSString *)version
+       productVersion:(NSString *)productVersion
+                  url:(NSURL *)url {
   if ((self = [super init])) {
     _version = version;
+    _productVersion = productVersion;
     _url = url;
   }
   return self;
@@ -67,11 +71,15 @@ static void AddEntryToDictionary(
   NSMutableDictionary<NSString *, XcodeVersionEntry *> *dict) {
   BOOL inApplications = [entry.url.path hasPrefix:@"/Applications/"];
   NSString *entryVersion = entry.version;
+  NSString *entryProductVersion = entry.productVersion;
   NSString *subversion = entryVersion;
   if (dict[entryVersion] && !inApplications) {
     return;
   }
   dict[entryVersion] = entry;
+  if (entryProductVersion) {
+    dict[entryProductVersion] = entry;
+  }
   while (YES) {
     NSRange range = [subversion rangeOfString:@"." options:NSBackwardsSearch];
     if (range.length == 0 || range.location == 0) {
@@ -80,8 +88,9 @@ static void AddEntryToDictionary(
     subversion = [subversion substringToIndex:range.location];
     XcodeVersionEntry *subversionEntry = dict[subversion];
     if (subversionEntry) {
-      BOOL atLeastAsLarge = ([subversionEntry.version compare:entry.version]
-                             == NSOrderedDescending);
+      BOOL atLeastAsLarge =
+          ([subversionEntry.version compare:entry.version
+                                    options:NSNumericSearch] != NSOrderedDescending);
       if (inApplications && atLeastAsLarge) {
         dict[subversion] = entry;
       }
@@ -185,9 +194,9 @@ static NSMutableDictionary<NSString *, XcodeVersionEntry *> *FindXcodes()
 
     NSURL *developerDir =
         [url URLByAppendingPathComponent:@"Contents/Developer"];
-    XcodeVersionEntry *entry =
-        [[XcodeVersionEntry alloc] initWithVersion:expandedVersion
-                                               url:developerDir];
+    XcodeVersionEntry *entry = [[XcodeVersionEntry alloc] initWithVersion:expandedVersion
+                                                           productVersion:productVersion
+                                                                      url:developerDir];
     AddEntryToDictionary(entry, dict);
   }
   return errors ? nil : dict;
@@ -224,10 +233,12 @@ static void DumpAsJson(
   FILE *output,
   NSMutableDictionary<NSString *, XcodeVersionEntry *> *dict) {
   fprintf(output, "{\n");
+  int i = 0;
   for (NSString *version in dict) {
     XcodeVersionEntry *entry = dict[version];
-    fprintf(output, "\t\"%s\": \"%s\",\n",
-            version.UTF8String, entry.url.fileSystemRepresentation);
+    fprintf(output, "\t\"%s\": \"%s\"%s\n",
+            version.UTF8String, entry.url.fileSystemRepresentation,
+            ++i == [dict count] ? "" : ",");
   }
   fprintf(output, "}\n");
 }


### PR DESCRIPTION
Update to latest, [`xcode_locator.m`](https://github.com/bazelbuild/bazel/blob/master/tools/osx/xcode_locator.m), to enable `--xcode_version=14C18` to work.

Example error:
```
$ bazelisk build --xcode_version=14C18 //tests/ios/unit-test/test-imports-app:TestImports-App
INFO: Invocation ID: 56c08719-2cb3-49d8-af7e-1a06d0be38f5
INFO: Build option --xcode_version has changed, discarding analysis cache.
ERROR: /private/var/tmp/_bazel_matt.robinson/0e64031a9efbb95e4728094ee9457143/external/local_config_xcode/BUILD:30:13: in xcode_config rule @local_config_xcode//:host_xcodes: --xcode_version=14C18 specified, but '14C18' is not an available Xcode version. available versions: [14.2.0.14C18, 14.0.1.14A400, 14.1.0.14B47b]. If you believe you have '14C18' installed, try running "bazel shutdown", and then re-run your command.
ERROR: /private/var/tmp/_bazel_matt.robinson/0e64031a9efbb95e4728094ee9457143/external/local_config_xcode/BUILD:30:13: Analysis of target '@local_config_xcode//:host_xcodes' failed
INFO: Repository TensorFlowLiteC instantiated at:
  /Users/matt.robinson/Developer/rules_ios/rules_ios/WORKSPACE:110:28: in <toplevel>
  /Users/matt.robinson/Developer/rules_ios/rules_ios/tests/ios/unit-test/test-imports-app/external_dependency.bzl:4:17: in load_framework_dependencies
Repository rule http_archive defined at:
  /private/var/tmp/_bazel_matt.robinson/0e64031a9efbb95e4728094ee9457143/external/bazel_tools/tools/build_defs/repo/http.bzl:372:31: in <toplevel>
ERROR: Analysis of target '//tests/ios/unit-test/test-imports-app:TestImports-App' failed; build aborted:
INFO: Elapsed time: 8.077s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (60 packages loaded, 604 targets configured)
```