### PR TITLE
[RBE] Plumb missing exec_properties field

### DIFF
--- a/rules/test.bzl
+++ b/rules/test.bzl
@@ -46,6 +46,11 @@ def _ios_test(name, test_rule, test_suite_rule, apple_library, infoplists_by_bui
     testonly = kwargs.pop("testonly", True)
     ios_test_kwargs = {arg: kwargs.pop(arg) for arg in _IOS_TEST_KWARGS if arg in kwargs}
     ios_test_kwargs["data"] = kwargs.pop("test_data", [])
+
+    test_exec_properties = kwargs.pop("test_exec_properties", None)
+    if test_exec_properties:
+        ios_test_kwargs["exec_properties"] = test_exec_properties
+
     if ios_test_kwargs.get("test_host", None) == True:
         ios_test_kwargs["test_host"] = "@build_bazel_rules_ios//rules/test_host_app:iOS-%s-AppHost" % ios_test_kwargs.get("minimum_os_version")
 

--- a/tests/ios/app/BUILD.bazel
+++ b/tests/ios/app/BUILD.bazel
@@ -249,6 +249,7 @@ ios_unit_test(
     name = "TestAppWithInfoPlist",
     srcs = ["infoplist_test.m"],
     minimum_os_version = "10.0",
+    test_exec_properties = {},
     test_host = ":AppWithInfoPlist",
 )
 


### PR DESCRIPTION
Thank to https://github.com/bazelbuild/bazel/issues/10799 we now have `exec_properties` and the tests are missing `exec_properties`, so set them. If you have different exec properties for inputs, you can set them with `exec_properties`

Conditional to not expand the size of the action graph