### PR TITLE
Fix xcconfig passthrough for `ios_application`

### DIFF
--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -82,6 +82,8 @@ def ios_application(
         namespace_is_module_name = False,
         platforms = {"ios": application_kwargs.get("minimum_os_version")},
         testonly = testonly,
+        xcconfig = xcconfig,
+        xcconfig_by_build_setting = xcconfig_by_build_setting,
         **kwargs
     )
 


### PR DESCRIPTION
Fix issue where `xcconfig` and `xcconfig_by_build_setting ` values for non-plist settings (e.g., Swift compiler flags) were not applied for `ios_application`.

I found this because we had `SWIFT_TREAT_WARNINGS_AS_ERRORS` set but didn't see `-warnings-as-errors` set on the swiftc invocation.