### PR TITLE
Feed custom `module_map` to compile actions

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -945,6 +945,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
                 module_name = module_name,
                 tags = _MANUAL,
             )
+            objc_hdrs.append(module_map)
             module_map = "%s.extended.modulemap" % name
 
     # Note: this needs to go here, in order to virtualize the extended module


### PR DESCRIPTION
At some point in recent updates/bumps we hit a regression which caused custom module maps to no longer be propagated to compile actions. This broke remote execution and caching.

Ensures the `input` maps also are sent to `objc_library` - prior to overriding it in the proceeding line of code.