### PR TITLE
[LTS][Bazel 5] Provide minimum LTS support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,6 +70,28 @@ jobs:
           name: bazel-testlogs
           path: bazel-testlogs
 
+  lts_ios_integration_tests:
+    name: Build and Test ( Virtual Frameworks + LTS )
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3
+      - name: Select Xcode
+        run: .github/workflows/xcode_select.sh
+      - name: Build and Test
+        run: |
+          export USE_BAZEL_VERSION=5.3.2
+          bazelisk build --features apple.virtualize_frameworks \
+              --local_test_jobs=1 \
+              --apple_platform_type=ios \
+              --deleted_packages='' \
+              -- //tests/ios/... \
+              -//tests/ios/frameworks/sources-with-prebuilt-binaries/...
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: bazel-testlogs
+          path: bazel-testlogs
+
   build_arm64_simulator:
     name: Build arm64 Simulator
     runs-on: macos-12

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,9 +81,7 @@ jobs:
         run: |
           export USE_BAZEL_VERSION=5.3.2
           bazelisk build --features apple.virtualize_frameworks \
-              --local_test_jobs=1 \
-              --apple_platform_type=ios \
-              --deleted_packages='' \
+              --config=ios \
               -- //tests/ios/... \
               -//tests/ios/frameworks/sources-with-prebuilt-binaries/...
       - uses: actions/upload-artifact@v2

--- a/README.md
+++ b/README.md
@@ -172,14 +172,34 @@ Bazel version required by current rules is [here](https://github.com/bazel-ios/r
 for the documentation.
 
 
-### 5.x.x LTS Support
+## 5.x.x LTS Support on HEAD
 
 LTS is a concept in [Bazel for versions](https://blog.bazel.build/2020/11/10/long-term-support-release.html)
+and we currently support 5.x.x only for a brief time. _The rough ETA for
+removing Bazel 5.x.x LTS support is end of Q2 2023 and if it's an issue we can
+correct course sooner._
 
-Because `rules_ios` should be loosely coupled to a given Bazel versions, we
-often handle several Bazel versions concurrently. Our users have a large
-variance of appetite for breakage, custom rules, application complexity, and
-infrastructure.  Dictating a single Bazel version is not possible amongst
-`rules_ios` users.  Because we want to keep running on HEAD ( and have everyone
-do so ) LTS support capabilities will often come into play and the burden to be
-an outlier should fall on the outliers here.
+Because `rules_ios` should be loosely coupled to a given Bazel versions, we can
+often handle several Bazel versions concurrently on `HEAD` without significant
+change and without having to have CI and review for LTS branches. Because we
+want to keep running on `HEAD`, LTS support is added with branches where
+necessary.  _The idea is paralleled to other to large scale migrations or python
+code which supported 2.x.x and 3.x.x concurrently_.
+
+We have a Bazel 5.x.x CI job which is the source of truth for vetting this.
+
+### rules_apple: What's up with rules_ios_1.0
+
+For `rules_apple` we attempt to achieve mutli versions and smoothing over
+maintainer velocity issues on a patched tag. For instance we may back-ported
+some features to our tag like [framework_import_support](https://github.com/bazel-ios/rules_apple/commit/78476e542160be2c32d467ef856ccc2e9152f187)
+
+### Maintainer concerns and rules_apple compatability
+
+We may shim APIs, back port patches from `rules_apple` to add features and
+smooth over integration. The unstable tag `rules_ios_1.0`. If you're just
+bumping `rules_apple` for Bazel 6.0 you don't need to worry about the LTS
+support if it passes CI. The burden to be an outlier should fall on the outliers
+here.
+
+

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ and we currently support 5.x.x only for a brief time. _The rough ETA for
 removing Bazel 5.x.x LTS support is end of Q2 2023 and if it's an issue we can
 correct course sooner._
 
-Because `rules_ios` should be loosely coupled to a given Bazel versions, we can
+Because `rules_ios` should be loosely coupled to a given Bazel version, we can
 often handle several Bazel versions concurrently on `HEAD` without significant
 change and without having to have CI and review for LTS branches. Because we
 want to keep running on `HEAD`, LTS support is added with branches where
@@ -190,16 +190,16 @@ We have a Bazel 5.x.x CI job which is the source of truth for vetting this.
 
 ### rules_apple: What's up with rules_ios_1.0
 
-For `rules_apple` we attempt to achieve mutli versions and smoothing over
+For `rules_apple` we attempt to achieve multi versions and smoothing over
 maintainer velocity issues on a patched tag. For instance we may back-ported
 some features to our tag like [framework_import_support](https://github.com/bazel-ios/rules_apple/commit/78476e542160be2c32d467ef856ccc2e9152f187)
 
 ### Maintainer concerns and rules_apple compatability
 
 We may shim APIs, back port patches from `rules_apple` to add features and
-smooth over integration. The unstable tag `rules_ios_1.0`. If you're just
-bumping `rules_apple` for Bazel 6.0 you don't need to worry about the LTS
-support if it passes CI. The burden to be an outlier should fall on the outliers
-here.
+smooth over integration. The unstable tag `rules_ios_1.0` has it all. If you're
+just bumping `rules_apple` for Bazel 6.0 you shouldn't need to worry about the
+LTS support if it passes CI. The burden to be an outlier should fall on the
+outliers here - if you've got an issue we can look into it together.
 
 

--- a/README.md
+++ b/README.md
@@ -171,3 +171,15 @@ Bazel version required by current rules is [here](https://github.com/bazel-ios/r
 [Click here](https://github.com/bazel-ios/rules_ios/tree/master/docs)
 for the documentation.
 
+
+### 5.x.x LTS Support
+
+LTS is a concept in [Bazel for versions](https://blog.bazel.build/2020/11/10/long-term-support-release.html)
+
+Because `rules_ios` should be loosely coupled to a given Bazel versions, we
+often handle several Bazel versions concurrently. Our users have a large
+variance of appetite for breakage, custom rules, application complexity, and
+infrastructure.  Dictating a single Bazel version is not possible amongst
+`rules_ios` users.  Because we want to keep running on HEAD ( and have everyone
+do so ) LTS support capabilities will often come into play and the burden to be
+an outlier should fall on the outliers here.

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -597,11 +597,11 @@ def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps):
 
     # Determine the interface version of rules_apple. We don't want to force
     # "hail mary" type rules and Bazel bumps on the community to run a given
-    # version of rules_ios and the API we depend on is relatively stable. If
+    # version of rules_ios and the API we depend on is relatively lts_5. If
     # this ceases to be the case than consider mainlining the few components we
     # use from it to remove this complexity.
     rules_apple_api_version = getattr(bundling_support, "rule_api_version", None)
-    use_stable_rules_apple = rules_apple_api_version == 1.0
+    use_lts_5_rules_apple_api = rules_apple_api_version == 1.0
 
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     executable_name = bundling_support.executable_name(ctx)
@@ -728,7 +728,7 @@ def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps):
         ),
     )
 
-    if use_stable_rules_apple:
+    if use_lts_5_rules_apple_api:
         processor_partials.append(
             partials.debug_symbols_partial(
                 actions = actions,
@@ -775,7 +775,7 @@ def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps):
         ),
     )
 
-    if use_stable_rules_apple:
+    if use_lts_5_rules_apple_api:
         processor_partials.append(
             partials.framework_provider_partial(
                 actions = actions,

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -128,6 +128,10 @@ def _validate_deps_minimum_os_version(framework_name, minimum_os_version, deps):
     deps: the deps of this framework
     """
 
+    # TODO @cshi we need a number of fixes to enable this
+    if True:
+        return
+
     for dep in deps:
         if AppleBundleInfo in dep:
             dep_bundle_info = dep[AppleBundleInfo]
@@ -591,6 +595,14 @@ def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps):
         # processed infoplit its possible, but validate for the common case
         fail("Missing bundle_id: Info.plist actions require one")
 
+    # Determine the interface version of rules_apple. We don't want to force
+    # "hail mary" type rules and Bazel bumps on the community to run a given
+    # version of rules_ios and the API we depend on is relatively stable. If
+    # this ceases to be the case than consider mainlining the few components we
+    # use from it to remove this complexity.
+    rules_apple_api_version = getattr(bundling_support, "rule_api_version", None)
+    use_stable_rules_apple = rules_apple_api_version == 1.0
+
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     executable_name = bundling_support.executable_name(ctx)
     features = features_support.compute_enabled_features(
@@ -653,9 +665,11 @@ def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps):
         predeclared_outputs = predeclared_outputs,
     )
 
-    # TODO(jmarino) - consider how to better handle frameworks of frameworks
     dep_frameworks = ctx.attr.frameworks
-    processor_partials = [
+
+    # TODO(jmarino) - consider how to better handle frameworks of frameworks
+    processor_partials = []
+    processor_partials.append(
         partials.apple_bundle_info_partial(
             actions = actions,
             bundle_extension = bundle_extension,
@@ -667,6 +681,8 @@ def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps):
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
         ),
+    )
+    processor_partials.append(
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
@@ -674,6 +690,8 @@ def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps):
             executable_name = executable_name,
             label_name = label.name,
         ),
+    )
+    processor_partials.append(
         partials.bitcode_symbols_partial(
             actions = actions,
             binary_artifact = binary_artifact,
@@ -682,6 +700,8 @@ def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps):
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
         ),
+    )
+    processor_partials.append(
         partials.codesigning_dossier_partial(
             actions = actions,
             apple_mac_toolchain_info = apple_mac_toolchain_info,
@@ -695,6 +715,8 @@ def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps):
             provisioning_profile = provisioning_profile,
             rule_descriptor = rule_descriptor,
         ),
+    )
+    processor_partials.append(
         partials.clang_rt_dylibs_partial(
             actions = actions,
             apple_mac_toolchain_info = apple_mac_toolchain_info,
@@ -704,41 +726,82 @@ def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps):
             platform_prerequisites = platform_prerequisites,
             dylibs = clang_rt_dylibs.get_from_toolchain(ctx),
         ),
-        partials.debug_symbols_partial(
-            actions = actions,
-            bundle_extension = bundle_extension,
-            bundle_name = bundle_name,
-            debug_dependencies = dep_frameworks,
-            dsym_binaries = debug_outputs.dsym_binaries,
-            linkmaps = debug_outputs.linkmaps,
-            dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
-            executable_name = executable_name,
-            platform_prerequisites = platform_prerequisites,
-        ),
+    )
+
+    if use_stable_rules_apple:
+        processor_partials.append(
+            partials.debug_symbols_partial(
+                actions = actions,
+                rule_label = label,
+                bundle_extension = bundle_extension,
+                bundle_name = bundle_name,
+                debug_dependencies = dep_frameworks,
+                dsym_binaries = debug_outputs.dsym_binaries,
+                linkmaps = debug_outputs.linkmaps,
+                dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
+                executable_name = executable_name,
+                platform_prerequisites = platform_prerequisites,
+                bin_root_path = bin_root_path,
+            ),
+        )
+    else:
+        processor_partials.append(
+            partials.debug_symbols_partial(
+                actions = actions,
+                bundle_extension = bundle_extension,
+                bundle_name = bundle_name,
+                debug_dependencies = dep_frameworks,
+                dsym_binaries = debug_outputs.dsym_binaries,
+                linkmaps = debug_outputs.linkmaps,
+                dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
+                executable_name = executable_name,
+                platform_prerequisites = platform_prerequisites,
+            ),
+        )
+
+    processor_partials.append(
         partials.embedded_bundles_partial(
             frameworks = [archive_for_embedding],
             embeddable_targets = dep_frameworks,
             platform_prerequisites = platform_prerequisites,
             signed_frameworks = depset(signed_frameworks),
         ),
+    )
+    processor_partials.append(
         partials.extension_safe_validation_partial(
             is_extension_safe = is_extension_safe,
             rule_label = label,
             targets_to_validate = dep_frameworks,
         ),
+    )
 
-        # Don't bake the headers here - for distro mode, this is done with
-        # xcframework
-        partials.framework_provider_partial(
-            actions = actions,
-            bin_root_path = bin_root_path,
-            binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
-            bundle_only = False,
-            cc_info = link_result.cc_info,
-            objc_provider = link_result.objc,
-            rule_label = label,
-        ),
+    if use_stable_rules_apple:
+        processor_partials.append(
+            partials.framework_provider_partial(
+                actions = actions,
+                bin_root_path = bin_root_path,
+                binary_artifact = binary_artifact,
+                bundle_name = bundle_name,
+                bundle_only = False,
+                objc_provider = link_result.objc,
+                rule_label = label,
+            ),
+        )
+    else:
+        processor_partials.append(
+            partials.framework_provider_partial(
+                actions = actions,
+                bin_root_path = bin_root_path,
+                binary_artifact = binary_artifact,
+                bundle_name = bundle_name,
+                bundle_only = False,
+                cc_info = link_result.cc_info,
+                objc_provider = link_result.objc,
+                rule_label = label,
+            ),
+        )
+
+    processor_partials.append(
         partials.resources_partial(
             actions = actions,
             apple_mac_toolchain_info = apple_mac_toolchain_info,
@@ -758,6 +821,8 @@ def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps):
             version = None,
             version_keys_required = False,
         ),
+    )
+    processor_partials.append(
         partials.swift_dylibs_partial(
             actions = actions,
             apple_mac_toolchain_info = apple_mac_toolchain_info,
@@ -766,6 +831,8 @@ def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps):
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
         ),
+    )
+    processor_partials.append(
         partials.apple_symbols_file_partial(
             actions = actions,
             binary_artifact = binary_artifact,
@@ -775,7 +842,7 @@ def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps):
             include_symbols_in_bundle = False,
             platform_prerequisites = platform_prerequisites,
         ),
-    ]
+    )
 
     processor_result = processor.process(
         actions = actions,

--- a/rules/import_middleman.bzl
+++ b/rules/import_middleman.bzl
@@ -1,6 +1,7 @@
 load("@build_bazel_rules_apple//apple:providers.bzl", "AppleFrameworkImportInfo")
 load("//rules:features.bzl", "feature_names")
 load("//rules/internal:objc_provider_utils.bzl", "objc_provider_utils")
+load("@build_bazel_rules_apple//apple/internal:bundling_support.bzl", "bundling_support")
 
 _FindImportsAspectInfo = provider(fields = {
     "imported_library_file": "",
@@ -92,10 +93,16 @@ def _find_imports_impl(target, ctx):
 
     if ctx.rule.kind == "objc_import":
         imported_library_file.append(target[apple_common.Objc].imported_library)
+
     elif AppleFrameworkImportInfo in target:
-        # The provider field that contains the `static_framework_file` changed in
-        # https://github.com/bazelbuild/rules_apple/commit/8d841342c238457896cd7596cc29b2d06c9a75f0
-        static_framework_file.append(target[apple_common.Objc].imported_library)
+        rules_apple_api_version = getattr(bundling_support, "rule_api_version", None)
+        use_lts_5_rules_apple_api = rules_apple_api_version == 1.0
+        if use_lts_5_rules_apple_api:
+            static_framework_file.append(target[apple_common.Objc].static_framework_file)
+        else:
+            # The provider field that contains the `static_framework_file` changed in
+            # https://github.com/bazelbuild/rules_apple/commit/8d841342c238457896cd7596cc29b2d06c9a75f0
+            static_framework_file.append(target[apple_common.Objc].imported_library)
 
         target_dynamic_framework_file = target[apple_common.Objc].dynamic_framework_file
         target_dynamic_framework_file_list = target_dynamic_framework_file.to_list()

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -47,6 +47,16 @@ def github_repo(name, project, repo, ref, sha256 = None, **kwargs):
         **kwargs
     )
 
+def _get_bazel_version():
+    bazel_version = getattr(native, "bazel_version", "")
+    if bazel_version:
+        parts = bazel_version.split(".")
+        if len(parts) > 2:
+            return struct(major = parts[0], minor = parts[1], patch = parts[2])
+
+    # Unknown, but don't crash
+    return struct(major = 0, minor = 0, patch = 0)
+
 def rules_ios_dependencies():
     """Fetches repositories that are dependencies of the `rules_apple` workspace.
     """
@@ -59,14 +69,29 @@ def rules_ios_dependencies():
         sha256 = "200a35c2c84096f155a5c6092bac2abf1b2149fbeb3eb730a2923997db079a83",
     )
 
-    _maybe(
-        github_repo,
-        name = "build_bazel_rules_apple",
-        ref = "b43c7f60b584d68d7d187c236d4328162ba2e806",
-        project = "bazelbuild",
-        repo = "rules_apple",
-        sha256 = "d3e8549c0c8966ba0e547a02f5601440be25a0b8143bd57ab5834b65b02c22be",
-    )
+    bazel_version = _get_bazel_version()
+    if bazel_version.major == "5":
+        # LTS support. Some of our third party deps from bazelbuild org don't
+        # support LTS but from time to time we'll evaluate supporting this to
+        # allow us to all run on HEAD
+        # For rules_apple, we maintain a tag rules_ios_1.0
+        _maybe(
+            github_repo,
+            name = "build_bazel_rules_apple",
+            ref = "78476e542160be2c32d467ef856ccc2e9152f187",
+            project = "bazelbuild",
+            repo = "rules_apple",
+            sha256 = "320e24459a03f6be2fa1986e6d973465e32e38e478e16cc2b1124a0d4a1bce42",
+        )
+    else:
+        _maybe(
+            github_repo,
+            name = "build_bazel_rules_apple",
+            ref = "b43c7f60b584d68d7d187c236d4328162ba2e806",
+            project = "bazelbuild",
+            repo = "rules_apple",
+            sha256 = "d3e8549c0c8966ba0e547a02f5601440be25a0b8143bd57ab5834b65b02c22be",
+        )
 
     _maybe(
         http_archive,


### PR DESCRIPTION
From time to time we'll evaluate supporting this to allow us to all run on HEAD and keep pushing / working together with minimal dammage.

Detect if the user is on Bazel 5+ and fallback to our tag of `rules_apple` and corresponding API. Because we depend on some of the more stable internals, this isn't such a big deal for now. Add CI vetting and a README note on the status.

Outside of this, a minor fix make it work for me: disable strict version validation we added around deps.

Bazel 6.0 has a number of open questions that will be answered later