### PR TITLE
Update macro arguments to specify rules_ios modified arguments

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -4,8 +4,10 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 package(default_visibility = ["//visibility:private"])
 
 _RULES = [
+    "app_clip",
     "app",
     "apple_patched",
+    "extension",
     "framework",
     "hmap",
     "library",

--- a/docs/app_clip_doc.md
+++ b/docs/app_clip_doc.md
@@ -1,0 +1,33 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+
+
+<a id="ios_app_clip"></a>
+
+## ios_app_clip
+
+<pre>
+ios_app_clip(<a href="#ios_app_clip-name">name</a>, <a href="#ios_app_clip-families">families</a>, <a href="#ios_app_clip-infoplists">infoplists</a>, <a href="#ios_app_clip-infoplists_by_build_setting">infoplists_by_build_setting</a>, <a href="#ios_app_clip-xcconfig">xcconfig</a>,
+             <a href="#ios_app_clip-xcconfig_by_build_setting">xcconfig_by_build_setting</a>, <a href="#ios_app_clip-kwargs">kwargs</a>)
+</pre>
+
+    Builds and packages an iOS App Clip.
+
+The docs for app_clip are at rules_apple
+https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-ios.md#ios_app_clip
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="ios_app_clip-name"></a>name |  The name of the iOS app clip.   |  none |
+| <a id="ios_app_clip-families"></a>families |  A list of iOS device families the target supports.   |  <code>["iphone", "ipad"]</code> |
+| <a id="ios_app_clip-infoplists"></a>infoplists |  A list of Info.plist files to be merged into the app clip.   |  <code>[]</code> |
+| <a id="ios_app_clip-infoplists_by_build_setting"></a>infoplists_by_build_setting |  A dictionary of infoplists grouped by bazel build setting.<br><br>Each value is applied if the respective bazel build setting is resolved during the analysis phase.<br><br>If '//conditions:default' is not set the value in 'infoplists' is set as default.   |  <code>{}</code> |
+| <a id="ios_app_clip-xcconfig"></a>xcconfig |  A dictionary of xcconfigs to be applied to the app clip by default.   |  <code>{}</code> |
+| <a id="ios_app_clip-xcconfig_by_build_setting"></a>xcconfig_by_build_setting |  A dictionary of xcconfigs grouped by bazel build setting.<br><br>Each value is applied if the respective bazel build setting is resolved during the analysis phase.<br><br>If '//conditions:default' is not set the value in 'xcconfig' is set as default.   |  <code>{}</code> |
+| <a id="ios_app_clip-kwargs"></a>kwargs |  Arguments passed to the ios_app_clip rule as appropriate.   |  none |
+
+

--- a/docs/app_doc.md
+++ b/docs/app_doc.md
@@ -7,7 +7,8 @@
 ## ios_application
 
 <pre>
-ios_application(<a href="#ios_application-name">name</a>, <a href="#ios_application-apple_library">apple_library</a>, <a href="#ios_application-infoplists_by_build_setting">infoplists_by_build_setting</a>, <a href="#ios_application-kwargs">kwargs</a>)
+ios_application(<a href="#ios_application-name">name</a>, <a href="#ios_application-families">families</a>, <a href="#ios_application-apple_library">apple_library</a>, <a href="#ios_application-infoplists">infoplists</a>, <a href="#ios_application-infoplists_by_build_setting">infoplists_by_build_setting</a>, <a href="#ios_application-xcconfig">xcconfig</a>,
+                <a href="#ios_application-xcconfig_by_build_setting">xcconfig_by_build_setting</a>, <a href="#ios_application-kwargs">kwargs</a>)
 </pre>
 
     Builds and packages an iOS application.
@@ -18,8 +19,12 @@ ios_application(<a href="#ios_application-name">name</a>, <a href="#ios_applicat
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="ios_application-name"></a>name |  The name of the iOS application.   |  none |
+| <a id="ios_application-families"></a>families |  A list of iOS device families the target supports.   |  <code>["iphone", "ipad"]</code> |
 | <a id="ios_application-apple_library"></a>apple_library |  The macro used to package sources into a library.   |  <code>&lt;function apple_library&gt;</code> |
+| <a id="ios_application-infoplists"></a>infoplists |  A list of Info.plist files to be merged into the iOS app.   |  <code>[]</code> |
 | <a id="ios_application-infoplists_by_build_setting"></a>infoplists_by_build_setting |  A dictionary of infoplists grouped by bazel build setting.<br><br>Each value is applied if the respective bazel build setting is resolved during the analysis phase.<br><br>If '//conditions:default' is not set the value in 'infoplists' is set as default.   |  <code>{}</code> |
+| <a id="ios_application-xcconfig"></a>xcconfig |  A dictionary of xcconfigs to be applied to the iOS app by default.   |  <code>{}</code> |
+| <a id="ios_application-xcconfig_by_build_setting"></a>xcconfig_by_build_setting |  A dictionary of xcconfigs grouped by bazel build setting.<br><br>Each value is applied if the respective bazel build setting is resolved during the analysis phase.<br><br>If '//conditions:default' is not set the value in 'xcconfig' is set as default.   |  <code>{}</code> |
 | <a id="ios_application-kwargs"></a>kwargs |  Arguments passed to the apple_library and ios_application rules as appropriate.   |  none |
 
 

--- a/docs/extension_doc.md
+++ b/docs/extension_doc.md
@@ -1,0 +1,35 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+
+
+<a id="ios_extension"></a>
+
+## ios_extension
+
+<pre>
+ios_extension(<a href="#ios_extension-name">name</a>, <a href="#ios_extension-families">families</a>, <a href="#ios_extension-infoplists">infoplists</a>, <a href="#ios_extension-infoplists_by_build_setting">infoplists_by_build_setting</a>, <a href="#ios_extension-xcconfig">xcconfig</a>,
+              <a href="#ios_extension-xcconfig_by_build_setting">xcconfig_by_build_setting</a>, <a href="#ios_extension-kwargs">kwargs</a>)
+</pre>
+
+    Builds and packages an iOS extension.
+
+The docs for ios_extension are at rules_apple
+https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-ios.md#ios_extension
+
+Perhaps we can just remove this wrapper longer term.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="ios_extension-name"></a>name |  The name of the iOS extension.   |  none |
+| <a id="ios_extension-families"></a>families |  A list of iOS device families the target supports.   |  <code>["iphone", "ipad"]</code> |
+| <a id="ios_extension-infoplists"></a>infoplists |  A list of Info.plist files to be merged into the extension.   |  <code>[]</code> |
+| <a id="ios_extension-infoplists_by_build_setting"></a>infoplists_by_build_setting |  A dictionary of infoplists grouped by bazel build setting.<br><br>Each value is applied if the respective bazel build setting is resolved during the analysis phase.<br><br>If '//conditions:default' is not set the value in 'infoplists' is set as default.   |  <code>{}</code> |
+| <a id="ios_extension-xcconfig"></a>xcconfig |  A dictionary of xcconfigs to be applied to the extension by default.   |  <code>{}</code> |
+| <a id="ios_extension-xcconfig_by_build_setting"></a>xcconfig_by_build_setting |  A dictionary of xcconfigs grouped by bazel build setting.<br><br>Each value is applied if the respective bazel build setting is resolved during the analysis phase.<br><br>If '//conditions:default' is not set the value in 'xcconfig' is set as default.   |  <code>{}</code> |
+| <a id="ios_extension-kwargs"></a>kwargs |  Arguments passed to the ios_extension rule as appropriate.   |  none |
+
+

--- a/docs/framework_doc.md
+++ b/docs/framework_doc.md
@@ -49,7 +49,8 @@ Packages compiled code into an Apple .framework package
 ## apple_framework
 
 <pre>
-apple_framework(<a href="#apple_framework-name">name</a>, <a href="#apple_framework-apple_library">apple_library</a>, <a href="#apple_framework-kwargs">kwargs</a>)
+apple_framework(<a href="#apple_framework-name">name</a>, <a href="#apple_framework-apple_library">apple_library</a>, <a href="#apple_framework-infoplists">infoplists</a>, <a href="#apple_framework-infoplists_by_build_setting">infoplists_by_build_setting</a>, <a href="#apple_framework-xcconfig">xcconfig</a>,
+                <a href="#apple_framework-xcconfig_by_build_setting">xcconfig_by_build_setting</a>, <a href="#apple_framework-kwargs">kwargs</a>)
 </pre>
 
 Builds and packages an Apple framework.
@@ -61,6 +62,10 @@ Builds and packages an Apple framework.
 | :------------- | :------------- | :------------- |
 | <a id="apple_framework-name"></a>name |  The name of the framework.   |  none |
 | <a id="apple_framework-apple_library"></a>apple_library |  The macro used to package sources into a library.   |  <code>&lt;function apple_library&gt;</code> |
+| <a id="apple_framework-infoplists"></a>infoplists |  A list of Info.plist files to be merged into the framework.   |  <code>[]</code> |
+| <a id="apple_framework-infoplists_by_build_setting"></a>infoplists_by_build_setting |  A dictionary of infoplists grouped by bazel build setting.<br><br>Each value is applied if the respective bazel build setting is resolved during the analysis phase.<br><br>If '//conditions:default' is not set the value in 'infoplists' is set as default.   |  <code>{}</code> |
+| <a id="apple_framework-xcconfig"></a>xcconfig |  A dictionary of xcconfigs to be applied to the framework by default.   |  <code>{}</code> |
+| <a id="apple_framework-xcconfig_by_build_setting"></a>xcconfig_by_build_setting |  A dictionary of xcconfigs grouped by bazel build setting.<br><br>Each value is applied if the respective bazel build setting is resolved during the analysis phase.<br><br>If '//conditions:default' is not set the value in 'xcconfig' is set as default.   |  <code>{}</code> |
 | <a id="apple_framework-kwargs"></a>kwargs |  Arguments passed to the apple_library and apple_framework_packaging rules as appropriate.   |  none |
 
 

--- a/rules/app_clip.bzl
+++ b/rules/app_clip.bzl
@@ -5,6 +5,7 @@ load("//rules/internal:framework_middleman.bzl", "dep_middleman", "framework_mid
 
 def ios_app_clip(
         name,
+        families = ["iphone", "ipad"],
         infoplists = [],
         infoplists_by_build_setting = {},
         xcconfig = {},
@@ -18,6 +19,7 @@ def ios_app_clip(
 
     Args:
         name: The name of the iOS app clip.
+        families: A list of iOS device families the target supports.
         infoplists: A list of Info.plist files to be merged into the app clip.
         infoplists_by_build_setting: A dictionary of infoplists grouped by bazel build setting.
 
@@ -81,6 +83,7 @@ def ios_app_clip(
         name = name,
         deps = deps,
         frameworks = frameworks,
+        families = families,
         output_discriminator = None,
         infoplists = select(processed_infoplists),
         testonly = testonly,

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -40,27 +40,48 @@ _APPLE_FRAMEWORK_PACKAGING_KWARGS = [
     "exported_symbols_lists",
 ]
 
-def apple_framework(name, apple_library = apple_library, **kwargs):
+def apple_framework(
+        name,
+        apple_library = apple_library,
+        infoplists = [],
+        infoplists_by_build_setting = {},
+        xcconfig = {},
+        xcconfig_by_build_setting = {},
+        **kwargs):
     """Builds and packages an Apple framework.
 
     Args:
         name: The name of the framework.
         apple_library: The macro used to package sources into a library.
+        infoplists: A list of Info.plist files to be merged into the framework.
+        infoplists_by_build_setting: A dictionary of infoplists grouped by bazel build setting.
+
+                                     Each value is applied if the respective bazel build setting
+                                     is resolved during the analysis phase.
+
+                                     If '//conditions:default' is not set the value in 'infoplists'
+                                     is set as default.
+        xcconfig: A dictionary of xcconfigs to be applied to the framework by default.
+        xcconfig_by_build_setting: A dictionary of xcconfigs grouped by bazel build setting.
+
+                                   Each value is applied if the respective bazel build setting
+                                   is resolved during the analysis phase.
+
+                                   If '//conditions:default' is not set the value in 'xcconfig'
+                                   is set as default.
         **kwargs: Arguments passed to the apple_library and apple_framework_packaging rules as appropriate.
     """
     framework_packaging_kwargs = {arg: kwargs.pop(arg) for arg in _APPLE_FRAMEWORK_PACKAGING_KWARGS if arg in kwargs}
     kwargs["enable_framework_vfs"] = kwargs.pop("enable_framework_vfs", True)
 
-    infoplists_by_build_setting = kwargs.pop("infoplists_by_build_setting", {})
-    default_infoplists = kwargs.pop("infoplists", [])
-    infoplists = None
-    if len(infoplists_by_build_setting.values()) > 0 or len(default_infoplists) > 0:
-        infoplists = select(process_infoplists(
+    merged_infoplists = None
+    if len(infoplists_by_build_setting.values()) > 0 or len(infoplists) > 0:
+        merged_infoplists = select(process_infoplists(
             name = name,
-            infoplists = default_infoplists,
+            infoplists = infoplists,
             infoplists_by_build_setting = infoplists_by_build_setting,
-            xcconfig = kwargs.get("xcconfig", {}),
-            xcconfig_by_build_setting = kwargs.get("xcconfig_by_build_setting", {}),
+            xcconfig = xcconfig,
+            xcconfig_by_build_setting = xcconfig_by_build_setting,
         ))
     environment_plist = kwargs.pop("environment_plist", select({
         "@build_bazel_rules_ios//rules/apple_platform:ios": "@build_bazel_rules_apple//apple/internal:environment_plist_ios",
@@ -72,7 +93,14 @@ def apple_framework(name, apple_library = apple_library, **kwargs):
 
     testonly = kwargs.pop("testonly", False)
 
-    library = apple_library(name = name, testonly = testonly, **kwargs)
+    library = apple_library(
+        name = name,
+        testonly = testonly,
+        xcconfig = xcconfig,
+        xcconfig_by_build_setting = xcconfig_by_build_setting,
+        **kwargs
+    )
+
     framework_deps = []
 
     # Setup force loading here - only for direct deps / direct libs and when `link_dynamic` is set.
@@ -91,7 +119,7 @@ def apple_framework(name, apple_library = apple_library, **kwargs):
     apple_framework_packaging(
         name = name,
         framework_name = library.namespace,
-        infoplists = infoplists,
+        infoplists = merged_infoplists,
         environment_plist = environment_plist,
         transitive_deps = library.transitive_deps,
         vfs = library.import_vfsoverlays,


### PR DESCRIPTION
A follow-up to #670 where we talked about moving the rules_ios modified kwargs to explicit arguments in the macros. Additionally, generates missing docs & updates outdated documentation.