### PR TITLE
Fix product_type when using `link_dynamic`

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -625,7 +625,7 @@ def _attrs_for_split_slice(attrs_by_split_slices, split_slice_key):
     else:
         return attrs_by_split_slices[split_slice_key]
 
-def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps):
+def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps, product_type):
     """Packages this as dynamic framework
 
     Currently, this doesn't include headers or other interface files.
@@ -714,6 +714,7 @@ def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps):
 
     # TODO(jmarino) - consider how to better handle frameworks of frameworks
     processor_partials = []
+
     processor_partials.append(
         partials.apple_bundle_info_partial(
             actions = actions,
@@ -724,7 +725,7 @@ def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps):
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
-            product_type = rule_descriptor.product_type,
+            product_type = product_type if product_type else ctx.attr._product_type,
         ),
     )
     processor_partials.append(
@@ -921,7 +922,7 @@ def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps):
         ] + processor_result.providers,
     )
 
-def _bundle_static_framework(ctx, is_extension_safe, current_apple_platform, outputs):
+def _bundle_static_framework(ctx, is_extension_safe, current_apple_platform, outputs, product_type):
     """Returns bundle info for a static framework commonly used intra-build"""
     partial_output = partial.call(
         partials.extension_safe_validation_partial(
@@ -945,7 +946,7 @@ def _bundle_static_framework(ctx, is_extension_safe, current_apple_platform, out
             minimum_os_version = str(current_apple_platform.target_os_version),
             minimum_deployment_os_version = ctx.attr.minimum_deployment_os_version,
             platform_type = str(current_apple_platform.platform.platform_type),
-            product_type = ctx.attr._product_type,
+            product_type = product_type if product_type else ctx.attr._product_type,
             uses_swift = outputs.swiftmodule != None,
         ),
     ] + partial_output.providers)
@@ -1038,10 +1039,10 @@ def _apple_framework_packaging_impl(ctx):
 
     # If we link dynamic - then package it as dynamic
     if ctx.attr.link_dynamic:
-        bundle_outs = _bundle_dynamic_framework(ctx, is_extension_safe = is_extension_safe, avoid_deps = avoid_deps)
+        bundle_outs = _bundle_dynamic_framework(ctx, is_extension_safe = is_extension_safe, avoid_deps = avoid_deps, product_type = apple_product_type.framework)
         avoid_deps_info = AvoidDepsInfo(libraries = depset(avoid_deps + ctx.attr.deps).to_list(), link_dynamic = True)
     else:
-        bundle_outs = _bundle_static_framework(ctx, is_extension_safe = is_extension_safe, current_apple_platform = current_apple_platform, outputs = outputs)
+        bundle_outs = _bundle_static_framework(ctx, is_extension_safe = is_extension_safe, current_apple_platform = current_apple_platform, outputs = outputs, product_type = apple_product_type.static_framework)
         avoid_deps_info = AvoidDepsInfo(libraries = depset(avoid_deps).to_list(), link_dynamic = False)
     swift_info = _get_merged_swift_info(ctx, framework_files, transitive_deps)
 

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -625,7 +625,7 @@ def _attrs_for_split_slice(attrs_by_split_slices, split_slice_key):
     else:
         return attrs_by_split_slices[split_slice_key]
 
-def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps, product_type):
+def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps):
     """Packages this as dynamic framework
 
     Currently, this doesn't include headers or other interface files.
@@ -725,7 +725,7 @@ def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps, product_type):
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
-            product_type = product_type if product_type else ctx.attr._product_type,
+            product_type = apple_product_type.framework,
         ),
     )
     processor_partials.append(
@@ -922,7 +922,7 @@ def _bundle_dynamic_framework(ctx, is_extension_safe, avoid_deps, product_type):
         ] + processor_result.providers,
     )
 
-def _bundle_static_framework(ctx, is_extension_safe, current_apple_platform, outputs, product_type):
+def _bundle_static_framework(ctx, is_extension_safe, current_apple_platform, outputs):
     """Returns bundle info for a static framework commonly used intra-build"""
     partial_output = partial.call(
         partials.extension_safe_validation_partial(
@@ -946,7 +946,7 @@ def _bundle_static_framework(ctx, is_extension_safe, current_apple_platform, out
             minimum_os_version = str(current_apple_platform.target_os_version),
             minimum_deployment_os_version = ctx.attr.minimum_deployment_os_version,
             platform_type = str(current_apple_platform.platform.platform_type),
-            product_type = product_type if product_type else ctx.attr._product_type,
+            product_type = apple_product_type.static_framework,
             uses_swift = outputs.swiftmodule != None,
         ),
     ] + partial_output.providers)
@@ -1039,10 +1039,10 @@ def _apple_framework_packaging_impl(ctx):
 
     # If we link dynamic - then package it as dynamic
     if ctx.attr.link_dynamic:
-        bundle_outs = _bundle_dynamic_framework(ctx, is_extension_safe = is_extension_safe, avoid_deps = avoid_deps, product_type = apple_product_type.framework)
+        bundle_outs = _bundle_dynamic_framework(ctx, is_extension_safe = is_extension_safe, avoid_deps = avoid_deps)
         avoid_deps_info = AvoidDepsInfo(libraries = depset(avoid_deps + ctx.attr.deps).to_list(), link_dynamic = True)
     else:
-        bundle_outs = _bundle_static_framework(ctx, is_extension_safe = is_extension_safe, current_apple_platform = current_apple_platform, outputs = outputs, product_type = apple_product_type.static_framework)
+        bundle_outs = _bundle_static_framework(ctx, is_extension_safe = is_extension_safe, current_apple_platform = current_apple_platform, outputs = outputs)
         avoid_deps_info = AvoidDepsInfo(libraries = depset(avoid_deps).to_list(), link_dynamic = False)
     swift_info = _get_merged_swift_info(ctx, framework_files, transitive_deps)
 

--- a/rules/legacy_xcodeproj.bzl
+++ b/rules/legacy_xcodeproj.bzl
@@ -805,7 +805,7 @@ def _populate_xcodeproj_targets_and_schemes(ctx, targets, src_dot_dots, all_tran
             if product_type != existing_type:
                 fail(_CONFLICTING_TARGET_MSG.format(ctx.label, target_name, existing_type, target_info.bazel_build_target_name, target_info.product_type))
 
-        target_macho_type = "staticlib" if product_type == "framework" else "$(inherited)"
+        target_macho_type = "staticlib" if product_type == "framework.static" else "$(inherited)"
         compiled_sources = [{
             "path": paths.join(src_dot_dots, s.short_path),
             "optional": True,

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/install.sh
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/installer
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/project.pbxproj
@@ -302,7 +302,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = ObjcFramework;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -324,7 +324,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = ObjcFrameworkTestLib;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -392,7 +392,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = ObjcFramework;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -454,7 +454,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = ObjcFrameworkTestLib;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -476,7 +476,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = ObjcFramework;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -597,7 +597,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = ObjcFrameworkTestLib;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -657,7 +657,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = ObjcFramework;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -702,7 +702,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = ObjcFrameworkTestLib;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";

--- a/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/install.sh
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/installer
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/project.pbxproj
@@ -394,7 +394,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-arm64-min10.0-applebin_ios-ios_arm64-dbg-ST-65c06fec92bf/bin/tests/ios/app/OnlySources_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = OnlySources;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -416,7 +416,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-arm64-min10.0-applebin_ios-ios_arm64-dbg-ST-65c06fec92bf/bin/tests/ios/app/FW_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-arm64-min10.0-applebin_ios-ios_arm64-dbg-ST-65c06fec92bf/bin/tests/ios/app/FW_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-arm64-min10.0-applebin_ios-ios_arm64-dbg-ST-65c06fec92bf/bin/tests/ios/app/FW_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-arm64-min10.0-applebin_ios-ios_arm64-dbg-ST-65c06fec92bf/bin/tests/ios/app/FW_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = FW;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -438,7 +438,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-arm64-min10.0-applebin_ios-ios_arm64-dbg-ST-65c06fec92bf/bin/tests/ios/app/OnlySources_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = OnlySources;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -485,7 +485,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-arm64-min10.0-applebin_ios-ios_arm64-dbg-ST-65c06fec92bf/bin/tests/ios/app/FW2_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-arm64-min10.0-applebin_ios-ios_arm64-dbg-ST-65c06fec92bf/bin/tests/ios/app/FW2_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = FW2;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -568,7 +568,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-arm64-min10.0-applebin_ios-ios_arm64-dbg-ST-65c06fec92bf/bin/tests/ios/app/FW2_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-arm64-min10.0-applebin_ios-ios_arm64-dbg-ST-65c06fec92bf/bin/tests/ios/app/FW2_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = FW2;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -590,7 +590,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-arm64-min10.0-applebin_ios-ios_arm64-dbg-ST-65c06fec92bf/bin/tests/ios/app/FW_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-arm64-min10.0-applebin_ios-ios_arm64-dbg-ST-65c06fec92bf/bin/tests/ios/app/FW_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-arm64-min10.0-applebin_ios-ios_arm64-dbg-ST-65c06fec92bf/bin/tests/ios/app/FW_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-arm64-min10.0-applebin_ios-ios_arm64-dbg-ST-65c06fec92bf/bin/tests/ios/app/FW_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = FW;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/install.sh
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/installer
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/install.sh
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/installer
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/project.pbxproj
@@ -186,7 +186,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = FW;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -244,7 +244,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = FW;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";

--- a/tests/ios/xcodeproj/Test-Mixed-Dynamic-App-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-Mixed-Dynamic-App-Project.xcodeproj/bazelinstallers/install.sh
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/ios/xcodeproj/Test-Mixed-Dynamic-App-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-Mixed-Dynamic-App-Project.xcodeproj/bazelinstallers/installer
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/ios/xcodeproj/Test-Mixed-Dynamic-App-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-Mixed-Dynamic-App-Project.xcodeproj/project.pbxproj
@@ -19,14 +19,14 @@
 		4B591E98E01C3FB1BE1C7410 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
 		6CD05C1A97322FF05C07A575 /* lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = lib.swift; sourceTree = "<group>"; };
 		77CDBB7A7D720A26918F4EBB /* c.framework */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.framework; path = c.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		7DCCC28E852EEDD2A2805FB8 /* a.framework */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.framework; path = a.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7DCCC28E852EEDD2A2805FB8 /* a.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = a.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8BD8BAFA513836E6FFFA7A8C /* b_data.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = b_data.txt; sourceTree = "<group>"; };
 		99827A0C0BB92411E52602A4 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
 		A2BAF01C313B0C71204CCEDF /* c_data.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = c_data.txt; sourceTree = "<group>"; };
 		A6299BB10CB8595BD904D1DC /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
 		B1B9B586F9DB3911E06810C8 /* lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = lib.swift; sourceTree = "<group>"; };
 		C3FE81D9E9639A366E8EB839 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		C75592B2FDAAFAD42D0AEC72 /* b.framework */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.framework; path = b.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C75592B2FDAAFAD42D0AEC72 /* b.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = b.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D301EC754F6CE825ED9D7D69 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		F42D4FFF4D2D5509A78D4D8F /* lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = lib.swift; sourceTree = "<group>"; };
 		FECA1E7A15F2CB0A2ED79E6E /* App.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -153,7 +153,7 @@
 			name = b;
 			productName = b;
 			productReference = C75592B2FDAAFAD42D0AEC72 /* b.framework */;
-			productType = "com.apple.product-type.framework.static";
+			productType = "com.apple.product-type.framework";
 		};
 		66A1334E30F3E6565E1D3198 /* App */ = {
 			isa = PBXNativeTarget;
@@ -201,7 +201,7 @@
 			name = a;
 			productName = a;
 			productReference = 7DCCC28E852EEDD2A2805FB8 /* a.framework */;
-			productType = "com.apple.product-type.framework.static";
+			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
 
@@ -576,7 +576,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/dynamic/c/c_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = c;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -598,7 +598,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/frameworks/dynamic/c/c_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = c;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/install.sh
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/installer
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/project.pbxproj
@@ -410,7 +410,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW2_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW2_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = FW2;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -457,7 +457,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/OnlySources_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = OnlySources;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -479,7 +479,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = FW;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -539,7 +539,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/OnlySources_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = OnlySources;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -611,7 +611,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW2_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW2_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = FW2;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -658,7 +658,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = FW;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/install.sh
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/installer
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/project.pbxproj
@@ -492,7 +492,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = FW;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -550,7 +550,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = FW;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -572,7 +572,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW2_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW2_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = FW2;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -594,7 +594,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW2_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW2_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = FW2;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/install.sh
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/installer
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/project.pbxproj
@@ -505,7 +505,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = FW;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -552,7 +552,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = FW;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -660,7 +660,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/OnlySources_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = OnlySources;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -720,7 +720,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/OnlySources_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = OnlySources;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -742,7 +742,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW2_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW2_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = FW2;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -764,7 +764,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW2_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW2_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = FW2;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/install.sh
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/installer
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/install.sh
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/installer
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/project.pbxproj
@@ -186,7 +186,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = FW;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";
@@ -244,7 +244,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-d31cf6d5fbab/bin/tests/ios/app/FW_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACH_O_TYPE = "$(inherited)";
+				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = FW;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "\"$(inherited)\"";

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/install.sh
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/installer
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/install.sh
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/installer
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/install.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/install.sh
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/installer
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/installer
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event

--- a/tools/xcodeproj_shims/install.sh
+++ b/tools/xcodeproj_shims/install.sh
@@ -11,6 +11,9 @@ find "${BAZEL_DIAGNOSTICS_DIR}" -type f -atime +7d -delete
 case "${PRODUCT_TYPE}" in
 com.apple.product-type.framework)
     input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${TARGET_NAME}/${FULL_PRODUCT_NAME}")
+    if [ ! -d "$input_options" ]; then
+        input_options=("bazel-bin/$BAZEL_BIN_SUBDIR/${FULL_PRODUCT_NAME}")
+    fi
     ;;
 com.apple.product-type.framework.static)
     # For static library, as the output is not under bazel-bin, we have to get it based on build event


### PR DESCRIPTION
We are currently bundling dynamic frameworks with `product_type` = `apple_product_type.static_framework` due to [this default](https://github.com/bazel-ios/rules_ios/blob/master/rules/framework.bzl#L1212) and the fact that `rule_descriptor` [uses that same default](https://github.com/bazelbuild/rules_apple/blob/master/apple/internal/rule_support.bzl#L900).

This PR set's `product_type` explicitly for each `_bundle_dynamic_framework` and `_bundle_static_framework` and sets the correct respective `MACH_O_TYPE` in the Xcode project generator.

Before:
![Screenshot 2023-07-18 at 4 52 49 PM](https://github.com/bazel-ios/rules_ios/assets/10197663/8700d1b5-a5ce-47e0-a19d-954c064a6eca)

After:
![Screenshot 2023-07-19 at 3 40 57 PM](https://github.com/bazel-ios/rules_ios/assets/10197663/e4f35b0f-eb7f-4864-87d7-0ee5be88a695)
