### PR TITLE
Bump rules_apple to 2.2.0

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -9,6 +9,7 @@ load("//rules:transition_support.bzl", "transition_support")
 load("//rules/internal:objc_provider_utils.bzl", "objc_provider_utils")
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@build_bazel_rules_apple//apple/internal:apple_product_type.bzl", "apple_product_type")
 load("@build_bazel_rules_apple//apple/internal:bundling_support.bzl", "bundling_support")
 load("@build_bazel_rules_apple//apple/internal:features_support.bzl", "features_support")
@@ -788,6 +789,14 @@ def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps):
             ),
         )
     else:
+        cc_toolchain = find_cpp_toolchain(ctx)
+        cc_features = cc_common.configure_features(
+            ctx = ctx,
+            cc_toolchain = cc_toolchain,
+            language = "objc",
+            requested_features = ctx.features,
+            unsupported_features = ctx.disabled_features,
+        )
         processor_partials.append(
             partials.framework_provider_partial(
                 actions = actions,
@@ -795,7 +804,9 @@ def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps):
                 binary_artifact = binary_artifact,
                 bundle_name = bundle_name,
                 bundle_only = False,
+                cc_features = cc_features,
                 cc_info = link_result.cc_info,
+                cc_toolchain = cc_toolchain,
                 objc_provider = link_result.objc,
                 rule_label = label,
             ),

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -87,10 +87,10 @@ def rules_ios_dependencies():
         _maybe(
             github_repo,
             name = "build_bazel_rules_apple",
-            ref = "a55a5e3b8dd75557f6feded6a5a4ba929bcd8edb",
+            ref = "935d5ad80300578f35833db26f124f20aeda9cba",
             project = "bazelbuild",
             repo = "rules_apple",
-            sha256 = "4bb8b5d2287af4e152f181c9b1d3b0ef5c0cc6abe18e7ab42dbb932a496b1058",
+            sha256 = "46186d7ceb726aedce566458b4a3e389fa2b20ce5a714180c74c875fc1a945fb",
         )
 
     _maybe(


### PR DESCRIPTION
https://github.com/bazelbuild/rules_apple/releases/tag/2.2.0

Handle https://github.com/bazelbuild/rules_apple/commit/6e41b943f9985c1fde71ad9a9ddb505937da0afb in `rules_ios`’s `framework_provider_partial` usage.