### PR TITLE
Minor vfs perf improvements

### DIFF
--- a/rules/framework/vfs_overlay.bzl
+++ b/rules/framework/vfs_overlay.bzl
@@ -1,3 +1,14 @@
+"""framework_vfs_overlay impl
+
+Note on `external-contents` key set many times in this file:
+
+Internal to swift and clang - LLVM `VirtualFileSystem` object can
+serialize paths relative to the absolute path of the overlay. This
+requires the paths are relative to the overlay. While deriving the
+in-memory tree roots, it pre-pends the prefix of the `vfsoverlay` path
+to each of the entries.
+"""
+
 load("//rules:providers.bzl", "FrameworkInfo")
 load("//rules:features.bzl", "feature_names")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")

--- a/rules/framework/vfs_overlay.bzl
+++ b/rules/framework/vfs_overlay.bzl
@@ -91,10 +91,11 @@ def _get_public_framework_header(path):
 # and incrementality. For imported frameworks, there is additional search paths
 # enabled
 def _make_root(vfs_parent, target_triple, swiftmodules, root_dir, extra_search_paths, module_map, hdrs, private_hdrs):
-    vfs_prefix = _make_relative_prefix(len(vfs_parent.split("/")) - 1)
+    vfs_parent_len = len(vfs_parent.split("/")) - 1
+    vfs_prefix = _make_relative_prefix(vfs_parent_len)
     private_headers_contents = []
     headers_contents = []
-    vfs_prefix = _make_relative_prefix(len(vfs_parent.split("/")) - 1)
+    vfs_prefix = _make_relative_prefix(vfs_parent_len)
 
     if extra_search_paths:
         paths = []
@@ -119,14 +120,14 @@ def _make_root(vfs_parent, target_triple, swiftmodules, root_dir, extra_search_p
 
     # Swiftmodules: should we factor this  upwards
     modules_contents = []
-    if len(module_map):
+    if module_map:
         modules_contents.append({
             "type": "file",
             "name": "module.modulemap",
             "external-contents": vfs_prefix + module_map[0].path,
         })
 
-    if len(swiftmodules):
+    if swiftmodules:
         any_swiftmodule_file = swiftmodules[0]
         if any_swiftmodule_file.is_source:
             # Handle a glob of files inside of a .swiftmodule e.g. for xcframework
@@ -146,7 +147,7 @@ def _make_root(vfs_parent, target_triple, swiftmodules, root_dir, extra_search_p
                 })
 
     modules = []
-    if len(modules_contents):
+    if modules_contents:
         modules = [{
             "name": "Modules",
             "type": "directory",
@@ -166,7 +167,7 @@ def _make_root(vfs_parent, target_triple, swiftmodules, root_dir, extra_search_p
         ])
 
     headers = []
-    if len(headers_contents):
+    if headers_contents:
         headers = [{
             "name": "Headers",
             "type": "directory",
@@ -184,7 +185,7 @@ def _make_root(vfs_parent, target_triple, swiftmodules, root_dir, extra_search_p
         ])
 
     private_headers = []
-    if len(private_headers_contents):
+    if private_headers_contents:
         private_headers = [{
             "name": "PrivateHeaders",
             "type": "directory",
@@ -192,14 +193,14 @@ def _make_root(vfs_parent, target_triple, swiftmodules, root_dir, extra_search_p
         }]
 
     roots = []
-    if len(headers) or len(private_headers) or len(modules):
+    if headers or private_headers or modules:
         roots.append({
             "name": root_dir,
             "type": "directory",
             "contents": headers + private_headers + modules,
         })
 
-    if len(swiftmodules) > 0:
+    if swiftmodules:
         contents = _provided_vfs_swift_module_contents(swiftmodules, vfs_prefix, target_triple)
         if contents:
             roots.append(contents)
@@ -368,7 +369,7 @@ def make_vfsoverlay(ctx, hdrs, module_map, private_hdrs, has_swift, swiftmodules
     )
 
     vfs_info = _make_vfs_info(framework_name, data)
-    if len(merge_vfsoverlays) > 0:
+    if merge_vfsoverlays:
         vfs_info = _merge_vfs_infos(vfs_info, merge_vfsoverlays)
         roots = _roots_from_datas(vfs_parent, target_triple, vfs_info.values() + [data])
 

--- a/rules/framework/vfs_overlay.bzl
+++ b/rules/framework/vfs_overlay.bzl
@@ -62,15 +62,17 @@ def _build_subtrees(paths, vfs_prefix):
         # Loop the _framework_ path and add each dir to the current tree.
         # Assume the last bit is a file then add it as a file
         idx = 0
+
+        parts_len = len(parts)
+        ext_c = _get_external_contents(vfs_prefix, path_info.path)
         for part in parts:
-            if idx == len(parts) - 1:
-                ext_c = _get_external_contents(vfs_prefix, path_info.path)
+            if idx == parts_len - 1:
                 curr_subdirs.dict[part] = -1
                 curr_subdirs.json["contents"].append({"name": part, "type": "file", "external-contents": ext_c})
                 break
 
             # Lookup a value for the current subdirs, otherwise append
-            next_subdirs = curr_subdirs.dict.get(part, None)
+            next_subdirs = curr_subdirs.dict[part] if part in curr_subdirs.dict else None
             if not next_subdirs:
                 next_subdirs_json = {"contents": [], "type": "directory", "name": part}
                 next_subdirs = struct(dict = {}, json = next_subdirs_json)


### PR DESCRIPTION
Running some tests using `--starlark_cpu_profile` in one big app we have and noticed some hot spots we can easily improve here. Nothing major but still a good optimization to make IMO.

The overall improvement at the `_framework_vfs_overlay_impl` level is from `109.82s` to down to `77.82s`:

before:
![Screen Shot 2023-04-06 at 10 17 43 AM](https://user-images.githubusercontent.com/10197663/230405354-48826b71-bec8-4de6-80cd-6d0fc4a58bf2.png)

after:
![Screen Shot 2023-04-06 at 10 17 52 AM](https://user-images.githubusercontent.com/10197663/230405406-cd6f83e9-d01c-4b02-bea5-dc8b3c3112cf.png)

I was surprised with how much time is spent on `append/extend/len` operations but I guess there's not much we can do here without revisiting the algo as a whole and see if there's a better way to go about generating the same outputs.

It's definitely weird that removing the macro `_get_external_contents` that was just concatenating strings has improved things and I ran the same "before vs after" profiles without making the change in this commit https://github.com/bazel-ios/rules_ios/pull/678/commits/908d03befb963b572849c48a8707eba63f5330d1 to see if it was indeed causing any impact. When I did that the improvement was not as a good, `_framework_vfs_overlay_impl` went from `109.82s` down to `92.12s`. I don't know if there's additional overhead in Starlark when macros are invoked but unless my interpretation is incorrect I think we should keep this commit. 
