### PR TITLE
[M1][xcodeproj] CLI to update xcodeproj rules tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Select Xcode 14.2.0
         run: .github/workflows/xcode_select.sh
       - name: Run tests
-        run: ./tests/xcodeproj-tests.sh && ./tests/test-tests.sh
+        run: ./tests/xcodeproj-tests.sh --run && ./tests/test-tests.sh
       - uses: actions/upload-artifact@v2
         if: failure()
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Select Xcode 14.2.0
         run: .github/workflows/xcode_select.sh
       - name: Run tests
-        run: ./tests/xcodeproj-tests.sh --clean && ./tests/test-tests.sh
+        run: ./tests/xcodeproj-tests.sh && ./tests/test-tests.sh
       - uses: actions/upload-artifact@v2
         if: failure()
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ user.bazelrc
 external
 *-XCHammer*.xcodeproj
 xchammer-includes
+index-import.runfiles

--- a/tests/ios/xcodeproj/tests.sh
+++ b/tests/ios/xcodeproj/tests.sh
@@ -2,8 +2,14 @@ set -eux
 
 cd $(dirname $0)
 
-# Make sure there are simulators avilable as destinations
-xcrun simctl list
+if [[ "$(arch)" == "arm"* ]]; then
+    echo -e "warning: rerun where Bazel is an x64_64 bazel:\narch -arch x86_64 /bin/bash -l -c \"$0 ${@}\""
+fi
+
+xcrun simctl list devices \
+| grep -q rules_ios:iPhone-14 || \
+        xcrun simctl create "rules_ios:iPhone-14" \
+                com.apple.CoreSimulator.SimDeviceType.iPhone-14
 
 export PROJECT_AND_SCHEME="-project Single-Static-Framework-Project.xcodeproj -scheme ObjcFrameworkTests"
 export SIM_DEVICE_ID=$(xcodebuild \
@@ -11,7 +17,7 @@ $PROJECT_AND_SCHEME \
 -showdestinations \
 -destination "generic/platform=iOS Simulator" | \
 grep "platform:iOS Sim" | \
-grep "name:iPhone 14" | \
+grep "name:rules_ios:iPhone-14" | \
 head -1 | \
 ruby -e "puts STDIN.read.split(',')[1].split(':').last")
 

--- a/tests/macos/xcodeproj/tests.sh
+++ b/tests/macos/xcodeproj/tests.sh
@@ -2,15 +2,21 @@ set -eux
 
 cd $(dirname $0)
 
-# This implicitly creates the simulators for use if not exist
-xcrun simctl list
+if [[ "$(arch)" == "arm"* ]]; then
+    echo -e "warning: rerun where Bazel is an x64_64 bazel:\narch -arch x86_64 /bin/bash -l -c \"$0 ${@}\""
+fi
+
+xcrun simctl list devices \
+| grep -q rules_ios:iPhone-14 || \
+        xcrun simctl create "rules_ios:iPhone-14" \
+                com.apple.CoreSimulator.SimDeviceType.iPhone-14
 
 export SIM_DEVICE_ID=$(xcodebuild \
   -project Single-Application-Project-AllTargets.xcodeproj \
   -scheme Single-Application-UnitTests \
   -showdestinations \
   -destination "generic/platform=iOS Simulator" | \
-  grep "name:iPhone 14" | \
+  grep "name:rules_ios:iPhone-14" | \
   head -1 | \
   ruby -e "puts STDIN.read.split(',')[1].split(':').last")
 

--- a/tests/test-tests.sh
+++ b/tests/test-tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+# This is a helper program for the testing system  - not something you'd run directly
 set -euo pipefail
 
 ## split tests

--- a/tests/xcodeproj-tests.sh
+++ b/tests/xcodeproj-tests.sh
@@ -81,8 +81,15 @@ update() {
 }
 
 if [[ "$(arch)" == "arm"* ]]; then
-    echo -e "error: rerun where Bazel is an x64_64 bazel:\narch -arch x86_64 /bin/bash -l -c \"$0 ${@}\""
-    exit 1
+    echo -e "warning: rerun where Bazel is an x64_64 bazel:\narch -arch x86_64 /bin/bash -l -c \"$0 ${@}\""
+
+    # This should work - rules_ios has been proven to work in this. If you
+    # don't have the right version of Bazelisk then install it.
+    #
+    # This is tested on bash Montery M1 Max to work. A lot of these tools will
+    # not work when spawned under rosetta without a login shell
+    arch -arch x86_64 $SHELL -l -c "$0 ${@}"
+    exit $?
 fi
 
 

--- a/tests/xcodeproj-tests.sh
+++ b/tests/xcodeproj-tests.sh
@@ -56,8 +56,8 @@ verify() {
 test_main() {
     test_macos
     test_simulator
-    test_build_for_device
     test_custom_output
+    test_build_for_device
     verify
 }
 

--- a/tests/xcodeproj-tests.sh
+++ b/tests/xcodeproj-tests.sh
@@ -2,85 +2,108 @@
 
 set -euo pipefail
 
-CLEAN=0
-for ARG in "$@"; do
-    case "$ARG" in
-    --clean)
-        CLEAN=1
-        ;;
-    --no-clean)
-        CLEAN=0
-        ;;
-    *)
-        echo "Unknown argument $ARG"
+test_macos() {
+    echo ".xcodeproj Tests for Mac OS platform"
+    bazelisk query 'kind("xcodeproj rule", tests/macos/xcodeproj/...)' | xargs -n 1 bazelisk run
+    bazelisk query 'attr(executable, 1, kind(genrule, tests/macos/xcodeproj/...))' | xargs -n 1 bazelisk run
+    ./tests/macos/xcodeproj/build.sh
+    ./tests/macos/xcodeproj/tests.sh
+}
+
+test_simulator() {
+    echo ".xcodeproj Tests for iOS platform (simulator)"
+    bazelisk query 'kind("xcodeproj rule", tests/ios/xcodeproj/...)' | xargs -n 1 bazelisk run
+    bazelisk query 'attr(executable, 1, kind(genrule, tests/ios/xcodeproj/...))' | xargs -n 1 bazelisk run
+    ./tests/ios/xcodeproj/pre_build_check.sh
+    ./tests/ios/xcodeproj/build.sh simulator
+    ./tests/ios/xcodeproj/post_build_check.sh simulator
+    ./tests/ios/xcodeproj/tests.sh
+}
+
+test_custom_output() {
+    echo ".xcodeproj Tests for iOS platform (simulator), for project generated under custom_output_path"
+
+    diff_result=$(diff -r ./tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj ./tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj || true)
+    expected_diff_result=$(cat ./tests/ios/xcodeproj/fixtures/test_custom_output_path_expected_diff.txt)
+    if [[ "$diff_result" != "$expected_diff_result" ]]; then
+        echo "The project under custom_output_path differs from the expectation"
+        diff -r ./tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj ./tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj
         exit 1
-        ;;
-    esac
-    shift
-done
+    fi
+}
 
-echo ".xcodeproj Tests for Mac OS platform"
+test_build_for_device() {
+    XCODE_PROJ_NAME="Test-BuildForDevice-Project"
+    bazelisk run //tests/ios/xcodeproj:$XCODE_PROJ_NAME --ios_multi_cpus=arm64
 
-if [[ CLEAN = 1 ]]; then
-    rm -rf tests/macos/xcodeproj/*.xcodeproj tests/macos/xcodeproj/build
-    bazelisk clean
-fi
+    ./tests/ios/xcodeproj/pre_build_check.sh $XCODE_PROJ_NAME
+    ./tests/ios/xcodeproj/build.sh device $XCODE_PROJ_NAME
+    ./tests/ios/xcodeproj/post_build_check.sh device $XCODE_PROJ_NAME
+}
 
-bazelisk query 'kind("xcodeproj rule", tests/macos/xcodeproj/...)' | xargs -n 1 bazelisk run
-bazelisk query 'attr(executable, 1, kind(genrule, tests/macos/xcodeproj/...))' | xargs -n 1 bazelisk run
+verify() {
+    echo "Checking for .xcodeproj changes"
+    git diff --exit-code tests/ios/xcodeproj tests/macos/xcodeproj
+    STATUS=$?
 
-./tests/macos/xcodeproj/build.sh
-./tests/macos/xcodeproj/tests.sh
+    # Dump these to bazel-testlogs for easier updating
+    find tests/ -name \*.xcodeproj \
+        -exec /bin/bash -c \
+        'mkdir -p bazel-testlogs/$(dirname {}) && ditto {} bazel-testlogs/$(dirname {})' \;
+    exit $STATUS
+}
 
-echo ".xcodeproj Tests for iOS platform (simulator)"
+test_main() {
+    test_macos
+    test_simulator
+    test_build_for_device
+    test_custom_output
+    verify
+}
 
-if [[ CLEAN = 1 ]]; then
-    rm -rf tests/ios/xcodeproj/*.xcodeproj tests/ios/xcodeproj/build
-    rm -rf tests/ios/xcodeproj/custom_output_path/*.xcodeproj tests/ios/xcodeproj/custom_output_path/build
-    bazelisk clean
-fi
+clean_projects() {
+    # The xcframeworks directory contains actual fixtures - have a better
+    # convention longer term
+    find \
+	tests/ios \
+	tests/macos \
+	-path "./tests/ios/xcframeworks/*/*" -prune \
+	-type d -name \*.xcodeproj -delete -exec rm -rf {} \; > /dev/null
+}
 
-bazelisk query 'kind("xcodeproj rule", tests/ios/xcodeproj/...)' | xargs -n 1 bazelisk run
-bazelisk query 'attr(executable, 1, kind(genrule, tests/ios/xcodeproj/...))' | xargs -n 1 bazelisk run
+update() {
+    echo "Updating projects."
+    bazelisk query 'kind("xcodeproj rule", tests/macos/xcodeproj/...)' | xargs -n 1 bazelisk run
+    bazelisk query 'attr(executable, 1, kind(genrule, tests/macos/xcodeproj/...))' | xargs -n 1 bazelisk run
+    bazelisk query 'kind("xcodeproj rule", tests/ios/xcodeproj/...)' | xargs -n 1 bazelisk run
+    bazelisk query 'attr(executable, 1, kind(genrule, tests/ios/xcodeproj/...))' | xargs -n 1 bazelisk run
+    bazelisk run //tests/ios/xcodeproj:Test-BuildForDevice-Project --ios_multi_cpus=arm64
+}
 
-./tests/ios/xcodeproj/pre_build_check.sh
-./tests/ios/xcodeproj/build.sh simulator
-./tests/ios/xcodeproj/post_build_check.sh simulator
-./tests/ios/xcodeproj/tests.sh
-
-echo ".xcodeproj Tests for iOS platform (simulator), for project generated under custom_output_path"
-
-diff_result=$(diff -r ./tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj ./tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj || true)
-expected_diff_result=$(cat ./tests/ios/xcodeproj/fixtures/test_custom_output_path_expected_diff.txt)
-if [[ "$diff_result" != "$expected_diff_result" ]]; then
-    echo "The project under custom_output_path differs from the expectation"
-    diff -r ./tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj ./tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj
+if [[ "$(arch)" == "arm"* ]]; then
+    echo -e "error: rerun where Bazel is an x64_64 bazel:\narch -arch x86_64 /bin/bash -l -c \"$0 ${@}\""
     exit 1
 fi
 
-echo ".xcodeproj Tests for iOS platform (device)"
 
-if [[ CLEAN = 1 ]]; then
-    rm -rf tests/ios/xcodeproj/*.xcodeproj tests/ios/xcodeproj/build
-    bazelisk clean
-fi
+for ARG in "$@"; do
+    case "$ARG" in
+    --clean)
+        clean_projects
+	exit $?
+        ;;
+    --run)
+        test_main
+	exit $?
+        ;;
+    --update)
+        update
+	exit $?
+        ;;
+    *)
+	shift
+    esac
+done
 
-XCODE_PROJ_NAME="Test-BuildForDevice-Project"
-bazelisk run //tests/ios/xcodeproj:$XCODE_PROJ_NAME --ios_multi_cpus=arm64
-
-./tests/ios/xcodeproj/pre_build_check.sh $XCODE_PROJ_NAME
-./tests/ios/xcodeproj/build.sh device $XCODE_PROJ_NAME
-./tests/ios/xcodeproj/post_build_check.sh device $XCODE_PROJ_NAME
-
-echo "Checking for .xcodeproj changes"
-
-git diff --exit-code tests/ios/xcodeproj tests/macos/xcodeproj
-STATUS=$?
-
-# Dump these to bazel-testlogs for easier updating
-find tests/ -name \*.xcodeproj \
-    -exec /bin/bash -c \
-    'mkdir -p bazel-testlogs/$(dirname {}) && ditto {} bazel-testlogs/$(dirname {})' \;
-
-exit $STATUS
-
+echo "usage: $0 [--clean|--run|--update]"
+exit 1

--- a/tests/xcodeproj-tests.sh
+++ b/tests/xcodeproj-tests.sh
@@ -65,10 +65,10 @@ clean_projects() {
     # The xcframeworks directory contains actual fixtures - have a better
     # convention longer term
     find \
-	tests/ios \
-	tests/macos \
-	-path "./tests/ios/xcframeworks/*/*" -prune \
-	-type d -name \*.xcodeproj -delete -exec rm -rf {} \; > /dev/null
+	tests/ios/xcodeproj \
+	tests/macos/xcodeproj \
+	-type d -name \*.xcodeproj  \
+	-exec rm -rf {} \; 2> /dev/null
 }
 
 update() {


### PR DESCRIPTION
This PR adds a way for people to run tests which test rules_ios xcodeproj rules tests.  Anytime anyone looks at a change that impacts transitions ( including myself ) it causing the world more confusion to figure out the magic encantation of the test program and rosetta. You can easily update the test fixtures with `--update` if you just care to fix the transitions.

I added assertions for rosetta if you work on arm64 - now it just fails to prevent people getting stuck on this.

Update the fixtures with:
```
arch -arch x86_64 /bin/bash -l -c ./tests/xcodeproj-tests.sh --update
```

Fixes #598

Tested and working end to end on the latest cut of macOS Montery and Xcode 14.1.

It needs a login shell or `xcodebuild` doesn't work.