### PR TITLE
[hmap][Bazel 6.0] Harden hmap writes

### DIFF
--- a/rules/hmap/hmap.c
+++ b/rules/hmap/hmap.c
@@ -191,22 +191,25 @@ int hmap_save(HeaderMap* hmap, char* path) {
         perror(path);
         return 1;
     }
+    int rc = 0;
     if (write(fd, hmap->data, hmap->stringsTableNextEntry) !=
         hmap->stringsTableNextEntry) {
         perror(path);
-        return 1;
+        rc = 1;
     }
 
-    if (fsync(fd)) {
+    // Don't fsync if it failed
+    if (rc != 1 && fsync(fd) < 0) {
         perror(path);
-        return  1;
+        rc = 1;
     }
 
+    // Close regardless of failure
     if (close(fd)) {
         perror(path);
-        return  1;
+        rc = 1;
     }
-    return 0;
+    return rc;
 }
 
 void hmap_dump(HeaderMap* hmap) {

--- a/rules/hmap/hmap.c
+++ b/rules/hmap/hmap.c
@@ -191,19 +191,22 @@ int hmap_save(HeaderMap* hmap, char* path) {
         perror(path);
         return 1;
     }
-    int rc = 0;
     if (write(fd, hmap->data, hmap->stringsTableNextEntry) !=
         hmap->stringsTableNextEntry) {
         perror(path);
-        rc = 1;
+        return 1;
     }
 
-    if (fsync(fd) < 0) {
-        rc = 1;
+    if (fsync(fd)) {
+        perror(path);
+        return  1;
     }
 
-    close(fd);
-    return rc;
+    if (close(fd)) {
+        perror(path);
+        return  1;
+    }
+    return 0;
 }
 
 void hmap_dump(HeaderMap* hmap) {

--- a/rules/hmap/hmap.c
+++ b/rules/hmap/hmap.c
@@ -197,6 +197,11 @@ int hmap_save(HeaderMap* hmap, char* path) {
         perror(path);
         rc = 1;
     }
+
+    if (fsync(fd) < 0) {
+        rc = 1;
+    }
+
     close(fd);
     return rc;
 }

--- a/rules/hmap/hmapbuild.c
+++ b/rules/hmap/hmapbuild.c
@@ -60,11 +60,12 @@ int main(int ac, char **av) {
             fprintf(stderr, "failed to add '%s' to hmap\n", m->key);
         }
     }
-    if (hmap_save(hmap, cli_args.output_file)) {
+    int rc = hmap_save(hmap, cli_args.output_file);
+    if (rc) {
         perror(cli_args.output_file);
     }
     hmap_free(hmap);
-    return 0;
+    return rc;
 }
 
 static void usage() {

--- a/rules/hmap/hmapbuild.c
+++ b/rules/hmap/hmapbuild.c
@@ -55,15 +55,14 @@ int main(int ac, char **av) {
     }
     debug("Writing hmap with %u entries", numEntries);
     HeaderMap *hmap = hmap_new(numEntries);
+    int rc = 0;
     for (m = entries; m != NULL; m = m->hh.next) {
         if (hmap_addEntry(hmap, m->key, m->value)) {
             fprintf(stderr, "failed to add '%s' to hmap\n", m->key);
+            rc |= 1;
         }
     }
-    int rc = hmap_save(hmap, cli_args.output_file);
-    if (rc) {
-        perror(cli_args.output_file);
-    }
+    rc |= hmap_save(hmap, cli_args.output_file);
     hmap_free(hmap);
     return rc;
 }

--- a/rules/hmap/hmapbuild.c
+++ b/rules/hmap/hmapbuild.c
@@ -55,13 +55,12 @@ int main(int ac, char **av) {
     }
     debug("Writing hmap with %u entries", numEntries);
     HeaderMap *hmap = hmap_new(numEntries);
-    int rc = 0;
     for (m = entries; m != NULL; m = m->hh.next) {
         if (hmap_addEntry(hmap, m->key, m->value)) {
             fprintf(stderr, "failed to add '%s' to hmap\n", m->key);
-            rc |= 1;
         }
     }
+    int rc = 0;
     rc |= hmap_save(hmap, cli_args.output_file);
     hmap_free(hmap);
     return rc;


### PR DESCRIPTION
Harden hmap logic. After updating to Bazel 6.0 I hav observed several invalid hmap files in `bazel-out` and `--disk_cache`s under load only. The system in question was running Bazel 6, intel, and macOS 12.5.2. This hardens the hmap code to fix 2 obscure/intermittent categories of failure.

1. Fix hmapbuild return code

First if a write fails in rules_ios - in  `hmapbuilder.c` isn't propagated. This is a longstanding bug and maybe masking other problems.

2. Call fsync to guard against data corruption

Per the man page

> fsync() causes all modified data and attributes of fildes to be moved to
> a permanent storage device. This normally results in all in-core
> modified copies of buffers for the associated file to be written to a
> disk.