### PR TITLE
Make symbol_graph optional

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -534,23 +534,37 @@ def _copy_swiftmodule(ctx, framework_files):
 
     # need to include the swiftmodule here, even though it will be found through the framework search path,
     # since swift_library needs to know that the swiftdoc is an input to the compile action
-    swift_module = swift_common.create_swift_module(
-        swiftdoc = outputs.swiftdoc,
-        swiftmodule = outputs.swiftmodule,
-        swiftinterface = outputs.swiftinterface,
-        symbol_graph = outputs.symbol_graph,
-    )
+    if outputs.symbol_graph:
+        swift_module = swift_common.create_swift_module(
+            swiftdoc = outputs.swiftdoc,
+            swiftmodule = outputs.swiftmodule,
+            swiftinterface = outputs.swiftinterface,
+            symbol_graph = outputs.symbol_graph,
+        )
+    else:
+        swift_module = swift_common.create_swift_module(
+            swiftdoc = outputs.swiftdoc,
+            swiftmodule = outputs.swiftmodule,
+            swiftinterface = outputs.swiftinterface,
+        )
 
     if swiftmodule_name != ctx.attr.framework_name:
         # Swift won't find swiftmodule files inside of frameworks whose name doesn't match the
         # module name. It's annoying (since clang finds them just fine), but we have no choice but to point to the
         # original swift module/doc, so that swift can find it.
-        swift_module = swift_common.create_swift_module(
-            swiftdoc = inputs.swiftdoc,
-            swiftmodule = inputs.swiftmodule,
-            swiftinterface = inputs.swiftinterface,
-            symbol_graph = inputs.symbol_graph,
-        )
+        if inputs.symbol_graph:
+            swift_module = swift_common.create_swift_module(
+                swiftdoc = inputs.swiftdoc,
+                swiftmodule = inputs.swiftmodule,
+                swiftinterface = inputs.swiftinterface,
+                symbol_graph = inputs.symbol_graph,
+            )
+        else:
+            swift_module = swift_common.create_swift_module(
+                swiftdoc = inputs.swiftdoc,
+                swiftmodule = inputs.swiftmodule,
+                swiftinterface = inputs.swiftinterface,
+            )
 
     return [
         # only add the swift module, the objc modulemap is already listed as a header,


### PR DESCRIPTION
For those on old `rules_swift` SHAs `symbol_graph` does not exist. This PR makes it "optional" to trigger the behaviour introduced in https://github.com/bazel-ios/rules_ios/pull/734.