### PR TITLE
Remove bad INFOPLIST_FILE in fixtures

### DIFF
--- a/rules/legacy_xcodeproj.bzl
+++ b/rules/legacy_xcodeproj.bzl
@@ -879,7 +879,7 @@ def _populate_xcodeproj_targets_and_schemes(ctx, targets, src_dot_dots, all_tran
 
         target_settings["BAZEL_LLDB_INIT_FILE"] = lldbinit_file
 
-        if product_type == "application" or product_type == "app-extension":
+        if product_type == "application" or product_type == "app-extension" or product_type == "framework.static":
             # Prevent XcodeGen from inferring a plist path on its own from target source files.
             # See PRs #593 and #601 for more context.
             target_settings["INFOPLIST_FILE"] = ""

--- a/rules/legacy_xcodeproj.bzl
+++ b/rules/legacy_xcodeproj.bzl
@@ -883,7 +883,8 @@ def _populate_xcodeproj_targets_and_schemes(ctx, targets, src_dot_dots, all_tran
             # Prevent XcodeGen from inferring a plist path on its own from target source files.
             # See PRs #593 and #601 for more context.
             target_settings["INFOPLIST_FILE"] = ""
-            target_settings["PRODUCT_BUNDLE_IDENTIFIER"] = target_info.bundle_id
+            if product_type != "framework.static":
+                target_settings["PRODUCT_BUNDLE_IDENTIFIER"] = target_info.bundle_id
 
         if product_type == "bundle.unit-test":
             target_settings["SUPPORTS_MACCATALYST"] = False

--- a/tests/ios/xcodeproj/Test-Mixed-Dynamic-App-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-Mixed-Dynamic-App-Project.xcodeproj/project.pbxproj
@@ -359,7 +359,6 @@
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/dynamic/c/c\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/dynamic/b/b_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
-				INFOPLIST_FILE = ../../../tests/ios/frameworks/dynamic/b/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACH_O_TYPE = "$(inherited)";
 				ONLY_ACTIVE_ARCH = YES;
@@ -445,7 +444,6 @@
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/dynamic/b/b\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/dynamic/c/c\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/dynamic/a/a_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
-				INFOPLIST_FILE = ../../../tests/ios/frameworks/dynamic/a/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACH_O_TYPE = "$(inherited)";
 				ONLY_ACTIVE_ARCH = YES;
@@ -493,7 +491,6 @@
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/dynamic/b/b\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/dynamic/c/c\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/dynamic/a/a_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
-				INFOPLIST_FILE = ../../../tests/ios/frameworks/dynamic/a/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACH_O_TYPE = "$(inherited)";
 				ONLY_ACTIVE_ARCH = YES;
@@ -552,7 +549,6 @@
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/dynamic/c/c\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/dynamic/b/b_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
-				INFOPLIST_FILE = ../../../tests/ios/frameworks/dynamic/b/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACH_O_TYPE = "$(inherited)";
 				ONLY_ACTIVE_ARCH = YES;

--- a/tests/ios/xcodeproj/fixtures/test_custom_output_path_expected_diff.txt
+++ b/tests/ios/xcodeproj/fixtures/test_custom_output_path_expected_diff.txt
@@ -7,7 +7,7 @@ diff -r ./tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/project.pbxproj .
 < 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 ---
 > 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../../..;
-212c212
+271c271
 < 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 ---
 > 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../../..;

--- a/tests/ios/xcodeproj/fixtures/test_custom_output_path_expected_diff.txt
+++ b/tests/ios/xcodeproj/fixtures/test_custom_output_path_expected_diff.txt
@@ -3,11 +3,11 @@ diff -r ./tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/project.pbxproj .
 < 			path = ../../..;
 ---
 > 			path = ../../../..;
-211c211
+213c213
 < 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 ---
 > 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../../..;
-269c269
+273c273
 < 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 ---
 > 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../../..;

--- a/tests/ios/xcodeproj/fixtures/test_custom_output_path_expected_diff.txt
+++ b/tests/ios/xcodeproj/fixtures/test_custom_output_path_expected_diff.txt
@@ -3,11 +3,11 @@ diff -r ./tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/project.pbxproj .
 < 			path = ../../..;
 ---
 > 			path = ../../../..;
-213c213
+212c212
 < 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 ---
 > 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../../..;
-273c273
+212c212
 < 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../..;
 ---
 > 				BAZEL_WORKSPACE_ROOT = $SRCROOT/../../../..;


### PR DESCRIPTION
The original value of `INFOPLIST_FILE` for these targets was `""`, I changed that [here](https://github.com/bazel-ios/rules_ios/pull/661/commits/3d6eb5642cb6cac9e5a7065be285715c396151c6) but I don't remember if that was a requirement for indexing work (I highly doubt) or what unblocked me at the time (looking back should've root cause first if that was the case).

So reverting this for now as it's blocking folks that want to update the Xcode fixtures (it's present on CI but can't be added automatically locally).

ps: note that `tests/ios/xcodeproj/fixtures/test_custom_output_path_expected_diff.txt` was also updated in the PR linked above, so I'm taking the new diff generated here as the new default.