### PR TITLE
support .inc file for func `_private_headers`

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -41,7 +41,7 @@ def _private_headers_impl(ctx):
 _private_headers = rule(
     implementation = _private_headers_impl,
     attrs = {
-        "headers": attr.label_list(mandatory = True, allow_files = [".h", ".hh", ".hpp"]),
+        "headers": attr.label_list(mandatory = True, allow_files = [".inc", ".h", ".hh", ".hpp"]),
     },
 )
 


### PR DESCRIPTION
apple_library has has supported include files with the suffix `.inc`. 
But this type of file is not allowed when creating a `PrivateHeadersInfo` provider