### PR TITLE
Pass datamodels to AppleResourceInfo in _precompiled_apple_resource_bundle

### DIFF
--- a/rules/precompiled_apple_resource_bundle.bzl
+++ b/rules/precompiled_apple_resource_bundle.bzl
@@ -199,6 +199,12 @@ def _precompiled_apple_resource_bundle_impl(ctx):
     return [
         AppleResourceInfo(
             unowned_resources = depset(),
+            datamodels = [
+                (output_bundle_dir.basename, None, depset([f]))
+                for resource_files in ctx.attr.resources
+                for f in resource_files.files.to_list()
+                if f.path.count("xcdatamodel")
+            ],
             owners = depset([
                 (output_bundle_dir.short_path, ctx.label),
                 (output_plist.short_path, ctx.label),

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -84,10 +84,10 @@ def rules_ios_dependencies(
         _maybe(
             github_repo,
             name = "build_bazel_rules_apple",
-            ref = "6f93e73382a01595d576247db9fa886769536605",
+            ref = "8210cec019da7dc8846c41bc643396559461e92d",
             project = "bazelbuild",
             repo = "rules_apple",
-            sha256 = "1618fc82e556ebc97ea360b8cacd3365ca3b0e0a85ccb32422468204843e752d",
+            sha256 = "de27679657f48ce9c264bc8bba30205a1a5705293e7f3aac3a34364e2b43da2f",
         )
     else:
         _maybe(


### PR DESCRIPTION
When integrating with `rules_xcodeproj` noticed that after generating an Xcode project the generator wasn't picking up existing `.xccurrentversion` files under `.xcdatamodeld` directories due to `rules_ios` not propagating these in the providers of `_precompiled_apple_resource_bundle`.

Because of this once you launch Xcode (just launching, no other user action needed) it is generating a non-empty `git diff` with `.xccurrentversion` files changed, most likely an Xcode internal logic to try to heal itself and find some `.xccurrentversion` to load (which could be different than the one you intended to use if you've got multiple version).

This PR passes `datamodels` to `AppleResourceInfo` to fix that.

Requires: https://github.com/bazel-ios/rules_apple/commit/8210cec019da7dc8846c41bc643396559461e92d

Without this `rules_apple` change we would hit the exception in the commit above:
```
raise Exception(f"failed to clonefile {src} to {full_dest}")
```
confirmed that the file being copied is exactly the same, so even though there's an overwrite happening when using `shutil` it's replacing a file for another file that is the same.