### PR TITLE
Add support for bzlmod

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,7 @@
+# Enable Bzlmod
+# TODO: While supporting Bazel 5 we need to keep experimental flag vs using "--enable_bzlmod"
+common --experimental_enable_bzlmod
+
 # We can't create a bzl_library for rules-swift because of its visibility,
 # so circumvent by not using the sandbox
 build --strategy=Stardoc=standalone

--- a/.github/workflows/preflight_env.sh
+++ b/.github/workflows/preflight_env.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# If flag --no-bzlmod is passed, writes a user.bazelrc file to disable Bzlmod.
+if [[ "$*" == *--no-bzlmod* ]]; then
+  echo "build --noexperimental_enable_bzlmod" > user.bazelrc
+fi
+
 set -e
 echo "Selecting Xcode for environment"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,11 +90,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Preflight Env
-        run: .github/workflows/preflight_env.sh
+        # Dont test Bazel 5 with bzlmod
+        run: .github/workflows/preflight_env.sh --no-bzlmod
       - name: Build and Test
         run: |
-          # iOS tests
+          # iOS tests without bzlmod on Bazel 5
           bazelisk build \
+            --noexperimental_enable_bzlmod \
             --config=ci_with_caches \
             --config=ios \
             --config=vfs \
@@ -147,7 +149,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Preflight Env
-        run: .github/workflows/preflight_env.sh
+        # TODO: stardoc doesn't currently support bzlmod: https://github.com/bazelbuild/stardoc/issues/117
+        run: .github/workflows/preflight_env.sh --no-bzlmod
         # Note: we need to pass the absolute to the Bazel run
       - name: buildifier
         run: |
@@ -166,7 +169,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Preflight Env
-        run: .github/workflows/preflight_env.sh
+        run: .github/workflows/preflight_env.sh --no-bzlmod
       - name: Run tests
         run: ./tests/xcodeproj-tests.sh --run && ./tests/test-tests.sh
       - uses: actions/upload-artifact@v2

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,13 +3,15 @@
 load("@build_bazel_rules_swift//swift/internal:feature_names.bzl", "SWIFT_FEATURE_USE_GLOBAL_INDEX_STORE")
 load("//rules:features.bzl", "feature_names")
 load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 
-sh_binary(
+buildifier(
     name = "buildifier",
-    srcs = select({
-        "@bazel_tools//src/conditions:darwin_x86_64": ["@buildifier.mac.amd64//file"],
-        "@bazel_tools//src/conditions:darwin_arm64": ["@buildifier.mac.arm64//file"],
-    }),
+    exclude_patterns = [
+        "./.git/*",
+        "./bazel-*/*",
+    ],
+    mode = "fix",
 )
 
 config_setting(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,113 @@
+"""
+Defines all the external repositories and dependencies for rules_ios.
+"""
+
+# Defines the rules_ios bzlmod module.
+# Version is updated during release to the registry.
+module(
+    name = "rules_ios",
+    version = "0",
+    bazel_compatibility = [">=5.0.0"],
+    compatibility_level = 1,
+    repo_name = "build_bazel_rules_ios",
+)
+
+# Declare the bzlmod dependencies needed by rules_ios and users of rules_ios
+bazel_dep(
+    name = "apple_support",
+    version = "1.6.0",
+    repo_name = "build_bazel_apple_support",
+)
+bazel_dep(
+    name = "rules_apple",
+    version = "2.3.0",
+    repo_name = "build_bazel_rules_apple",
+)
+bazel_dep(
+    name = "rules_cc",
+    version = "0.0.6",
+)
+bazel_dep(
+    name = "rules_python",
+    version = "0.24.0",
+)
+bazel_dep(
+    name = "rules_swift",
+    version = "1.8.0",
+    repo_name = "build_bazel_rules_swift",
+)
+
+# Declare the development dependencies needed for rules_ios development
+bazel_dep(
+    name = "buildifier_prebuilt",
+    version = "6.1.0",
+    dev_dependency = True,
+)
+bazel_dep(
+    name = "rules_pkg",
+    version = "0.9.1",
+    dev_dependency = True,
+)
+bazel_dep(
+    name = "bazel_skylib",
+    version = "1.4.1",
+    dev_dependency = True,
+)
+
+# Load non-bzlmod dependencies from rules_ios
+non_module_deps = use_extension("//rules:module_extensions.bzl", "non_module_deps")
+use_repo(
+    non_module_deps,
+    "com_github_yonaskolb_xcodegen",
+)
+
+non_module_dev_deps = use_extension(
+    "//rules:module_extensions.bzl",
+    "non_module_dev_deps",
+    dev_dependency = True,
+)
+use_repo(
+    non_module_dev_deps,
+    "GoogleMobileAdsSDK",
+    "TensorFlowLiteC",
+    "arm64-to-sim",
+    "com_github_apple_swiftcollections",
+    "tart",
+)
+
+# Configure Xcode
+xcode_configure = use_extension(
+    "//rules:module_extensions.bzl",
+    "xcode_configure",
+    dev_dependency = True,
+)
+xcode_configure.configure(
+    remote_xcode_label = "",
+    xcode_locator_label = "//tools/toolchains/xcode_configure:xcode_locator.m",
+)
+
+# Load non-bzlmod dependencies used in this repo from rules_swift
+swift_non_module_deps = use_extension("@build_bazel_rules_swift//swift:extensions.bzl", "non_module_deps")
+use_repo(
+    swift_non_module_deps,
+    "build_bazel_rules_swift_index_import",
+    "build_bazel_rules_swift_local_config",
+)
+
+# Load non-bzlmod dependencies used in this repo from rules_apple
+apple_non_module_deps = use_extension("@build_bazel_rules_apple//apple:extensions.bzl", "non_module_deps")
+use_repo(
+    apple_non_module_deps,
+    "xctestrunner",
+)
+
+# Register the Python toolchain
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+    is_default = True,
+    python_version = "3.9",
+)
+use_repo(
+    python,
+    "python_versions",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,11 +1,19 @@
+# This file marks the root of the Bazel workspace.
+# See MODULE.bazel for dependencies and setup.
+# It is only used when bzlmod is disabled.
+# When bzlmod is enabled WORKSPACE.bzlmod is used.
+
 workspace(name = "build_bazel_rules_ios")
 
 load(
     "//rules:repositories.bzl",
     "rules_ios_dependencies",
+    "rules_ios_dev_dependencies",
 )
 
 rules_ios_dependencies()
+
+rules_ios_dev_dependencies()
 
 load(
     "@build_bazel_rules_apple//apple:repositories.bzl",
@@ -55,25 +63,14 @@ load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 
 stardoc_repositories()
 
-load(
-    "@bazel_tools//tools/build_defs/repo:http.bzl",
-    "http_file",
-)
+# Download prebuilt binaries buildifier
+load("@buildifier_prebuilt//:deps.bzl", "buildifier_prebuilt_deps")
 
-# Download offical release of buildifier.mac
-http_file(
-    name = "buildifier.mac.amd64",
-    executable = True,
-    sha256 = "c9378d9f4293fc38ec54a08fbc74e7a9d28914dae6891334401e59f38f6e65dc",
-    urls = ["https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-darwin-amd64"],
-)
+buildifier_prebuilt_deps()
 
-http_file(
-    name = "buildifier.mac.arm64",
-    executable = True,
-    sha256 = "745feb5ea96cb6ff39a76b2821c57591fd70b528325562486d47b5d08900e2e4",
-    urls = ["https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-darwin-arm64"],
-)
+load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains")
+
+buildifier_prebuilt_register_toolchains()
 
 load(
     "//tests/ios/frameworks/external-dependency:external_dependency.bzl",

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,0 +1,27 @@
+# This file marks the root of the Bazel workspace.
+# See MODULE.bazel for dependencies and setup.
+# It is only used when bzlmod is enabled.
+# This file will generally be kept empty in favor of using MODULE.bazel fully.
+
+workspace(name = "build_bazel_rules_ios")
+
+# TODO: stardoc doesn't currently support bzlmod: https://github.com/bazelbuild/stardoc/issues/117
+# Once that closes we should depend on it via the WORKSPACE file.
+# In the meantime, this is a workaround to at least allow building.
+# Note however that updating docs with bzlmod will not work until the above is resolved.
+# Until then use: --noenable_bzlmod
+load(
+    "@bazel_tools//tools/build_defs/repo:git.bzl",
+    "git_repository",
+)
+
+git_repository(
+    name = "io_bazel_stardoc",
+    commit = "6f274e903009158504a9d9130d7f7d5f3e9421ed",
+    remote = "https://github.com/bazelbuild/stardoc.git",
+    shallow_since = "1667581897 -0400",
+)
+
+load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
+
+stardoc_repositories()

--- a/rules/module_extensions.bzl
+++ b/rules/module_extensions.bzl
@@ -1,0 +1,43 @@
+"""Definitions for bzlmod module extensions."""
+
+load(
+    "//rules:repositories.bzl",
+    "rules_ios_dependencies",
+    "rules_ios_dev_dependencies",
+)
+load(
+    "//tools/toolchains/xcode_configure:xcode_configure.bzl",
+    _xcode_configure = "xcode_configure",
+)
+
+def _non_module_deps_impl(_):
+    rules_ios_dependencies(
+        load_bzlmod_dependencies = False,
+    )
+
+non_module_deps = module_extension(implementation = _non_module_deps_impl)
+
+def _non_module_dev_deps_impl(_):
+    rules_ios_dev_dependencies(load_bzlmod_dependencies = False)
+
+non_module_dev_deps = module_extension(implementation = _non_module_dev_deps_impl)
+
+def _xcode_configure_impl(module_ctx):
+    for mod in module_ctx.modules:
+        for xcode_configure_attr in mod.tags.configure:
+            _xcode_configure(
+                remote_xcode_label = xcode_configure_attr.remote_xcode_label,
+                xcode_locator_label = xcode_configure_attr.xcode_locator_label,
+            )
+
+xcode_configure = module_extension(
+    implementation = _xcode_configure_impl,
+    tag_classes = {
+        "configure": tag_class(
+            attrs = {
+                "remote_xcode_label": attr.string(mandatory = True),
+                "xcode_locator_label": attr.string(mandatory = True),
+            },
+        ),
+    },
+)

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -5,7 +5,10 @@ load(
     "http_archive",
     "http_file",
 )
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+load(
+    "@bazel_tools//tools/build_defs/repo:git.bzl",
+    "new_git_repository",
+)
 
 def _maybe(repo_rule, name, **kwargs):
     """Executes the given repository rule if it hasn't been executed already.
@@ -55,16 +58,47 @@ def _get_bazel_version():
     # Unknown, but don't crash
     return struct(major = 0, minor = 0, patch = 0)
 
-def rules_ios_dependencies():
-    """Fetches repositories that are dependencies of `rules_ios`"""
-    bazel_version = _get_bazel_version()
-    if bazel_version.major == "5":
-        # Minimum commit vetted of rules_swift - not necessarily exclusive with
-        # this bazel version or rules_apple version but tested on CI as so.
+def rules_ios_dependencies(
+        load_bzlmod_dependencies = True):
+    """Fetches repositories that are public dependencies of `rules_ios`.
+
+    Args:
+        load_bzlmod_dependencies: if `True` loads dependencies that are available via bzlmod (set to True when using WORKSPACE, and False when using bzlmod)
+    """
+
+    if load_bzlmod_dependencies:
+        _rules_ios_bzlmod_dependencies()
+
+    # If legacy project generator is deprecated this can be removed.
+    _rules_ios_legacy_xcodeproj_dependencies()
+
+def rules_ios_dev_dependencies(
+        load_bzlmod_dependencies = True):
+    """
+    Fetches repositories that are development dependencies of `rules_ios`
+
+    Args:
+        load_bzlmod_dependencies: if `True` loads dependencies that are available via bzlmod (set to True when using WORKSPACE, and False when using bzlmod)
+    """
+
+    if load_bzlmod_dependencies:
+        _rules_ios_bzlmod_dev_dependencies()
+
+    _rules_ios_tool_dependencies()
+    _rules_ios_test_dependencies()
+
+def _rules_ios_bzlmod_dependencies():
+    """
+    Fetches repositories that are dependencies of `rules_ios` and available via bzlmod
+
+    These are only included when using WORKSPACE, when using bzlmod they're loaded in MODULE.bazel
+    """
+
+    if _get_bazel_version().major == "5":
         _maybe(
             github_repo,
             name = "build_bazel_rules_swift",
-            project = "bazel-ios",
+            project = "bazelbuild",
             ref = "e0272df7d98a563c07aa2e78722cd8ce62549864",
             repo = "rules_swift",
             sha256 = "006743d481c477928796ad985ba32b591f5926cd590d32b207e018049b569594",
@@ -84,32 +118,58 @@ def rules_ios_dependencies():
         )
     else:
         _maybe(
-            github_repo,
+            http_archive,
             name = "build_bazel_rules_swift",
-            project = "bazelbuild",
-            ref = "17e20f7edf27e647f1b45f11ed75d51c17820c3b",
-            repo = "rules_swift",
-            sha256 = "d50c2cb6f1c2c30cf44a8ea60469cd399f7458061169bde76a177b63d6b74330",
+            sha256 = "3a595a64afdcaf65b74b794661556318041466d727e175fa8ce20bdf1bb84ba0",
+            url = "https://github.com/bazelbuild/rules_swift/releases/download/1.10.0/rules_swift.1.10.0.tar.gz",
         )
 
         _maybe(
-            github_repo,
+            http_archive,
             name = "build_bazel_rules_apple",
-            ref = "915ac30a9fa1fd3809599a5ab90fa1c6640fe8dc",
-            project = "bazelbuild",
-            repo = "rules_apple",
-            sha256 = "0204016496a39d5c70247650e098905d129f25347c7e1f019f838ca74252ce2d",
+            sha256 = "8ac4c7997d863f3c4347ba996e831b5ec8f7af885ee8d4fe36f1c3c8f0092b2c",
+            url = "https://github.com/bazelbuild/rules_apple/releases/download/2.5.0/rules_apple.2.5.0.tar.gz",
         )
 
     _maybe(
         http_archive,
         name = "bazel_skylib",
+        sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7",
         urls = [
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
         ],
-        sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
     )
+
+def _rules_ios_bzlmod_dev_dependencies():
+    """
+    Fetches repositories that are development dependencies of `rules_ios` and available via bzlmod.
+
+    These are only included when using WORKSPACE, when using bzlmod they're loaded in MODULE.bazel
+    """
+
+    _maybe(
+        http_archive,
+        name = "rules_pkg",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz",
+            "https://github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz",
+        ],
+        sha256 = "8f9ee2dc10c1ae514ee599a8b42ed99fa262b757058f65ad3c384289ff70c4b8",
+    )
+
+    _maybe(
+        http_archive,
+        name = "buildifier_prebuilt",
+        sha256 = "e46c16180bc49487bfd0f1ffa7345364718c57334fa0b5b67cb5f27eba10f309",
+        strip_prefix = "buildifier-prebuilt-6.1.0",
+        urls = [
+            "http://github.com/keith/buildifier-prebuilt/archive/6.1.0.tar.gz",
+        ],
+    )
+
+def _rules_ios_legacy_xcodeproj_dependencies():
+    """Fetches the repositories that are dependencies of the legacy xcode project generator"""
 
     _maybe(
         http_archive,
@@ -131,6 +191,16 @@ native_binary(
         urls = ["https://github.com/segiddins/XcodeGen/releases/download/2.18.0-12-g04d6749/xcodegen.zip"],
     )
 
+def _rules_ios_tool_dependencies():
+    """Fetches the repositories that are dependencies of `rules_ios`'s development tools."""
+
+    _maybe(
+        http_file,
+        name = "tart",
+        urls = ["https://github.com/cirruslabs/tart/releases/download/0.14.0/tart"],
+        sha256 = "2c61526aa07ade30ab6534b0fdc0a0edeb56ec2084dadee587e53c46e3a8edc3",
+    )
+
     _maybe(
         new_git_repository,
         name = "arm64-to-sim",
@@ -147,19 +217,33 @@ swift_binary(
 )
         """,
     )
+
+def _rules_ios_test_dependencies():
+    """Fetches the repositories that are dependencies of `rules_ios`'s tests."""
+
     _maybe(
-        http_archive,
-        name = "rules_pkg",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz",
-            "https://github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz",
-        ],
-        sha256 = "8a298e832762eda1830597d64fe7db58178aa84cd5926d76d5b744d6558941c2",
+        github_repo,
+        name = "com_github_apple_swiftcollections",
+        build_file = "@//tests/ios/frameworks/external-dependency:BUILD.com_github_apple_swiftcollections",
+        project = "apple",
+        ref = "0.0.3",
+        repo = "swift-collections",
+        sha256 = "e6f36a1f9bb163437b4e9bc8da641a6129f16af7799eb8418c4a35749ceb1ef7",
     )
 
     _maybe(
-        http_file,
-        name = "tart",
-        urls = ["https://github.com/cirruslabs/tart/releases/download/0.14.0/tart"],
-        sha256 = "2c61526aa07ade30ab6534b0fdc0a0edeb56ec2084dadee587e53c46e3a8edc3",
+        http_archive,
+        name = "TensorFlowLiteC",
+        url = "https://dl.google.com/dl/cpdc/3895e5bf508673ae/TensorFlowLiteC-2.6.0.tar.gz",
+        sha256 = "a28ce764da496830c0a145b46e5403fb486b5b6231c72337aaa8eaf3d762cc8d",
+        build_file = "@//tests/ios/unit-test/test-imports-app:BUILD.TensorFlowLiteC",
+        strip_prefix = "TensorFlowLiteC-2.6.0",
+    )
+
+    _maybe(
+        http_archive,
+        name = "GoogleMobileAdsSDK",
+        url = "https://dl.google.com/dl/cpdc/e0dda986a9f84d14/Google-Mobile-Ads-SDK-8.10.0.tar.gz",
+        sha256 = "0726df5d92165912c9e60a79504a159ad9b7231dda851abede8f8792b266dba5",
+        build_file = "@//tests/ios/unit-test/test-imports-app:BUILD.GoogleMobileAds",
     )


### PR DESCRIPTION
Adds initial support for bzlmod to rules_ios.

Major changes:

- Update versions in `repositories.bzl` to use minimum supported bzlmod version
- Add `MODULE.bazel` and required files to enable bzlmod by default in Bazel 6+
- Enable bzlmod by default in the repository

Required workarounds:

- Disable bzlmod when running legacy .xcodeproj tests. This rule collects workspace name in an aspect which now resolves to simply `_main` in bzlmod. This doesnt seem to cause any actual issues with the generated project besides the repository being named `_main`. Proper fix is to have this use runfiles but I do not have enough context to make that change. 

Things to follow-up on:

- Add bzlmod support for stardoc
  - This requires some more changes to bzl_library usage and update to Stardoc version, will do this in a separate PR before publishing.
- Publish to Bazel Central Registry (and introduce files to required to do so)
- Finalize documentation and update README (after publication)
- Consider better support for legacy xcode project generator, the tests will continue to run without bzlmod as the aspect requires workspace name collection udpates.

Depends on: #716, #719 