### PR TITLE
Forward `test_coverage_manifest` to test rules

### DIFF
--- a/rules/test.bzl
+++ b/rules/test.bzl
@@ -20,6 +20,7 @@ _IOS_TEST_KWARGS = [
     "flaky",
     "frameworks",
     "provisioning_profile",
+    "test_coverage_manifest",
     "test_filter",
 ]
 


### PR DESCRIPTION
Allow `test_coverage_manifest` to be used on the test rules.

https://github.com/bazelbuild/rules_apple/pull/1824

https://github.com/bazelbuild/rules_apple/blob/ca789914d90bb41ac68cd334d60dc365b66707d4/apple/internal/rule_factory.bzl#L219-L224