### PR TITLE
Add remote cache and CI configs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -54,9 +54,23 @@ build:ios_multi_arch_test --ios_minimum_os=10.2
 build:ios_multi_arch_test --ios_multi_cpus=i386,x86_64
 
 # - Remote cache configuration
+build:remote_cache --bes_backend=grpcs://remote.buildbuddy.io
+build:remote_cache --bes_results_url=https://app.buildbuddy.io/invocation/
+build:remote_cache --experimental_build_event_upload_strategy=local
+build:remote_cache --experimental_remote_cache_compression
+build:remote_cache --experimental_remote_merkle_tree_cache
+build:remote_cache --modify_execution_info=^(BitcodeSymbolsCopy|BundleApp|BundleTreeApp|DsymDwarf|DsymLipo|GenerateAppleSymbolsFile|ObjcBinarySymbolStrip|CppLink|ObjcLink|ProcessAndSign|SignBinary|SwiftArchive|SwiftStdlibCopy)$=+no-remote,^(BundleResources|ImportedDynamicFrameworkProcessor)$=+no-remote-exec
+build:remote_cache --nolegacy_important_outputs
+build:remote_cache --noslim_profile
 build:remote_cache --remote_cache=grpcs://remote.buildbuddy.io
 build:remote_cache --remote_timeout=3600
-build:remote_cache --modify_execution_info=^(BitcodeSymbolsCopy|BundleApp|BundleTreeApp|DsymDwarf|DsymLipo|GenerateAppleSymbolsFile|ObjcBinarySymbolStrip|CppLink|ObjcLink|ProcessAndSign|SignBinary|SwiftArchive|SwiftStdlibCopy)$=+no-remote,^(BundleResources|ImportedDynamicFrameworkProcessor)$=+no-remote-exec
+
+# Enable remote_cache config by default
+build --config=remote_cache
+
+# By default don't upload local results to remote cache, only CI does this.
+build --noremote_upload_local_results
+build:ci --remote_upload_local_results
 
 # - CI Configuration
 # disable curses control since CI logs are not interactive

--- a/.bazelrc
+++ b/.bazelrc
@@ -2,9 +2,11 @@
 # so circumvent by not using the sandbox
 build --strategy=Stardoc=standalone
 
-# Debugging does not work in sandbox mode. Uncomment these lines to turn off sandboxing.
-# build --genrule_strategy=standalone
-# build --spawn_strategy=standalone
+# Spawn strategy required for some tests
+build --spawn_strategy=standalone
+
+# Setup Xcode configuration for xcodeproj tests
+build --xcode_version_config=//:host_xcodes
 
 build --verbose_failures # Print the full command line for commands that failed
 build --test_output=errors # Prints log file output to the console on failure
@@ -28,14 +30,50 @@ build --test_env=PATH=/usr/bin:/bin:/usr/sbin:/sbin
 # Bazel 5 - matches ios_sim_arm64 CPU, Bazel 4 - needs "override" flags
 build --features apple.arm64_simulator_use_device_deps
 
-# Note - tree artifacts needs to be on
-build:lldb_ios_test --spawn_strategy=standalone --apple_platform_type=ios --define=apple.experimental.tree_artifact_outputs=1
-
 # Delete the VM test suite for github
 build --deleted_packages tests/ios/vmd
 
 # Allow for server to start (GitHub actions can timeout)
 startup --local_startup_timeout_secs=240
+
+# - iOS Configuration
+# Required for tests/ios/... targets
+build:ios --apple_platform_type=ios
+
+# - VFS configuration
+# Required for some tests in tests/ios/... targets
+build:vfs --features=apple.virtualize_frameworks
+
+# - iOS lldb test configuration
+build:ios_lldb_test --config=ios
+build:ios_lldb_test --define=apple.experimental.tree_artifact_outputs=1
+
+# - iOS multi arch test configuration
+build:ios_multi_arch_test --config=ios
+build:ios_multi_arch_test --ios_minimum_os=10.2
+build:ios_multi_arch_test --ios_multi_cpus=i386,x86_64
+
+# - Remote cache configuration
+build:cache --remote_cache=grpcs://remote.buildbuddy.io
+build:cache --remote_timeout=3600
+build:cache --modify_execution_info=^(BitcodeSymbolsCopy|BundleApp|BundleTreeApp|DsymDwarf|DsymLipo|GenerateAppleSymbolsFile|ObjcBinarySymbolStrip|CppLink|ObjcLink|ProcessAndSign|SignBinary|SwiftArchive|SwiftStdlibCopy)$=+no-remote,^(BundleResources|ImportedDynamicFrameworkProcessor)$=+no-remote-exec
+
+# - CI Configuration
+# disable curses control since CI logs are not interactive
+common:ci --curses=no
+# turn off loading message updates
+common:ci --noshow_loading_progress
+# throttle progress updates in CI as they can clutter the logs
+common:ci --show_progress_rate_limit=15.0
+build:ci --progress_report_interval=60
+# enable more verbose logging
+build:ci --verbose_failures
+build:ci --subcommands
+# ci setup for tests, tend to be more flaky on github actions
+build:ci --jobs=4
+test:ci --test_timeout=600
+test:ci --flaky_test_attempts=//tests/ios/...@3
+test:ci --local_test_jobs=1
 
 # Load a user.bazelrc
 try-import %workspace%/user.bazelrc

--- a/.bazelrc
+++ b/.bazelrc
@@ -54,9 +54,9 @@ build:ios_multi_arch_test --ios_minimum_os=10.2
 build:ios_multi_arch_test --ios_multi_cpus=i386,x86_64
 
 # - Remote cache configuration
-build:cache --remote_cache=grpcs://remote.buildbuddy.io
-build:cache --remote_timeout=3600
-build:cache --modify_execution_info=^(BitcodeSymbolsCopy|BundleApp|BundleTreeApp|DsymDwarf|DsymLipo|GenerateAppleSymbolsFile|ObjcBinarySymbolStrip|CppLink|ObjcLink|ProcessAndSign|SignBinary|SwiftArchive|SwiftStdlibCopy)$=+no-remote,^(BundleResources|ImportedDynamicFrameworkProcessor)$=+no-remote-exec
+build:remote_cache --remote_cache=grpcs://remote.buildbuddy.io
+build:remote_cache --remote_timeout=3600
+build:remote_cache --modify_execution_info=^(BitcodeSymbolsCopy|BundleApp|BundleTreeApp|DsymDwarf|DsymLipo|GenerateAppleSymbolsFile|ObjcBinarySymbolStrip|CppLink|ObjcLink|ProcessAndSign|SignBinary|SwiftArchive|SwiftStdlibCopy)$=+no-remote,^(BundleResources|ImportedDynamicFrameworkProcessor)$=+no-remote-exec
 
 # - CI Configuration
 # disable curses control since CI logs are not interactive

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,12 @@ jobs:
         run: .github/workflows/xcode_select.sh
       - name: Build and Test
         run: |
-          # Host config
-          bazelisk test --local_test_jobs=1 -- //... -//tests/ios/...
+          # non-iOS tests
+          bazelisk test \
+            --config=ci \
+            -- \
+            //... \
+            -//tests/ios/...
 
           # Clean up after simctl (https://github.com/bazelbuild/rules_apple/issues/185)
           pgrep Simulator | xargs kill || true
@@ -30,16 +34,20 @@ jobs:
           # Create single ephemeral iOS sim
           SIMULATOR_UDID=$(./tools/tests/prepare_sim.py)
 
+          # iOS tests
           bazelisk test \
-            --local_test_jobs=1 \
-            --apple_platform_type=ios \
+            --config=ci \
+            --config=ios \
             --test_arg=--destination=platform=ios_simulator,id=$SIMULATOR_UDID \
-            -- //tests/ios/...
+            -- \
+            //tests/ios/...
+
       - uses: actions/upload-artifact@v2
         if: failure()
         with:
           name: bazel-testlogs
           path: bazel-testlogs
+
   build_virtual_frameworks:
     # Build the entire tree with this feature enabled. Longer term, we'll likely
     # consider merging this feature into the default behavior and can re-align
@@ -52,13 +60,21 @@ jobs:
         run: .github/workflows/xcode_select.sh
       - name: Build and Test
         run: |
-          # Host config
-          bazelisk build --features apple.virtualize_frameworks --local_test_jobs=1 -- //... -//tests/ios/...
+          # non-iOS tests
+          bazelisk test \
+            --config=ci \
+            --config=vfs \
+            -- \
+            //... \
+            -//tests/ios/...
 
-          bazelisk build --features apple.virtualize_frameworks \
-              --local_test_jobs=1 \
-              --apple_platform_type=ios \
-              -- //tests/ios/...
+          # iOS tests
+          bazelisk test \
+            --config=ci \
+            --config=ios \
+            --config=vfs \
+            -- \
+            //tests/ios/...
 
       - uses: actions/upload-artifact@v2
         if: failure()
@@ -69,16 +85,22 @@ jobs:
   lts_ios_integration_tests:
     name: Build and Test ( Virtual Frameworks + LTS )
     runs-on: macos-12
+    env:
+      USE_BAZEL_VERSION: 5.3.2
     steps:
       - uses: actions/checkout@v3
       - name: Select Xcode
         run: .github/workflows/xcode_select.sh
       - name: Build and Test
         run: |
-          export USE_BAZEL_VERSION=5.3.2
-          bazelisk build --features apple.virtualize_frameworks \
-              --config=ios \
-              -- //tests/ios/...
+          # iOS tests
+          bazelisk build \
+            --config=ci \
+            --config=ios \
+            --config=vfs \
+            -- \
+            //tests/ios/...
+
       - uses: actions/upload-artifact@v2
         if: failure()
         with:
@@ -95,17 +117,23 @@ jobs:
       - name: Build and Test
         run: |
           bazelisk build \
+            --config=ci \
+            --config=vfs \
             --ios_multi_cpus=sim_arm64  \
-            --features apple.virtualize_frameworks \
-            -- //... -//tests/ios/...
+            -- \
+            //... \
+            -//tests/ios/...
 
           # Misc issues:
           #   - Fails on a non fat framework for //tests/ios/unit-test/test-imports-app/
           bazelisk build \
+            --config=ci \
+            --config=ios \
+            --config=vfs \
             --ios_multi_cpus=sim_arm64 \
-            --features apple.virtualize_frameworks \
-            --apple_platform_type=ios \
-            -- //tests/ios/... -//tests/ios/unit-test/test-imports-app/...
+            -- \
+            //tests/ios/... \
+            -//tests/ios/unit-test/test-imports-app/...
 
       - uses: actions/upload-artifact@v2
         if: failure()
@@ -113,7 +141,7 @@ jobs:
           name: bazel-testlogs
           path: bazel-testlogs
 
-  buildifier:
+  lint:
     name: Check Starlark and Docs
     runs-on: macos-12
     steps:
@@ -122,9 +150,16 @@ jobs:
         run: .github/workflows/xcode_select.sh
         # Note: we need to pass the absolute to the Bazel run
       - name: buildifier
-        run: find $PWD -type f \( -name 'WORKSPACE' -o -name '*.bzl' -o -name '*.bazel' \) | xargs bazel run buildifier -- -lint=fix && git diff --exit-code
+        run: |
+          find $PWD -type f \( -name 'WORKSPACE' -o -name '*.bzl' -o -name '*.bazel' \) | xargs bazel run //:buildifier -- -lint=fix
+          git diff --exit-code
       - name: Check docs
-        run: bazelisk run docs && git diff --exit-code docs
+        run: |
+          bazelisk run \
+            --config=ci \
+            //docs
+          git diff --exit-code docs
+
   xcodeproj_tests:
     name: .xcodeproj Tests on Xcode 14.2.0
     runs-on: macos-12
@@ -148,12 +183,19 @@ jobs:
       - name: Select Xcode 14.2.0
         run: .github/workflows/xcode_select.sh
       - name: Run tests
-        run: bazelisk test tests/ios/lldb/app:objc_app_po_test  tests/ios/lldb/app:objc_app_variable_test --config lldb_ios_test
+        run: |
+          bazelisk test \
+            --config=ci \
+            --config=ios_lldb_test \
+            tests/ios/lldb/app:objc_app_po_test \
+            tests/ios/lldb/app:objc_app_variable_test
+
       - uses: actions/upload-artifact@v2
         if: failure()
         with:
           name: bazel-testlogs
           path: bazel-testlogs
+
   multi_arch_support:
     name: Build iOS App for Multiple Architecture
     runs-on: macos-12
@@ -162,4 +204,8 @@ jobs:
       - name: Select Xcode
         run: .github/workflows/xcode_select.sh
       - name: Build App
-        run: bazelisk build -s tests/ios/app/App --apple_platform_type=ios --ios_minimum_os=10.2  --ios_multi_cpus=i386,x86_64
+        run: |
+          bazelisk build \
+            --config=ci \
+            --config=ios_multi_arch_test \
+            tests/ios/app/App

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Select Xcode
         run: .github/workflows/xcode_select.sh
-      - name: Build and Test
+      - name: Build
         run: |
           # iOS tests
           bazelisk build \
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Select Xcode
         run: .github/workflows/xcode_select.sh
-      - name: Build and Test
+      - name: Build
         run: |
           bazelisk build \
             --config=ci \
@@ -187,6 +187,7 @@ jobs:
           bazelisk test \
             --config=ci \
             --config=ios_lldb_test \
+            -- \
             tests/ios/lldb/app:objc_app_po_test \
             tests/ios/lldb/app:objc_app_variable_test
 
@@ -208,4 +209,5 @@ jobs:
           bazelisk build \
             --config=ci \
             --config=ios_multi_arch_test \
+            -- \
             tests/ios/app/App

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Select Xcode
         run: .github/workflows/xcode_select.sh
-      - name: Build
+      - name: Build and Test
         run: |
           # iOS tests
           bazelisk build \
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Select Xcode
         run: .github/workflows/xcode_select.sh
-      - name: Build
+      - name: Build and Test
         run: |
           bazelisk build \
             --config=ci \

--- a/.github/workflows/xcode_select.sh
+++ b/.github/workflows/xcode_select.sh
@@ -6,20 +6,3 @@ printenv
 
 sudo xcode-select -p
 sudo xcode-select -s /Applications/Xcode_14.2.app
-
-echo "Generating bazelrc"
-
-# Setup for github actions - these are very flaky
-echo "test --test_timeout=600 --flaky_test_attempts=//tests/ios/...@3" > user.bazelrc
-echo "test --local_test_jobs=1" >> user.bazelrc
-
-echo "build --jobs=4" >> user.bazelrc
-echo "build --spawn_strategy=standalone" >> user.bazelrc
-echo "build --xcode_version_config=//:host_xcodes" >> user.bazelrc
-
-echo "build:ios --apple_platform_type=ios" >> user.bazelrc
-
-# Remote cache
-echo "build --remote_cache=grpcs://remote.buildbuddy.io" >> user.bazelrc
-echo "build --remote_timeout=3600" >> user.bazelrc
-echo "build --modify_execution_info=^(BitcodeSymbolsCopy|BundleApp|BundleTreeApp|DsymDwarf|DsymLipo|GenerateAppleSymbolsFile|ObjcBinarySymbolStrip|CppLink|ObjcLink|ProcessAndSign|SignBinary|SwiftArchive|SwiftStdlibCopy)$=+no-remote,^(BundleResources|ImportedDynamicFrameworkProcessor)$=+no-remote-exec" >> user.bazelrc


### PR DESCRIPTION
Before this change the CI and cache configs were being generated by `.github/workflows/xcode_select.sh` which makes it difficult for a contributor to find these and to then apply them.

Changes:
 - New Bazel configurations that make it easier to reproduce CI setup and debug issues locally.
 - New configs for testing specific tests that were previously only in the workflow file.
 - Removes the `user.bazelrc` generation CI was doing in favor of the new `ci` and `cache` configs.
 - Updates the workflows to use the new configs where needed.

Depends on #716 