### PR TITLE
[Retry] Fix transitive framework import in opt build

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -24,7 +24,7 @@ load("@build_bazel_rules_apple//apple/internal:rule_support.bzl", "rule_support"
 load("@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl", "AppleMacToolsToolchainInfo", "AppleXPlatToolsToolchainInfo")
 load("@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl", "clang_rt_dylibs")
 load("@build_bazel_rules_apple//apple:providers.bzl", "AppleBundleInfo", "IosFrameworkBundleInfo")
-load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo", "swift_common")
+load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo", "swift_clang_module_aspect", "swift_common")
 load(
     "@build_bazel_rules_apple//apple/internal/aspects:resource_aspect.bzl",
     "apple_resource_aspect",
@@ -1118,6 +1118,7 @@ The default behavior bakes this into the top level app. When false, it's statica
 """,
         ),
         "transitive_deps": attr.label_list(
+            aspects = [swift_clang_module_aspect],
             mandatory = True,
             cfg = apple_common.multi_arch_split,
             doc =

--- a/rules/import_middleman.bzl
+++ b/rules/import_middleman.bzl
@@ -264,15 +264,9 @@ def _file_collector_rule_impl(ctx):
     )
 
     additional_providers = []
-    if not virtualize_frameworks:
-        dep_cc_infos = [dep[CcInfo] for dep in ctx.attr.deps if CcInfo in dep]
-        cc_info = cc_common.merge_cc_infos(direct_cc_infos = [], cc_infos = dep_cc_infos)
-        additional_providers.append(cc_info)
-    else:
-        cc_info = objc_provider_utils.merge_cc_info_providers(
-            cc_info_providers = [dep[CcInfo] for dep in ctx.attr.deps if CcInfo in dep],
-        )
-        additional_providers.append(cc_info)
+    dep_cc_infos = [dep[CcInfo] for dep in ctx.attr.deps if CcInfo in dep]
+    cc_info = cc_common.merge_cc_infos(direct_cc_infos = [], cc_infos = dep_cc_infos)
+    additional_providers.append(cc_info)
 
     return [
         DefaultInfo(files = depset(dynamic_framework_dirs + replaced_frameworks)),

--- a/rules/internal/objc_provider_utils.bzl
+++ b/rules/internal/objc_provider_utils.bzl
@@ -1,4 +1,4 @@
- def _add_to_dict_if_present(dict, key, value):
+def _add_to_dict_if_present(dict, key, value):
     if value:
         dict[key] = value
 

--- a/rules/internal/objc_provider_utils.bzl
+++ b/rules/internal/objc_provider_utils.bzl
@@ -1,4 +1,4 @@
-def _add_to_dict_if_present(dict, key, value):
+ def _add_to_dict_if_present(dict, key, value):
     if value:
         dict[key] = value
 
@@ -55,29 +55,9 @@ def _merge_dynamic_framework_providers(dynamic_framework_providers):
 
     return apple_common.new_dynamic_framework_provider(**fields)
 
-def _merge_cc_info_providers(cc_info_providers, merge_keys = [
-    "headers",
-    "includes",
-    "defines",
-]):
-    fields = {}
-    for key in merge_keys:
-        set = depset(
-            direct = [],
-            # Note:  we may want to merge this with the below inputs?
-            transitive = [getattr(dep.compilation_context, key) for dep in cc_info_providers],
-        )
-        _add_to_dict_if_present(fields, key, set)
-
-    # We don't use this on Bazel 4-5 for now
-    linking_context = cc_common.create_linking_context(linker_inputs = depset())
-    compilation_context = cc_common.create_compilation_context(**fields)
-    return CcInfo(compilation_context = compilation_context, linking_context = linking_context)
-
 objc_provider_utils = struct(
     merge_objc_providers_dict = _merge_objc_providers_dict,
     merge_objc_providers = _merge_objc_providers,
-    merge_cc_info_providers = _merge_cc_info_providers,
     merge_dynamic_framework_providers = _merge_dynamic_framework_providers,
     add_to_dict_if_present = _add_to_dict_if_present,
 )


### PR DESCRIPTION
**Retry merging PR #570, which solves issue #569.** The original PR got reverted because of issue #712.

### Original description
`apple_*_(xc)framework_import` provides `_SwiftInteropInfo` instead of `SwiftInfo`. In `apple_framework_packaging`, when [we merge the SwiftInfo](https://github.com/bazel-ios/rules_ios/blob/b1499fc08a7e4b7a7ba238fb4c9b089e6648ecbd/rules/framework.bzl#L901), the info from the framework import get lost there.

To fix the problem, we can add `swift_clang_module_aspect` to the `transitive_deps` attribute of `apple_framework_packaging`, which converts `_SwiftInteropInfo` to `SwiftInfo`. `swift_library` does this for `deps` as well.

@mattrobmattrob @thiagohmcruz 
