### PR TITLE
Support `additional_linker_inputs` on `ios_application`

### DIFF
--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -36,6 +36,8 @@ _IOS_APPLICATION_KWARGS = [
     "frameworks",
     "version",
     "app_clips",
+    "linkopts",
+    "additional_linker_inputs",
 ]
 
 def ios_application(


### PR DESCRIPTION
The `ios_applicatoin` in rules_apple has parameters `linkopts` and `additional_linker_inputs`.  This change makes the `ios_application` in rules_ios also supports them.