### PR TITLE
XCHammer is opt-in follow up

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,18 @@ Alternatively the `bazel-ios` org has forks of both [XCHammer](https://github.co
 ```python
 rules_ios_dependencies(load_xchammer_dependencies = True)
 ```
-and additionally pass this attribute to the `xcodeproj` macro above `use_xchammer = True`, optionally pass `generate_xcode_schemes = True` to build with Xcode.
+and additionally declare the `xchammer_xcodeproj` macro this way
+```python
+load("@build_bazel_rules_ios//rules:xchammer_xcodeproj.bzl", "xchammer_xcodeproj")
+
+xchammer_xcodeproj(
+    name = "MyXcode",
+    bazel_path = "bazelisk",
+    generate_xcode_schemes = False # if True enables "build with Xcode"
+    targets = [ ":iOS-App"]
+)
+```
+Checkout [xchammer_xcodeproj.bzl](https://github.com/bazel-ios/rules_ios/blob/master/rules/xchammer_xcodeproj.bzl) for available attributes.
 
 Last, [rules_xcodeproj](https://github.com/MobileNativeFoundation/rules_xcodeproj) is another great alternative and we're working with them to better integrate it with `rules_ios`. Checkout [examples/rules_ios](https://github.com/MobileNativeFoundation/rules_xcodeproj/tree/main/examples/rules_ios) for examples of how to use it with `rules_ios`.
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,7 +5,7 @@ load(
     "rules_ios_dependencies",
 )
 
-rules_ios_dependencies(load_xchammer_dependencies = True)
+rules_ios_dependencies()
 
 load(
     "@build_bazel_rules_apple//apple:repositories.bzl",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,7 +5,7 @@ load(
     "rules_ios_dependencies",
 )
 
-rules_ios_dependencies()
+rules_ios_dependencies(load_xchammer_dependencies = True)
 
 load(
     "@build_bazel_rules_apple//apple:repositories.bzl",

--- a/rules/xchammer_xcodeproj.bzl
+++ b/rules/xchammer_xcodeproj.bzl
@@ -1,0 +1,57 @@
+""" XCHammer specific project generation macros """
+
+load("@xchammer//:BazelExtensions/xcodeproject.bzl", "xcode_project")
+load("@xchammer//:BazelExtensions/xchammerconfig.bzl", "bazel_build_service_config", "project_config")
+load("//rules:library.bzl", "GLOBAL_INDEX_STORE_PATH")
+
+def _patch_bazel_build_service_config(name, kwargs_bazel_build_service_config):
+    """Adds sensible defaults
+
+    If users don't specify these values adding defaults that make sense in rules_ios, XCHammer adds
+    its own default values if not specified otherwise (very similar to these atm).
+
+    It's really important to align the index stores with `xcbuildkit` so 'GLOBAL_INDEX_STORE_PATH' is always set
+    for now since this is how `rules_ios` is setup. Later on we can make this more configurable.
+    """
+    if kwargs_bazel_build_service_config:
+        return bazel_build_service_config(
+            bep_path = kwargs_bazel_build_service_config.bepPath if kwargs_bazel_build_service_config.bepPath else "/tmp/{}.bep".format(name),
+            index_store_path = "$SRCROOT/%s" % GLOBAL_INDEX_STORE_PATH,
+            indexing_data_dir = kwargs_bazel_build_service_config.indexingDataDir if kwargs_bazel_build_service_config.indexingDataDir else "/tmp/xcbuildkit-data/{}/indexing".format(name),
+            indexing_enabled = kwargs_bazel_build_service_config.indexingEnabled if kwargs_bazel_build_service_config.indexingEnabled else False,
+            progress_bar_enabled = kwargs_bazel_build_service_config.progressBarEnabled if kwargs_bazel_build_service_config.progressBarEnabled else False,
+        )
+    return None
+
+def xchammer_xcodeproj(
+        name,
+        **kwargs):
+    """Macro that wrapper XCHammer's xcode_project macro with some sensible defaults (this is currently "alpha" software, see README)
+
+    Args:
+      name: Name of the rule to be declared
+      **kwargs: Arguments to propagate
+    """
+
+    # Ensures testonly is set (see https://github.com/bazel-ios/rules_ios/pull/573)
+    testonly = kwargs.pop("testonly", False)
+
+    # Ensures some sensible default values are set
+    generate_xcode_schemes = kwargs.pop("generate_xcode_schemes", False)
+    xcconfig_overrides = kwargs.pop("xcconfig_overrides", {})
+    bazel_build_service_config = _patch_bazel_build_service_config(name, kwargs.pop("bazel_build_service_config", None))
+    bazel_path = kwargs.get("bazel_path", "/usr/local/bin/bazel")
+    targets = kwargs.get("deps", [])
+
+    xcode_project(
+        name = name,
+        testonly = testonly,
+        bazel = bazel_path,
+        project_config = project_config(
+            generate_xcode_schemes = generate_xcode_schemes,
+            paths = ["**"],
+            xcconfig_overrides = xcconfig_overrides,
+        ),
+        bazel_build_service_config = bazel_build_service_config,
+        targets = targets,
+    )

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -1,56 +1,16 @@
 """ Xcode Project Generation Logic """
 
 load("//rules:legacy_xcodeproj.bzl", legacy_xcodeproj = "xcodeproj")
-load("@xchammer//:BazelExtensions/xcodeproject.bzl", xchammer_xcodeproj = "xcode_project")
-load("@xchammer//:BazelExtensions/xchammerconfig.bzl", "bazel_build_service_config", "project_config")
-load("//rules:library.bzl", "GLOBAL_INDEX_STORE_PATH")
-
-def _patch_bazel_build_service_config(name, kwargs_bazel_build_service_config):
-    """Adds sensible defaults
-
-    If users don't specify these values adding defaults that make sense in rules_ios, XCHammer adds
-    its own default values if not specified otherwise (very similar to these atm).
-
-    It's really important to align the index stores with `xcbuildkit` so 'GLOBAL_INDEX_STORE_PATH' is always set
-    for now since this is how `rules_ios` is setup. Later on we can make this more configurable.
-    """
-    if kwargs_bazel_build_service_config:
-        return bazel_build_service_config(
-            bep_path = kwargs_bazel_build_service_config.bepPath if kwargs_bazel_build_service_config.bepPath else "/tmp/{}.bep".format(name),
-            index_store_path = "$SRCROOT/%s" % GLOBAL_INDEX_STORE_PATH,
-            indexing_data_dir = kwargs_bazel_build_service_config.indexingDataDir if kwargs_bazel_build_service_config.indexingDataDir else "/tmp/xcbuildkit-data/{}/indexing".format(name),
-            indexing_enabled = kwargs_bazel_build_service_config.indexingEnabled if kwargs_bazel_build_service_config.indexingEnabled else False,
-            progress_bar_enabled = kwargs_bazel_build_service_config.progressBarEnabled if kwargs_bazel_build_service_config.progressBarEnabled else False,
-        )
-    return None
 
 def xcodeproj(name, **kwargs):
-    """Macro that allows one to declare one of 'legacy_xcodeproj', 'xchammer_xcodeproj' depending on value of 'use_xchammer' flag
+    """Macro that declares current default Xcode project generator (see `rules/legacy_xcodeproj.bzl`)
 
     Args:
       name: Name of the rule to be declared
-      **kwargs: Arguments to propagate, the XCHammer specific ones are going to be removed before declaring the legacy rule
+      **kwargs: Arguments to propagate
     """
 
-    # Pop XCHammer specific attributes so these don't get propagated to `legacy_xcodeproj`
-    use_xchammer = kwargs.pop("use_xchammer", False)
-    generate_xcode_schemes = kwargs.pop("generate_xcode_schemes", False)
-    xcconfig_overrides = kwargs.pop("xcconfig_overrides", {})
+    # Ensures testonly is set (see https://github.com/bazel-ios/rules_ios/pull/573)
     testonly = kwargs.pop("testonly", False)
-    bazel_build_service_config = _patch_bazel_build_service_config(name, kwargs.pop("bazel_build_service_config", None))
 
-    if use_xchammer:
-        xchammer_xcodeproj(
-            name = name,
-            testonly = testonly,
-            bazel = kwargs.get("bazel_path", "/usr/local/bin/bazel"),
-            project_config = project_config(
-                generate_xcode_schemes = generate_xcode_schemes,
-                paths = ["**"],
-                xcconfig_overrides = xcconfig_overrides,
-            ),
-            bazel_build_service_config = bazel_build_service_config,
-            targets = kwargs.get("deps", []),
-        )
-    else:
-        legacy_xcodeproj(name = name, testonly = testonly, **kwargs)
+    legacy_xcodeproj(name = name, testonly = testonly, **kwargs)

--- a/tests/ios/xcodeproj/BUILD.bazel
+++ b/tests/ios/xcodeproj/BUILD.bazel
@@ -1,6 +1,7 @@
 load("//rules:xcodeproj.bzl", "xcodeproj")
 load("//rules:legacy_xcodeproj.bzl", "xcodeproj_project_options")
 load("//rules:additional_scheme_info.bzl", "additional_scheme_info")
+load("//rules:xchammer_xcodeproj.bzl", "xchammer_xcodeproj")
 load("@xchammer//:BazelExtensions/xchammerconfig.bzl", "bazel_build_service_config")
 
 xcodeproj(
@@ -223,9 +224,8 @@ xcodeproj(
     ],
 )
 
-xcodeproj(
+xchammer_xcodeproj(
     name = "App-XCHammer",
-    use_xchammer = True,
     deps = [
         "//tests/ios/app:App",
         "//tests/ios/extensions:ExampleExtension",
@@ -233,13 +233,12 @@ xcodeproj(
     ],
 )
 
-xcodeproj(
+xchammer_xcodeproj(
     name = "App-XCHammerWithXCBuildKit",
     bazel_build_service_config = bazel_build_service_config(
         indexing_enabled = True,
         progress_bar_enabled = True,
     ),
-    use_xchammer = True,
     deps = [
         "//tests/ios/app:App",
         "//tests/ios/extensions:ExampleExtension",

--- a/tests/ios/xcodeproj/BUILD.bazel
+++ b/tests/ios/xcodeproj/BUILD.bazel
@@ -1,8 +1,6 @@
 load("//rules:xcodeproj.bzl", "xcodeproj")
 load("//rules:legacy_xcodeproj.bzl", "xcodeproj_project_options")
 load("//rules:additional_scheme_info.bzl", "additional_scheme_info")
-load("//rules:xchammer_xcodeproj.bzl", "xchammer_xcodeproj")
-load("@xchammer//:BazelExtensions/xchammerconfig.bzl", "bazel_build_service_config")
 
 xcodeproj(
     name = "Single-Static-Framework-Project",
@@ -221,27 +219,5 @@ xcodeproj(
     project_attributes_overrides = {"ORGANIZATIONNAME": "rules_ios"},
     deps = [
         "//tests/ios/frameworks/dynamic:App",
-    ],
-)
-
-xchammer_xcodeproj(
-    name = "App-XCHammer",
-    deps = [
-        "//tests/ios/app:App",
-        "//tests/ios/extensions:ExampleExtension",
-        "//tests/ios/frameworks/with-bundle-id:FrameworkWithBundleId",
-    ],
-)
-
-xchammer_xcodeproj(
-    name = "App-XCHammerWithXCBuildKit",
-    bazel_build_service_config = bazel_build_service_config(
-        indexing_enabled = True,
-        progress_bar_enabled = True,
-    ),
-    deps = [
-        "//tests/ios/app:App",
-        "//tests/ios/extensions:ExampleExtension",
-        "//tests/ios/frameworks/with-bundle-id:FrameworkWithBundleId",
     ],
 )

--- a/tests/ios/xcodeproj/BUILD.bazel
+++ b/tests/ios/xcodeproj/BUILD.bazel
@@ -1,6 +1,8 @@
 load("//rules:xcodeproj.bzl", "xcodeproj")
 load("//rules:legacy_xcodeproj.bzl", "xcodeproj_project_options")
 load("//rules:additional_scheme_info.bzl", "additional_scheme_info")
+load("//rules:xchammer_xcodeproj.bzl", "xchammer_xcodeproj")
+load("@xchammer//:BazelExtensions/xchammerconfig.bzl", "bazel_build_service_config")
 
 xcodeproj(
     name = "Single-Static-Framework-Project",
@@ -219,5 +221,27 @@ xcodeproj(
     project_attributes_overrides = {"ORGANIZATIONNAME": "rules_ios"},
     deps = [
         "//tests/ios/frameworks/dynamic:App",
+    ],
+)
+
+xchammer_xcodeproj(
+    name = "App-XCHammer",
+    deps = [
+        "//tests/ios/app:App",
+        "//tests/ios/extensions:ExampleExtension",
+        "//tests/ios/frameworks/with-bundle-id:FrameworkWithBundleId",
+    ],
+)
+
+xchammer_xcodeproj(
+    name = "App-XCHammerWithXCBuildKit",
+    bazel_build_service_config = bazel_build_service_config(
+        indexing_enabled = True,
+        progress_bar_enabled = True,
+    ),
+    deps = [
+        "//tests/ios/app:App",
+        "//tests/ios/extensions:ExampleExtension",
+        "//tests/ios/frameworks/with-bundle-id:FrameworkWithBundleId",
     ],
 )


### PR DESCRIPTION
Follow up to https://github.com/bazel-ios/rules_ios/pull/683

The previous PR wasn't handling this correctly, clients would still fail if they **don't pass** `load_xchammer_dependencies` to opt-out of loading XCHammer
```python
rules_ios_dependencies(load_xchammer_dependencies = True)
```

To truly make this opt-in clients need to load a different symbol. This is advertised as "alpha" software atm so breaking changes like this are expected.