### PR TITLE
Enable Runfiles deps for all test rules

### DIFF
--- a/docs/test_doc.md
+++ b/docs/test_doc.md
@@ -39,6 +39,7 @@ ios_unit_snapshot_test(<a href="#ios_unit_snapshot_test-name">name</a>, <a href=
 | :------------- | :------------- | :------------- |
 | <a id="ios_unit_snapshot_test-name"></a>name |  The name of the UI test.   |  none |
 | <a id="ios_unit_snapshot_test-apple_library"></a>apple_library |  The macro used to package sources into a library.   |  <code>&lt;function apple_library&gt;</code> |
+| <a id="ios_unit_snapshot_test-include_internal_test_deps"></a>include_internal_test_deps |  Arguments passed to the rules_ios to include internal_test_deps.   |  none |
 | <a id="ios_unit_snapshot_test-kwargs"></a>kwargs |  Arguments passed to the apple_library and ios_unit_test rules as appropriate.   |  none |
 
 

--- a/docs/test_doc.md
+++ b/docs/test_doc.md
@@ -19,6 +19,7 @@ ios_ui_test(<a href="#ios_ui_test-name">name</a>, <a href="#ios_ui_test-apple_li
 | :------------- | :------------- | :------------- |
 | <a id="ios_ui_test-name"></a>name |  The name of the UI test.   |  none |
 | <a id="ios_ui_test-apple_library"></a>apple_library |  The macro used to package sources into a library.   |  <code>&lt;function apple_library&gt;</code> |
+| <a id="ios_unit_snapshot_test-include_internal_test_deps"></a>include_internal_test_deps |  Arguments passed to the rules_ios to include internal_test_deps.   |  none |
 | <a id="ios_ui_test-kwargs"></a>kwargs |  Arguments passed to the apple_library and ios_ui_test rules as appropriate.   |  none |
 
 
@@ -60,6 +61,7 @@ ios_unit_test(<a href="#ios_unit_test-name">name</a>, <a href="#ios_unit_test-ap
 | :------------- | :------------- | :------------- |
 | <a id="ios_unit_test-name"></a>name |  The name of the unit test.   |  none |
 | <a id="ios_unit_test-apple_library"></a>apple_library |  The macro used to package sources into a library.   |  <code>&lt;function apple_library&gt;</code> |
+| <a id="ios_unit_snapshot_test-include_internal_test_deps"></a>include_internal_test_deps |  Arguments passed to the rules_ios to include internal_test_deps.   |  none |
 | <a id="ios_unit_test-kwargs"></a>kwargs |  Arguments passed to the apple_library and ios_unit_test rules as appropriate.   |  none |
 
 

--- a/rules/test.bzl
+++ b/rules/test.bzl
@@ -24,7 +24,16 @@ _IOS_TEST_KWARGS = [
     "visibility",
 ]
 
-def _ios_test(name, test_rule, test_suite_rule, apple_library, infoplists_by_build_setting = {}, split_name_to_kwargs = {}, internal_test_deps = [], **kwargs):
+def _ios_test(
+    name, 
+    test_rule, 
+    test_suite_rule, 
+    apple_library, 
+    infoplists_by_build_setting = {}, 
+    split_name_to_kwargs = {}, 
+    internal_test_deps = ["@bazel_tools//tools/cpp/runfiles"],
+    **kwargs
+    ):
     """
     Builds and packages iOS Unit/UI Tests.
 
@@ -170,4 +179,4 @@ def ios_unit_snapshot_test(name, apple_library = apple_library, **kwargs):
         apple_library: The macro used to package sources into a library.
         **kwargs: Arguments passed to the apple_library and ios_unit_test rules as appropriate.
     """
-    _ios_test(name, rules_apple_ios_unit_test, rules_apple_ios_unit_test_suite, apple_library, internal_test_deps = ["@bazel_tools//tools/cpp/runfiles"], **kwargs)
+    _ios_test(name, rules_apple_ios_unit_test, rules_apple_ios_unit_test_suite, apple_library, **kwargs)

--- a/rules/test.bzl
+++ b/rules/test.bzl
@@ -25,13 +25,13 @@ _IOS_TEST_KWARGS = [
 ]
 
 def _ios_test(
-    name, 
-    test_rule, 
-    test_suite_rule, 
-    apple_library, 
-    infoplists_by_build_setting = {}, 
-    split_name_to_kwargs = {}, 
-    internal_test_deps = ["@bazel_tools//tools/cpp/runfiles"],
+    name,
+    test_rule,
+    test_suite_rule,
+    apple_library,
+    include_internal_test_deps,
+    infoplists_by_build_setting = {},
+    split_name_to_kwargs = {},    
     **kwargs
     ):
     """
@@ -53,6 +53,7 @@ def _ios_test(
         **kwargs: Arguments passed to the apple_library and test_rule rules as appropriate.
     """
 
+    internal_test_deps = ["@bazel_tools//tools/cpp/runfiles"] if include_internal_test_deps else []
     testonly = kwargs.pop("testonly", True)
     ios_test_kwargs = {arg: kwargs.pop(arg) for arg in _IOS_TEST_KWARGS if arg in kwargs}
     ios_test_kwargs["data"] = kwargs.pop("test_data", [])
@@ -146,7 +147,7 @@ def _ios_test(
             **ios_test_kwargs
         )
 
-def ios_unit_test(name, apple_library = apple_library, **kwargs):
+def ios_unit_test(name, apple_library = apple_library, include_internal_test_deps = False, **kwargs):
     """
     Builds and packages iOS Unit Tests.
 
@@ -155,9 +156,9 @@ def ios_unit_test(name, apple_library = apple_library, **kwargs):
         apple_library: The macro used to package sources into a library.
         **kwargs: Arguments passed to the apple_library and ios_unit_test rules as appropriate.
     """
-    _ios_test(name, rules_apple_ios_unit_test, rules_apple_ios_unit_test_suite, apple_library, **kwargs)
+    _ios_test(name, rules_apple_ios_unit_test, rules_apple_ios_unit_test_suite, apple_library, include_internal_test_deps, **kwargs)
 
-def ios_ui_test(name, apple_library = apple_library, **kwargs):
+def ios_ui_test(name, apple_library = apple_library, include_internal_test_deps = False, **kwargs):
     """
     Builds and packages iOS UI Tests.
 
@@ -168,9 +169,9 @@ def ios_ui_test(name, apple_library = apple_library, **kwargs):
     """
     if not kwargs.get("test_host", None):
         fail("test_host is required for ios_ui_test.")
-    _ios_test(name, rules_apple_ios_ui_test, rules_apple_ios_ui_test_suite, apple_library, **kwargs)
+    _ios_test(name, rules_apple_ios_ui_test, rules_apple_ios_ui_test_suite, apple_library, include_internal_test_deps, **kwargs)
 
-def ios_unit_snapshot_test(name, apple_library = apple_library, **kwargs):
+def ios_unit_snapshot_test(name, apple_library = apple_library, include_internal_test_deps = True, **kwargs):
     """
     Builds and packages iOS Unit Snapshot Tests.
 
@@ -179,4 +180,4 @@ def ios_unit_snapshot_test(name, apple_library = apple_library, **kwargs):
         apple_library: The macro used to package sources into a library.
         **kwargs: Arguments passed to the apple_library and ios_unit_test rules as appropriate.
     """
-    _ios_test(name, rules_apple_ios_unit_test, rules_apple_ios_unit_test_suite, apple_library, **kwargs)
+    _ios_test(name, rules_apple_ios_unit_test, rules_apple_ios_unit_test_suite, apple_library, include_internal_test_deps, **kwargs)


### PR DESCRIPTION
We introduced `internal_test_deps` in this [PR](https://github.com/bazel-ios/rules_ios/pull/682) for snapshot tests. This enable us to have more freedom to control whether we want `internal_test_deps` in our test rules