### PR TITLE
Update Gems from tests to fix possible security vulnerability

### DIFF
--- a/tests/ios/frameworks/sources-with-prebuilt-binaries/Gemfile
+++ b/tests/ios/frameworks/sources-with-prebuilt-binaries/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org' do
-  gem 'cocoapods', '1.11.3'
+  gem 'cocoapods', '1.12.0'
   gem 'cocoapods-binary', '0.4.4'
 end

--- a/tests/ios/frameworks/sources-with-prebuilt-binaries/Gemfile.lock
+++ b/tests/ios/frameworks/sources-with-prebuilt-binaries/Gemfile.lock
@@ -4,30 +4,29 @@ GEM
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.5)
+    CFPropertyList (3.0.6)
       rexml
-    activesupport (6.1.7)
+    activesupport (7.0.4.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
-    addressable (2.8.1)
+    addressable (2.8.2)
       public_suffix (>= 2.0.2, < 6.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
     claide (1.1.0)
-    cocoapods (1.11.3)
+    cocoapods (1.12.0)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.11.3)
+      cocoapods-core (= 1.12.0)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
-      cocoapods-downloader (>= 1.4.0, < 2.0)
+      cocoapods-downloader (>= 1.6.0, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
-      cocoapods-trunk (>= 1.4.0, < 2.0)
+      cocoapods-trunk (>= 1.6.0, < 2.0)
       cocoapods-try (>= 1.1.0, < 2.0)
       colored2 (~> 3.1)
       escape (~> 0.0.4)
@@ -35,14 +34,14 @@ GEM
       gh_inspector (~> 1.0)
       molinillo (~> 0.8.0)
       nap (~> 1.0)
-      ruby-macho (>= 1.0, < 3.0)
+      ruby-macho (>= 2.3.0, < 3.0)
       xcodeproj (>= 1.21.0, < 2.0)
     cocoapods-binary (0.4.4)
       cocoapods (>= 1.5.0, < 2.0)
       fourflusher (~> 2.0)
       xcpretty (~> 0.3.0)
-    cocoapods-core (1.11.3)
-      activesupport (>= 5.0, < 7)
+    cocoapods-core (1.12.0)
+      activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
       concurrent-ruby (~> 1.1)
@@ -61,9 +60,9 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     escape (0.0.4)
-    ethon (0.15.0)
+    ethon (0.16.0)
       ffi (>= 1.15.0)
     ffi (1.15.5)
     fourflusher (2.3.1)
@@ -72,8 +71,8 @@ GEM
     httpclient (2.8.3)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    json (2.6.2)
-    minitest (5.16.3)
+    json (2.6.3)
+    minitest (5.18.0)
     molinillo (0.8.0)
     nanaimo (0.3.0)
     nap (1.1.0)
@@ -84,7 +83,7 @@ GEM
     ruby-macho (2.5.1)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (2.0.5)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     xcodeproj (1.22.0)
       CFPropertyList (>= 2.3.3, < 4.0)
@@ -95,13 +94,12 @@ GEM
       rexml (~> 3.2.4)
     xcpretty (0.3.0)
       rouge (~> 2.0.7)
-    zeitwerk (2.6.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (= 1.11.3)!
+  cocoapods (= 1.12.0)!
   cocoapods-binary (= 0.4.4)!
 
 BUNDLED WITH


### PR DESCRIPTION
Was seeing this when pushing:

```
remote: 
remote: 
remote: GitHub found 2 vulnerabilities on bazel-ios/rules_ios's default branch (1 moderate, 1 low). To find out more, visit:        
remote:      https://github.com/bazel-ios/rules_ios/security/dependabot        
remote: 
```

Updating the gemfile to bump `activesupport` version and cocoapods to get rid of any possible issues here

See:  https://github.com/bazel-ios/rules_ios/security/dependabot for more info