### PR TITLE
Adding 15.0 as a version of the test host app to generate

### DIFF
--- a/rules/test_host_app/test_host_app.bzl
+++ b/rules/test_host_app/test_host_app.bzl
@@ -21,6 +21,7 @@ DEFAULT_MINIMUM_OS_VERSION_LIST = [
     "14.1",
     "14.2",
     "14.3",
+    "15.0",
 ]
 
 def generate_test_host_apps(versions = None, **kwargs):


### PR DESCRIPTION
Adding 15.0 to the list of DEFAULT_MINIMUM_OS_VERSION_LIST in test_host_app.bzl. This will allow `ios_unit_test` targets with `minimum_os_version = 15.0` using `test_host = True` to work.