### PR TITLE
Turn off remote cache for local dev, cleanup github actions UI clutter

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -54,19 +54,17 @@ build:ios_multi_arch_test --ios_minimum_os=10.2
 build:ios_multi_arch_test --ios_multi_cpus=i386,x86_64
 
 # - Remote cache configuration
-build:remote_cache --bes_backend=grpcs://remote.buildbuddy.io
-build:remote_cache --bes_results_url=https://app.buildbuddy.io/invocation/
-build:remote_cache --experimental_build_event_upload_strategy=local
-build:remote_cache --experimental_remote_cache_compression
-build:remote_cache --experimental_remote_merkle_tree_cache
-build:remote_cache --modify_execution_info=^(BitcodeSymbolsCopy|BundleApp|BundleTreeApp|DsymDwarf|DsymLipo|GenerateAppleSymbolsFile|ObjcBinarySymbolStrip|CppLink|ObjcLink|ProcessAndSign|SignBinary|SwiftArchive|SwiftStdlibCopy)$=+no-remote,^(BundleResources|ImportedDynamicFrameworkProcessor)$=+no-remote-exec
-build:remote_cache --nolegacy_important_outputs
-build:remote_cache --noslim_profile
-build:remote_cache --remote_cache=grpcs://remote.buildbuddy.io
-build:remote_cache --remote_timeout=3600
+build:ci_remote_cache --bes_backend=grpcs://remote.buildbuddy.io
+build:ci_remote_cache --bes_results_url=https://app.buildbuddy.io/invocation/
+build:ci_remote_cache --experimental_build_event_upload_strategy=local
+build:ci_remote_cache --experimental_remote_cache_compression
+build:ci_remote_cache --experimental_remote_merkle_tree_cache
+build:ci_remote_cache --modify_execution_info=^(BitcodeSymbolsCopy|BundleApp|BundleTreeApp|DsymDwarf|DsymLipo|GenerateAppleSymbolsFile|ObjcBinarySymbolStrip|CppLink|ObjcLink|ProcessAndSign|SignBinary|SwiftArchive|SwiftStdlibCopy)$=+no-remote,^(BundleResources|ImportedDynamicFrameworkProcessor)$=+no-remote-exec
+build:ci_remote_cache --nolegacy_important_outputs
+build:ci_remote_cache --noslim_profile
+build:ci_remote_cache --remote_cache=grpcs://remote.buildbuddy.io
+build:ci_remote_cache --remote_timeout=3600
 
-# Enable remote_cache config by default
-build --config=remote_cache
 
 # By default don't upload local results to remote cache, only CI does this.
 build --noremote_upload_local_results

--- a/.bazelrc
+++ b/.bazelrc
@@ -80,7 +80,6 @@ common:ci --show_progress_rate_limit=15.0
 build:ci --progress_report_interval=60
 # enable more verbose logging
 build:ci --verbose_failures
-build:ci --subcommands
 # ci setup for tests, tend to be more flaky on github actions
 build:ci --jobs=4
 # allow extra time for simulators to boot

--- a/.bazelrc
+++ b/.bazelrc
@@ -54,17 +54,17 @@ build:ios_multi_arch_test --ios_minimum_os=10.2
 build:ios_multi_arch_test --ios_multi_cpus=i386,x86_64
 
 # - Remote cache configuration
-build:ci_remote_cache --bes_backend=grpcs://remote.buildbuddy.io
-build:ci_remote_cache --bes_results_url=https://app.buildbuddy.io/invocation/
-build:ci_remote_cache --experimental_build_event_upload_strategy=local
-build:ci_remote_cache --experimental_remote_cache_compression
-build:ci_remote_cache --experimental_remote_merkle_tree_cache
-build:ci_remote_cache --modify_execution_info=^(BitcodeSymbolsCopy|BundleApp|BundleTreeApp|DsymDwarf|DsymLipo|GenerateAppleSymbolsFile|ObjcBinarySymbolStrip|CppLink|ObjcLink|ProcessAndSign|SignBinary|SwiftArchive|SwiftStdlibCopy)$=+no-remote,^(BundleResources|ImportedDynamicFrameworkProcessor)$=+no-remote-exec
-build:ci_remote_cache --nolegacy_important_outputs
-build:ci_remote_cache --noslim_profile
-build:ci_remote_cache --remote_cache=grpcs://remote.buildbuddy.io
-build:ci_remote_cache --remote_timeout=3600
-
+build:ci_with_caches --bes_backend=grpcs://remote.buildbuddy.io
+build:ci_with_caches --bes_results_url=https://app.buildbuddy.io/invocation/
+build:ci_with_caches --experimental_build_event_upload_strategy=local
+build:ci_with_caches --experimental_remote_cache_compression
+build:ci_with_caches --experimental_remote_merkle_tree_cache
+build:ci_with_caches --modify_execution_info=^(BitcodeSymbolsCopy|BundleApp|BundleTreeApp|DsymDwarf|DsymLipo|GenerateAppleSymbolsFile|ObjcBinarySymbolStrip|CppLink|ObjcLink|ProcessAndSign|SignBinary|SwiftArchive|SwiftStdlibCopy)$=+no-remote,^(BundleResources|ImportedDynamicFrameworkProcessor)$=+no-remote-exec
+build:ci_with_caches --nolegacy_important_outputs
+build:ci_with_caches --noslim_profile
+build:ci_with_caches --remote_cache=grpcs://remote.buildbuddy.io
+build:ci_with_caches --remote_timeout=3600
+build:ci_with_caches --config=ci
 
 # By default don't upload local results to remote cache, only CI does this.
 build --noremote_upload_local_results

--- a/.github/workflows/preflight_env.sh
+++ b/.github/workflows/preflight_env.sh
@@ -6,3 +6,7 @@ printenv
 
 sudo xcode-select -p
 sudo xcode-select -s /Applications/Xcode_14.2.app
+
+cat << EOF > $HOME/.bazelrc
+build:ci --config=ci_remote_cache
+EOF

--- a/.github/workflows/preflight_env.sh
+++ b/.github/workflows/preflight_env.sh
@@ -6,7 +6,3 @@ printenv
 
 sudo xcode-select -p
 sudo xcode-select -s /Applications/Xcode_14.2.app
-
-cat << EOF > $HOME/.bazelrc
-build:ci --config=ci_remote_cache
-EOF

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
-      - name: Select Xcode
-        run: .github/workflows/xcode_select.sh
+      - name: Preflight Env
+        run: .github/workflows/preflight_env.sh
       - name: Build and Test
         run: |
           # non-iOS tests
@@ -56,8 +56,8 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
-      - name: Select Xcode
-        run: .github/workflows/xcode_select.sh
+      - name: Preflight Env
+        run: .github/workflows/preflight_env.sh
       - name: Build and Test
         run: |
           # non-iOS tests
@@ -89,8 +89,8 @@ jobs:
       USE_BAZEL_VERSION: 5.3.2
     steps:
       - uses: actions/checkout@v3
-      - name: Select Xcode
-        run: .github/workflows/xcode_select.sh
+      - name: Preflight Env
+        run: .github/workflows/preflight_env.sh
       - name: Build and Test
         run: |
           # iOS tests
@@ -112,8 +112,8 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
-      - name: Select Xcode
-        run: .github/workflows/xcode_select.sh
+      - name: Preflight Env
+        run: .github/workflows/preflight_env.sh
       - name: Build and Test
         run: |
           bazelisk build \
@@ -146,8 +146,8 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
-      - name: Select Xcode
-        run: .github/workflows/xcode_select.sh
+      - name: Preflight Env
+        run: .github/workflows/preflight_env.sh
         # Note: we need to pass the absolute to the Bazel run
       - name: buildifier
         run: |
@@ -165,8 +165,8 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
-      - name: Select Xcode 14.2.0
-        run: .github/workflows/xcode_select.sh
+      - name: Preflight Env
+        run: .github/workflows/preflight_env.sh
       - name: Run tests
         run: ./tests/xcodeproj-tests.sh --run && ./tests/test-tests.sh
       - uses: actions/upload-artifact@v2
@@ -180,8 +180,8 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
-      - name: Select Xcode 14.2.0
-        run: .github/workflows/xcode_select.sh
+      - name: Preflight Env
+        run: .github/workflows/preflight_env.sh
       - name: Run tests
         run: |
           bazelisk test \
@@ -202,8 +202,8 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
-      - name: Select Xcode
-        run: .github/workflows/xcode_select.sh
+      - name: Preflight Env
+        run: .github/workflows/preflight_env.sh
       - name: Build App
         run: |
           bazelisk build \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           # non-iOS tests
           bazelisk test \
-            --config=ci \
+            --config=ci_with_caches \
             -- \
             //... \
             -//tests/ios/...
@@ -36,7 +36,7 @@ jobs:
 
           # iOS tests
           bazelisk test \
-            --config=ci \
+            --config=ci_with_caches \
             --config=ios \
             --test_arg=--destination=platform=ios_simulator,id=$SIMULATOR_UDID \
             -- \
@@ -62,7 +62,7 @@ jobs:
         run: |
           # non-iOS tests
           bazelisk test \
-            --config=ci \
+            --config=ci_with_caches \
             --config=vfs \
             -- \
             //... \
@@ -70,7 +70,7 @@ jobs:
 
           # iOS tests
           bazelisk test \
-            --config=ci \
+            --config=ci_with_caches \
             --config=ios \
             --config=vfs \
             -- \
@@ -95,7 +95,7 @@ jobs:
         run: |
           # iOS tests
           bazelisk build \
-            --config=ci \
+            --config=ci_with_caches \
             --config=ios \
             --config=vfs \
             -- \
@@ -117,7 +117,7 @@ jobs:
       - name: Build and Test
         run: |
           bazelisk build \
-            --config=ci \
+            --config=ci_with_caches \
             --config=vfs \
             --ios_multi_cpus=sim_arm64  \
             -- \
@@ -127,7 +127,7 @@ jobs:
           # Misc issues:
           #   - Fails on a non fat framework for //tests/ios/unit-test/test-imports-app/
           bazelisk build \
-            --config=ci \
+            --config=ci_with_caches \
             --config=ios \
             --config=vfs \
             --ios_multi_cpus=sim_arm64 \
@@ -156,7 +156,7 @@ jobs:
       - name: Check docs
         run: |
           bazelisk run \
-            --config=ci \
+            --config=ci_with_caches \
             //docs
           git diff --exit-code docs
 
@@ -185,7 +185,7 @@ jobs:
       - name: Run tests
         run: |
           bazelisk test \
-            --config=ci \
+            --config=ci_with_caches \
             --config=ios_lldb_test \
             -- \
             tests/ios/lldb/app:objc_app_po_test \
@@ -207,7 +207,7 @@ jobs:
       - name: Build App
         run: |
           bazelisk build \
-            --config=ci \
+            --config=ci_with_caches \
             --config=ios_multi_arch_test \
             -- \
             tests/ios/app/App


### PR DESCRIPTION
Configure bazelrc in the `preflight_env.sh` script

Ensure we enable existing remote cache on github actions