### PR TITLE
Bump CI to ventura + print simulators

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   integration_tests:
     name: Build and Test
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
       - name: Select Xcode
@@ -26,6 +26,9 @@ jobs:
 
           # Clean up after simctl (https://github.com/bazelbuild/rules_apple/issues/185)
           pgrep Simulator | xargs kill || true
+
+          # Loads simulator device set into memory for the first time
+          xcrun simctl list
 
           # Create single ephemeral iOS sim
           SIMULATOR_UDID=$(./tools/tests/prepare_sim.py)
@@ -47,7 +50,7 @@ jobs:
     # consider merging this feature into the default behavior and can re-align
     # the CI job
     name: Build and Test ( Virtual Frameworks )
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
       - name: Select Xcode
@@ -72,7 +75,7 @@ jobs:
 
   lts_ios_integration_tests:
     name: Build and Test ( Virtual Frameworks + LTS )
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
       - name: Select Xcode
@@ -92,7 +95,7 @@ jobs:
 
   build_arm64_simulator:
     name: Build arm64 Simulator
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
       - name: Select Xcode
@@ -119,7 +122,7 @@ jobs:
 
   buildifier:
     name: Check Starlark and Docs
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
       - name: Select Xcode
@@ -131,7 +134,7 @@ jobs:
         run: bazelisk run docs && git diff --exit-code docs
   xcodeproj_tests:
     name: .xcodeproj Tests on Xcode 14.2.0
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
       - name: Select Xcode 14.2.0
@@ -146,7 +149,7 @@ jobs:
 
   lldb_ios_tests_xcode:
     name: LLDB tests on Xcode 14.2.0
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
       - name: Select Xcode 14.2.0
@@ -160,7 +163,7 @@ jobs:
           path: bazel-testlogs
   multi_arch_support:
     name: Build iOS App for Multiple Architecture
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
       - name: Select Xcode


### PR DESCRIPTION
Bumping to macOS-13 github runner as there is a ton of issues in Montery.

This PR additionally dumps the `xcrun simctl list` result to load the simulator device set ( does rutime boostrap, sig checking, etc )