### PR TITLE
Update rules_apple to 2.3.0 + remove bitcode support

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -721,16 +721,6 @@ def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps):
         ),
     )
     processor_partials.append(
-        partials.bitcode_symbols_partial(
-            actions = actions,
-            binary_artifact = binary_artifact,
-            bitcode_symbol_maps = debug_outputs.bitcode_symbol_maps,
-            dependency_targets = dep_frameworks,
-            label_name = label.name,
-            platform_prerequisites = platform_prerequisites,
-        ),
-    )
-    processor_partials.append(
         partials.codesigning_dossier_partial(
             actions = actions,
             apple_mac_toolchain_info = apple_mac_toolchain_info,

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -91,10 +91,10 @@ def rules_ios_dependencies(
         _maybe(
             github_repo,
             name = "build_bazel_rules_apple",
-            ref = "935d5ad80300578f35833db26f124f20aeda9cba",
+            ref = "915ac30a9fa1fd3809599a5ab90fa1c6640fe8dc",
             project = "bazelbuild",
             repo = "rules_apple",
-            sha256 = "46186d7ceb726aedce566458b4a3e389fa2b20ce5a714180c74c875fc1a945fb",
+            sha256 = "0204016496a39d5c70247650e098905d129f25347c7e1f019f838ca74252ce2d",
         )
 
     _maybe(


### PR DESCRIPTION
Update `rules_apple` to https://github.com/bazelbuild/rules_apple/releases/tag/2.3.0 (https://github.com/bazelbuild/rules_apple/commit/915ac30a9fa1fd3809599a5ab90fa1c6640fe8dc) and handle https://github.com/bazelbuild/rules_apple/pull/1534.