### PR TITLE
Prune release asset for rules_ios

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -22,7 +22,15 @@ jobs:
           git config user.email "noreply@github.com"
 
           # Archive the repository
-          COPYFILE_DISABLE=1 tar czvf "rules_ios.$TAG.tar.gz" ./*
+          # Considerations:
+          # - Dont package hidden files (including the .git directory)
+          # - Dont package the bazel-* symlink directories
+          # - Dont package the tests directory
+          COPYFILE_DISABLE=1 tar czvf "rules_ios.$TAG.tar.gz" \
+            --exclude="./.*" \
+            --exclude="./bazel-*" \
+            --exclude="./tests" \
+            ./*
 
           # Create the release notes
           ./.github/workflows/generate_release_notes.sh "$TAG" | tee notes.md


### PR DESCRIPTION
Removes some directories from the final release archive that take a significant amount of space and aren't required for consumers.

## Before

```sh
du -h rules_ios.1.0.0.tar.gz
49M    rules_ios.1.0.0.tar.gz
```

## After

```sh
du -h rules_ios.1.0.0.tar.gz
1.0M   rules_ios.1.0.0.tar.gz
```