### PR TITLE
Introduce wrapped_bazelisk in tests and add docs for updating Xcode fixtures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,23 @@ If you are a maintainer of the repository and would like to tag a new release, f
 - Type in a version number, follow SemVer whenever possible.
 - After a few minutes the release should show up in the [Releases](https://github.com/bazel-ios/rules_ios/releases) page.
 
+## Updating Xcode fixtures
+
+Check the output of `find . -name '*.xcodeproj'` and note that there are many `.xcodeproj` fixtures used to ensure we catch regressions as changes that affect the Xcode project generator are made. If you made such changes and want to update the fixtures before opening a PR run:
+```sh
+./tests/xcodeproj-tests.sh --update
+```
+
+**IMPORTANT**: If you're on Intel the command above should generally "just work" but if you're on Apple Silicon you have to ensure your `bazelisk` installation is a `FAT` file so the script can select the `x86_64` architecture and generate the correct fixtures. In other words the command
+```sh
+lipo -info $(which bazelisk)
+```
+should return something like this
+```sh
+Architectures in the fat file: path/to/bazelisk are: x86_64 arm64
+```
+otherwise you won't be able to update fixtures locally.
+
 ## Bazel 6 & LTS Support
 
 ### 5.x.x LTS Support on HEAD

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -4,3 +4,5 @@ load("//rules:plists_test.bzl", "plists_test_suite")
 xcconfig_test_suite(name = "xcconfig_test")
 
 plists_test_suite(name = "plists_test")
+
+exports_files(["wrapped_bazelisk.sh"])

--- a/tests/ios/xcodeproj/BUILD.bazel
+++ b/tests/ios/xcodeproj/BUILD.bazel
@@ -127,8 +127,9 @@ cat <<'EOS' > $@
 #!/bin/sh
 set -euxo pipefail
 rm -fr {package_name}/{target_name}.xcodeproj
-bazelisk run {package_name}:{target_name}
-bazelisk run {package_name}:{target_name}
+source tests/wrapped_bazelisk.sh
+wrapped_bazelisk run {package_name}:{target_name}
+wrapped_bazelisk run {package_name}:{target_name}
 EOS
     """.format(
         package_name = package_name(),
@@ -147,8 +148,9 @@ cat <<'EOS' > $@
 #!/bin/sh
 set -euxo pipefail
 rm -fr {package_name}/{target_name}.xcodeproj
-bazelisk run {package_name}:{target_name}
-bazelisk run {package_name}:{target_name}
+source tests/wrapped_bazelisk.sh
+wrapped_bazelisk run {package_name}:{target_name}
+wrapped_bazelisk run {package_name}:{target_name}
 EOS
     """.format(
         package_name = package_name(),

--- a/tests/ios/xcodeproj/tests.sh
+++ b/tests/ios/xcodeproj/tests.sh
@@ -2,10 +2,6 @@ set -eux
 
 cd $(dirname $0)
 
-if [[ "$(arch)" == "arm"* ]]; then
-    echo -e "warning: rerun where Bazel is an x64_64 bazel:\narch -arch x86_64 /bin/bash -l -c \"$0 ${@}\""
-fi
-
 xcrun simctl list devices \
 | grep -q rules_ios:iPhone-14 || \
         xcrun simctl create "rules_ios:iPhone-14" \

--- a/tests/macos/xcodeproj/BUILD.bazel
+++ b/tests/macos/xcodeproj/BUILD.bazel
@@ -104,8 +104,9 @@ cat <<'EOS' > $@
 #!/bin/sh
 set -euxo pipefail
 rm -fr {package_name}/{target_name}.xcodeproj
-bazelisk run {package_name}:{target_name}
-bazelisk run {package_name}:{target_name}
+source tests/wrapped_bazelisk.sh
+wrapped_bazelisk run {package_name}:{target_name}
+wrapped_bazelisk run {package_name}:{target_name}
 EOS
     """.format(
         package_name = package_name(),

--- a/tests/macos/xcodeproj/tests.sh
+++ b/tests/macos/xcodeproj/tests.sh
@@ -2,10 +2,6 @@ set -eux
 
 cd $(dirname $0)
 
-if [[ "$(arch)" == "arm"* ]]; then
-    echo -e "warning: rerun where Bazel is an x64_64 bazel:\narch -arch x86_64 /bin/bash -l -c \"$0 ${@}\""
-fi
-
 xcrun simctl list devices \
 | grep -q rules_ios:iPhone-14 || \
         xcrun simctl create "rules_ios:iPhone-14" \

--- a/tests/test-tests.sh
+++ b/tests/test-tests.sh
@@ -2,14 +2,16 @@
 # This is a helper program for the testing system  - not something you'd run directly
 set -euo pipefail
 
+source tests/wrapped_bazelisk.sh
+
 ## split tests
-test_suite_count=$(bazelisk query 'kind("test_suite", //tests/ios/unit-test:SplitTests)' | wc -l | xargs)
+test_suite_count=$(wrapped_bazelisk query 'kind("test_suite", //tests/ios/unit-test:SplitTests)' | wc -l | xargs)
 if [[ "$test_suite_count" != "1" ]]; then
   echo "Expected 1 test suite for split tests got $test_suite_count"
   exit 1
 fi
 
-tests_count=$(bazelisk query 'tests(kind("test_suite", //tests/ios/unit-test:SplitTests))' | wc -l | xargs)
+tests_count=$(wrapped_bazelisk query 'tests(kind("test_suite", //tests/ios/unit-test:SplitTests))' | wc -l | xargs)
 if [[ "$tests_count" != "2" ]]; then
   echo "More than 2 tests for split tests got $tests_count"
   exit 1

--- a/tests/wrapped_bazelisk.sh
+++ b/tests/wrapped_bazelisk.sh
@@ -1,0 +1,9 @@
+wrapped_bazelisk() {
+  if [[ "$(arch)" != "x86_64" ]]; then
+    arch -arch x86_64 bazelisk "$@"
+  else
+    bazelisk "$@"
+  fi
+}
+
+export -f wrapped_bazelisk


### PR DESCRIPTION
The command suggested [here](https://github.com/bazel-ios/rules_ios/pull/664) is not working for me on Apple Silicon (had to fix missing double quotes there)
```sh
arch -arch x86_64 /bin/bash -l -c "./tests/xcodeproj-tests.sh --update"
```
and is updating fixtures that shouldn't be updated (`x86_64` is being updated to `arm64`), e.g.:
```sh
-                               HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
+                               HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-sim_arm64-min10.0-applebin_ios-ios_sim_arm64-dbg-ST-4994c467dfba/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-sim_arm64-min10.0-applebin_ios-ios_sim_arm64-dbg-ST-4994c467dfba/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
```

I believe that's happening because `arch-arch x86_64` does not propagate to all underlying `bazelisk` invocations. This PR "wraps" `bazelisk` to fix that. Specifically changes are:

* Add `tests/wrapped_bazelisk.sh` and `source` it where needed, `bazelisk` is conditionally wrapped if `x86_64` is not found (it will happen in both AS and in the `bazelisk` invocations we do in `genrule` targets to test project re-generation)
* Update `CONTRIBUTING.md` with instructions (caveats on `bazelisk` being `FAT` or not)

With the changes in this PR the command (no need to prefix with `arch`)
```sh
./tests/xcodeproj-tests.sh --update
```
should no-op if no other changes were made in the repo and update fixtures otherwise (on both Intel and AS).