### PR TITLE
Fix boolean operation Starlark xcconfig crash in Xcode 14.2 xcspec

### DIFF
--- a/data/xcspec_evals.bzl
+++ b/data/xcspec_evals.bzl
@@ -499,7 +499,7 @@ def _com_apple_compilers_llvm_clang_1_0__CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRA
     return (False, "NO")
 
 def _com_apple_compilers_llvm_clang_1_0__CLANG_ENABLE_MODULE_IMPLEMENTATION_OF__Condition(xcconfigs, id_configs):
-    # $(CLANG_ENABLE_MODULES) && $(DEFINES_MODULE)
+    # $(CLANG_ENABLE_MODULES) == "YES" && $(DEFINES_MODULE) == "YES"
 
     used_user_content = False
 
@@ -525,7 +525,7 @@ def _com_apple_compilers_llvm_clang_1_0__CLANG_ENABLE_MODULE_IMPLEMENTATION_OF__
             (eval_val_1_used_user_content, eval_val_1) = XCSPEC_EVALS[opt["DefaultValue"]](xcconfigs, id_configs)
             used_user_content = used_user_content or eval_val_1_used_user_content
 
-    return (used_user_content, (eval_val_0 and eval_val_1))
+    return (used_user_content, (eval_val_0 == "YES" and eval_val_1 == "YES"))
 
 def _com_apple_compilers_llvm_clang_1_0__CLANG_ENABLE_MODULE_IMPLEMENTATION_OF__DefaultValue(xcconfigs, id_configs):
     # YES

--- a/tests/ios/xcconfig/BUILD.bazel
+++ b/tests/ios/xcconfig/BUILD.bazel
@@ -81,6 +81,16 @@ apple_framework(
     xcconfig_by_build_setting = _XCCONFIG_BY_BUILD_SETTING,
 )
 
+apple_framework(
+    name = "WithEdgeCaseConfigs",
+    srcs = glob(["WithEdgeCaseConfigs/*.m"]),
+    platforms = {"ios": "10.0"},
+    visibility = ["//visibility:public"],
+    xcconfig = {
+        "DEFINES_MODULE": "YES",  # Broken by Xcode 14.2 xcspec eval
+    },
+)
+
 ios_application(
     name = "App",
     srcs = ["App/main.m"],
@@ -93,6 +103,7 @@ ios_application(
     deps = [
         ":WithDefinesObjc",
         ":WithDefinesSwift",
+        ":WithEdgeCaseConfigs",
     ],
 )
 

--- a/tests/ios/xcconfig/WithEdgeCaseConfigs/WithEdgeCaseConfigs.m
+++ b/tests/ios/xcconfig/WithEdgeCaseConfigs/WithEdgeCaseConfigs.m
@@ -1,0 +1,4 @@
+@import Foundation;
+
+@interface WithEdgeCaseConfigs : NSObject
+@end


### PR DESCRIPTION
# Summary

Regression introduced in #644 due to change in `xcspec_evals.bzl`

The issue is the `DEFINES_MODULE` xcconfig expects a string `YES` or `NO`, the code now does a check for `"<YES/NO>" and "<YES/NO>"` which causes a Starlark crash. 

Instead, revert back to using `var == "YES"` to get the correct boolean type out of the xcconfig value. 

We should follow up to understand _why_ this was caused.

I added a test to ensure we catch something similar in the future with that particular value.

## Error

```
bazel build //tests/ios/app:AppWithConfigurableAttrs

Analyzing: target //tests/ios/app:AppWithConfigurableAttrs (59 packages loaded, 1262 targets configured)
FATAL: bazel crashed due to an internal error. Printing stack trace:
java.lang.RuntimeException: Unrecoverable error while evaluating node 'ConfiguredTargetKey{label=//tests/ios/app:AppWithConfigurableAttrs_objc, config=BuildConfigurationKey[9ea6e389a26228ecb8df2e1d4412bec7804688be29c838be3a56bc00782d436b]}' (requested by nodes 'ConfiguredTargetKey{label=//tests/ios/app:AppWithConfigurableAttrs.force_load_direct_deps, config=BuildConfigurationKey[9ea6e389a26228ecb8df2e1d4412bec7804688be29c838be3a56bc00782d436b]}', 'ConfiguredTargetKey{label=//tests/ios/app:AppWithConfigurableAttrs.dep_middleman, config=BuildConfigurationKey[9ea6e389a26228ecb8df2e1d4412bec7804688be29c838be3a56bc00782d436b]}', 'ConfiguredTargetKey{label=//tests/ios/app:AppWithConfigurableAttrs.framework_middleman, config=BuildConfigurationKey[5f63a04dfbb11fae3a7047038bee955d71f88f5203d9780a0b6fab50f5ad7344]}')
        at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:642)
        at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:382)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
Caused by: net.starlark.java.eval.Starlark$UncheckedEvalException: NullPointerException thrown during Starlark evaluation (//tests/ios/app:AppWithConfigurableAttrs_objc)
        at <starlark>.create_compilation_attributes(<builtin>:0)
        at <starlark>._build_common_variables(/virtual_builtins_bzl/common/objc/compilation_support.bzl:81)
        at <starlark>._objc_library_impl(/virtual_builtins_bzl/common/objc/objc_library.bzl:42)
Caused by: java.lang.NullPointerException
        at java.base/java.lang.String.replace(Unknown Source)
        at com.google.devtools.build.lib.rules.objc.ObjcStarlarkInternal.expandFlag(ObjcStarlarkInternal.java:163)
        at com.google.devtools.build.lib.rules.objc.ObjcStarlarkInternal.expandToolchainAndRuleContextVariables(ObjcStarlarkInternal.java:137)
        at com.google.devtools.build.lib.rules.objc.ObjcStarlarkInternal.createCompilationAttributes(ObjcStarlarkInternal.java:88)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
        at java.base/java.lang.reflect.Method.invoke(Unknown Source)
        at net.starlark.java.eval.MethodDescriptor.call(MethodDescriptor.java:162)
        at net.starlark.java.eval.BuiltinFunction.fastcall(BuiltinFunction.java:77)
        at net.starlark.java.eval.Starlark.fastcall(Starlark.java:638)
        at net.starlark.java.eval.Eval.evalCall(Eval.java:682)
        at net.starlark.java.eval.Eval.eval(Eval.java:497)
        at net.starlark.java.eval.Eval.execAssignment(Eval.java:109)
        at net.starlark.java.eval.Eval.exec(Eval.java:268)
        at net.starlark.java.eval.Eval.execStatements(Eval.java:82)
        at net.starlark.java.eval.Eval.execFunctionBody(Eval.java:66)
        at net.starlark.java.eval.StarlarkFunction.fastcall(StarlarkFunction.java:173)
        at net.starlark.java.eval.Starlark.fastcall(Starlark.java:638)
        at net.starlark.java.eval.Eval.evalCall(Eval.java:682)
        at net.starlark.java.eval.Eval.eval(Eval.java:497)
        at net.starlark.java.eval.Eval.execAssignment(Eval.java:109)
        at net.starlark.java.eval.Eval.exec(Eval.java:268)
        at net.starlark.java.eval.Eval.execStatements(Eval.java:82)
        at net.starlark.java.eval.Eval.execFunctionBody(Eval.java:66)
        at net.starlark.java.eval.StarlarkFunction.fastcall(StarlarkFunction.java:173)
        at net.starlark.java.eval.Starlark.fastcall(Starlark.java:638)
        at com.google.devtools.build.lib.analysis.starlark.StarlarkRuleConfiguredTargetUtil.buildRule(StarlarkRuleConfiguredTargetUtil.java:99)
        at com.google.devtools.build.lib.analysis.ConfiguredTargetFactory.createRule(ConfiguredTargetFactory.java:363)
        at com.google.devtools.build.lib.analysis.ConfiguredTargetFactory.createConfiguredTarget(ConfiguredTargetFactory.java:192)
        at com.google.devtools.build.lib.skyframe.SkyframeBuildView.createConfiguredTarget(SkyframeBuildView.java:1231)
        at com.google.devtools.build.lib.skyframe.ConfiguredTargetFunction.createConfiguredTarget(ConfiguredTargetFunction.java:1197)
        at com.google.devtools.build.lib.skyframe.ConfiguredTargetFunction.compute(ConfiguredTargetFunction.java:414)
        at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:571)
        at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:382)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
```