### PR TITLE
Add remote cache for CI jobs

### DIFF
--- a/.github/workflows/xcode_select.sh
+++ b/.github/workflows/xcode_select.sh
@@ -19,3 +19,7 @@ echo "build --xcode_version_config=//:host_xcodes" >> user.bazelrc
 
 # `deleted_packages` is needed below in order to override the value of the .bazelrc file
 echo "build:ios --apple_platform_type=ios --deleted_packages=''" >> user.bazelrc
+
+# Remote cache
+echo "build --remote_cache=grpcs://remote.buildbuddy.io" >> user.bazelrc
+echo "build --remote_timeout=3600" >> user.bazelrc

--- a/.github/workflows/xcode_select.sh
+++ b/.github/workflows/xcode_select.sh
@@ -23,3 +23,4 @@ echo "build:ios --apple_platform_type=ios --deleted_packages=''" >> user.bazelrc
 # Remote cache
 echo "build --remote_cache=grpcs://remote.buildbuddy.io" >> user.bazelrc
 echo "build --remote_timeout=3600" >> user.bazelrc
+echo "build --modify_execution_info=^(BitcodeSymbolsCopy|BundleApp|BundleTreeApp|DsymDwarf|DsymLipo|GenerateAppleSymbolsFile|ObjcBinarySymbolStrip|CppLink|ObjcLink|ProcessAndSign|SignBinary|SwiftArchive|SwiftStdlibCopy)$=+no-remote,^(BundleResources|ImportedDynamicFrameworkProcessor)$=+no-remote-exec" >> user.bazelrc


### PR DESCRIPTION
New version of https://github.com/bazel-ios/rules_ios/pull/376 to use BuildBuddy remote cache for CI jobs. Only enabled for CI jobs at this point vs. in the `.bazelrc` to avoid being prescriptive for dev workflows.