### PR TITLE
Loading XCHammer is opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ ios_application(
 
 ### Xcode project generation
 
-_Bazel optimized Xcode project generation that's tested and works end to end with open source remote execution and caching_
+There are currently at least three options to generate Xcode projects that build with Bazel.
 
+`rules_ios` has its own project generator that is considered stable and ready to be used in production. Here's a minimal example of how to load it in your `BUILD` file:
 ```python
 load("@build_bazel_rules_ios//rules:xcodeproj.bzl", "xcodeproj")
 
@@ -42,9 +43,15 @@ xcodeproj(
     deps = [ ":iOS-App"] 
 )
 ```
+Checkout [legacy_xcodeproj.bzl](https://github.com/bazel-ios/rules_ios/blob/master/rules/legacy_xcodeproj.bzl) for available attributes.
 
-_projects are optimized to build with Bazel and optionally fallback to building with Xcode_
+Alternatively the `bazel-ios` org has forks of both [XCHammer](https://github.com/bazel-ios/xchammer) and [Tulsi](https://github.com/bazel-ios/tulsi) with some changes to make it work with `rules_ios` and optionally enable the "build with Xcode" use case. This is currently considered "alpha" software and not recommended to be used in production. If you want to test it out when loading `rules_ios` per [WORKSPACE setup](#workspace-setup) instructions below load `rules_ios` dependencies like so
+```python
+rules_ios_dependencies(load_xchammer_dependencies = True)
+```
+and additionally pass this attribute to the `xcodeproj` macro above `use_xchammer = True`, optionally pass `generate_xcode_schemes = True` to build with Xcode.
 
+Last, [rules_xcodeproj](https://github.com/MobileNativeFoundation/rules_xcodeproj) is another great alternative and we're working with them to better integrate it with `rules_ios`. Checkout [examples/rules_ios](https://github.com/MobileNativeFoundation/rules_xcodeproj/tree/main/examples/rules_ios) for examples of how to use it with `rules_ios`.
 
 ### Frameworks
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,9 +3,12 @@ workspace(name = "build_bazel_rules_ios")
 load(
     "//rules:repositories.bzl",
     "rules_ios_dependencies",
+    "rules_ios_xchammer_dependencies",
 )
 
 rules_ios_dependencies()
+
+rules_ios_xchammer_dependencies()
 
 load(
     "@build_bazel_rules_apple//apple:repositories.bzl",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,12 +3,9 @@ workspace(name = "build_bazel_rules_ios")
 load(
     "//rules:repositories.bzl",
     "rules_ios_dependencies",
-    "rules_ios_xchammer_dependencies",
 )
 
-rules_ios_dependencies()
-
-rules_ios_xchammer_dependencies()
+rules_ios_dependencies(load_xchammer_dependencies = True)
 
 load(
     "@build_bazel_rules_apple//apple:repositories.bzl",

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -57,7 +57,7 @@ def _get_bazel_version():
     # Unknown, but don't crash
     return struct(major = 0, minor = 0, patch = 0)
 
-def xchammer_dependencies():
+def rules_ios_xchammer_dependencies():
     """Dependencies that can optionally be loaded into a WORKSPACE file if the intent is to use XCHammer
     """
     if not native.existing_rule("xchammer"):

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -58,8 +58,8 @@ def _get_bazel_version():
     return struct(major = 0, minor = 0, patch = 0)
 
 def xchammer_dependencies():
-"""Dependencies that can optionally be loaded into a WORKSPACE file if the intent is to use XCHammer
-"""
+    """Dependencies that can optionally be loaded into a WORKSPACE file if the intent is to use XCHammer
+    """
     if not native.existing_rule("xchammer"):
         git_repository(
             name = "xchammer",

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -57,6 +57,28 @@ def _get_bazel_version():
     # Unknown, but don't crash
     return struct(major = 0, minor = 0, patch = 0)
 
+def xchammer_dependencies():
+"""Dependencies that can optionally be loaded into a WORKSPACE file if the intent is to use XCHammer
+"""
+    if not native.existing_rule("xchammer"):
+        git_repository(
+            name = "xchammer",
+            remote = "https://github.com/bazel-ios/xchammer.git",
+            # XCHammer dev branch: bazel-ios/rules-ios-xchammer
+            commit = "fffd8033bed79e61a908ca1a72acff867a5b5825",
+            shallow_since = "1670600984 -0500",
+        )
+    xchammer_dependencies()
+
+    if not native.existing_rule("xcbuildkit"):
+        git_repository(
+            name = "xcbuildkit",
+            commit = "18a2b0e73d2e0cba759d5b4da24e47af106922d7",
+            remote = "https://github.com/jerrymarino/xcbuildkit.git",
+        )
+
+    xcbuildkit_dependencies()
+
 def rules_ios_dependencies():
     """Fetches repositories that are dependencies of the `rules_apple` workspace.
     """
@@ -155,22 +177,3 @@ swift_binary(
         urls = ["https://github.com/cirruslabs/tart/releases/download/0.14.0/tart"],
         sha256 = "2c61526aa07ade30ab6534b0fdc0a0edeb56ec2084dadee587e53c46e3a8edc3",
     )
-
-    if not native.existing_rule("xchammer"):
-        git_repository(
-            name = "xchammer",
-            remote = "https://github.com/bazel-ios/xchammer.git",
-            # XCHammer dev branch: bazel-ios/rules-ios-xchammer
-            commit = "fffd8033bed79e61a908ca1a72acff867a5b5825",
-            shallow_since = "1670600984 -0500",
-        )
-    xchammer_dependencies()
-
-    if not native.existing_rule("xcbuildkit"):
-        git_repository(
-            name = "xcbuildkit",
-            commit = "18a2b0e73d2e0cba759d5b4da24e47af106922d7",
-            remote = "https://github.com/jerrymarino/xcbuildkit.git",
-        )
-
-    xcbuildkit_dependencies()

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -57,30 +57,12 @@ def _get_bazel_version():
     # Unknown, but don't crash
     return struct(major = 0, minor = 0, patch = 0)
 
-def rules_ios_xchammer_dependencies():
-    """Dependencies that can optionally be loaded into a WORKSPACE file if the intent is to use XCHammer
-    """
-    if not native.existing_rule("xchammer"):
-        git_repository(
-            name = "xchammer",
-            remote = "https://github.com/bazel-ios/xchammer.git",
-            # XCHammer dev branch: bazel-ios/rules-ios-xchammer
-            commit = "fffd8033bed79e61a908ca1a72acff867a5b5825",
-            shallow_since = "1670600984 -0500",
-        )
-    xchammer_dependencies()
+def rules_ios_dependencies(
+        load_xchammer_dependencies = False):
+    """Fetches repositories that are dependencies of `rules_ios`.
 
-    if not native.existing_rule("xcbuildkit"):
-        git_repository(
-            name = "xcbuildkit",
-            commit = "18a2b0e73d2e0cba759d5b4da24e47af106922d7",
-            remote = "https://github.com/jerrymarino/xcbuildkit.git",
-        )
-
-    xcbuildkit_dependencies()
-
-def rules_ios_dependencies():
-    """Fetches repositories that are dependencies of the `rules_apple` workspace.
+    Args:
+        load_xchammer_dependencies: if `True` loads XCHammer and xcbuildkit dependencies (this is considered "alpha" software at the moment, see `README`)
     """
     _maybe(
         github_repo,
@@ -177,3 +159,23 @@ swift_binary(
         urls = ["https://github.com/cirruslabs/tart/releases/download/0.14.0/tart"],
         sha256 = "2c61526aa07ade30ab6534b0fdc0a0edeb56ec2084dadee587e53c46e3a8edc3",
     )
+
+    if load_xchammer_dependencies:
+        if not native.existing_rule("xchammer"):
+            git_repository(
+                name = "xchammer",
+                remote = "https://github.com/bazel-ios/xchammer.git",
+                # XCHammer dev branch: bazel-ios/rules-ios-xchammer
+                commit = "fffd8033bed79e61a908ca1a72acff867a5b5825",
+                shallow_since = "1670600984 -0500",
+            )
+        xchammer_dependencies()
+
+        if not native.existing_rule("xcbuildkit"):
+            git_repository(
+                name = "xcbuildkit",
+                commit = "18a2b0e73d2e0cba759d5b4da24e47af106922d7",
+                remote = "https://github.com/jerrymarino/xcbuildkit.git",
+            )
+
+        xcbuildkit_dependencies()


### PR DESCRIPTION
Prevents unnecessarily downloading XCHammer dependencies if there's no intent of using it. If they do want to use it they just need to invoke this new macro in their `WORKSPACE` file.