### PR TITLE
[Test] Break massive ios_test function into factory

### DIFF
--- a/docs/test_doc.md
+++ b/docs/test_doc.md
@@ -2,12 +2,139 @@
 
 
 
+<a id="default_test_factory.make_tests"></a>
+
+## default_test_factory.make_tests
+
+<pre>
+default_test_factory.make_tests(<a href="#default_test_factory.make_tests-factory">factory</a>, <a href="#default_test_factory.make_tests-name">name</a>, <a href="#default_test_factory.make_tests-test_rule">test_rule</a>, <a href="#default_test_factory.make_tests-kwargs">kwargs</a>)
+</pre>
+
+    Main entry point of generating tests"
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="default_test_factory.make_tests-factory"></a>factory |  <p align="center"> - </p>   |  none |
+| <a id="default_test_factory.make_tests-name"></a>name |  <p align="center"> - </p>   |  none |
+| <a id="default_test_factory.make_tests-test_rule"></a>test_rule |  <p align="center"> - </p>   |  none |
+| <a id="default_test_factory.make_tests-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
+
+
+<a id="default_test_factory.make_test_suite"></a>
+
+## default_test_factory.make_test_suite
+
+<pre>
+default_test_factory.make_test_suite(<a href="#default_test_factory.make_test_suite-factory">factory</a>, <a href="#default_test_factory.make_test_suite-name">name</a>, <a href="#default_test_factory.make_test_suite-test_rule">test_rule</a>, <a href="#default_test_factory.make_test_suite-test_kwargs">test_kwargs</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="default_test_factory.make_test_suite-factory"></a>factory |  <p align="center"> - </p>   |  none |
+| <a id="default_test_factory.make_test_suite-name"></a>name |  <p align="center"> - </p>   |  none |
+| <a id="default_test_factory.make_test_suite-test_rule"></a>test_rule |  <p align="center"> - </p>   |  none |
+| <a id="default_test_factory.make_test_suite-test_kwargs"></a>test_kwargs |  <p align="center"> - </p>   |  none |
+
+
+<a id="default_test_factory.make_test_suite_splits"></a>
+
+## default_test_factory.make_test_suite_splits
+
+<pre>
+default_test_factory.make_test_suite_splits(<a href="#default_test_factory.make_test_suite_splits-factory">factory</a>, <a href="#default_test_factory.make_test_suite_splits-name">name</a>, <a href="#default_test_factory.make_test_suite_splits-in_kwargs">in_kwargs</a>)
+</pre>
+
+    Helper function to split up a test for named splits and runners splits
+
+At the end of the day, we need to able to control how many tests / bundles
+there are for sharding by class, otherwise it would recompile many times.
+
+Finally - you can set the splits to be whatever you want.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="default_test_factory.make_test_suite_splits-factory"></a>factory |  <p align="center"> - </p>   |  none |
+| <a id="default_test_factory.make_test_suite_splits-name"></a>name |  <p align="center"> - </p>   |  none |
+| <a id="default_test_factory.make_test_suite_splits-in_kwargs"></a>in_kwargs |  <p align="center"> - </p>   |  none |
+
+
+<a id="default_test_factory.make_runner_split"></a>
+
+## default_test_factory.make_runner_split
+
+<pre>
+default_test_factory.make_runner_split(<a href="#default_test_factory.make_runner_split-name">name</a>, <a href="#default_test_factory.make_runner_split-runner">runner</a>, <a href="#default_test_factory.make_runner_split-in_split">in_split</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="default_test_factory.make_runner_split-name"></a>name |  <p align="center"> - </p>   |  none |
+| <a id="default_test_factory.make_runner_split-runner"></a>runner |  <p align="center"> - </p>   |  none |
+| <a id="default_test_factory.make_runner_split-in_split"></a>in_split |  <p align="center"> - </p>   |  none |
+
+
+<a id="default_test_factory.make_named_split"></a>
+
+## default_test_factory.make_named_split
+
+<pre>
+default_test_factory.make_named_split(<a href="#default_test_factory.make_named_split-name">name</a>, <a href="#default_test_factory.make_named_split-split_kwargs">split_kwargs</a>, <a href="#default_test_factory.make_named_split-in_split">in_split</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="default_test_factory.make_named_split-name"></a>name |  <p align="center"> - </p>   |  none |
+| <a id="default_test_factory.make_named_split-split_kwargs"></a>split_kwargs |  <p align="center"> - </p>   |  none |
+| <a id="default_test_factory.make_named_split-in_split"></a>in_split |  <p align="center"> - </p>   |  none |
+
+
+<a id="default_test_factory.make_test"></a>
+
+## default_test_factory.make_test
+
+<pre>
+default_test_factory.make_test(<a href="#default_test_factory.make_test-name">name</a>, <a href="#default_test_factory.make_test-test_rule">test_rule</a>, <a href="#default_test_factory.make_test-kwargs">kwargs</a>)
+</pre>
+
+    Helper to create an individual test
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="default_test_factory.make_test-name"></a>name |  <p align="center"> - </p>   |  none |
+| <a id="default_test_factory.make_test-test_rule"></a>test_rule |  <p align="center"> - </p>   |  none |
+| <a id="default_test_factory.make_test-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
+
+
 <a id="ios_ui_test"></a>
 
 ## ios_ui_test
 
 <pre>
-ios_ui_test(<a href="#ios_ui_test-name">name</a>, <a href="#ios_ui_test-apple_library">apple_library</a>, <a href="#ios_ui_test-kwargs">kwargs</a>)
+ios_ui_test(<a href="#ios_ui_test-name">name</a>, <a href="#ios_ui_test-apple_library">apple_library</a>, <a href="#ios_ui_test-test_factory">test_factory</a>, <a href="#ios_ui_test-kwargs">kwargs</a>)
 </pre>
 
     Builds and packages iOS UI Tests.
@@ -19,6 +146,7 @@ ios_ui_test(<a href="#ios_ui_test-name">name</a>, <a href="#ios_ui_test-apple_li
 | :------------- | :------------- | :------------- |
 | <a id="ios_ui_test-name"></a>name |  The name of the UI test.   |  none |
 | <a id="ios_ui_test-apple_library"></a>apple_library |  The macro used to package sources into a library.   |  <code>&lt;function apple_library&gt;</code> |
+| <a id="ios_ui_test-test_factory"></a>test_factory |  Use this to generate other variations of tests.   |  <code>struct(make_named_split = &lt;function _make_named_split&gt;, make_runner_split = &lt;function _make_runner_split&gt;, make_test = &lt;function _make_test&gt;, make_test_suite = &lt;function _make_test_suite&gt;, make_test_suite_splits = &lt;function _make_test_suite_splits&gt;, make_tests = &lt;function _make_tests&gt;)</code> |
 | <a id="ios_ui_test-kwargs"></a>kwargs |  Arguments passed to the apple_library and ios_ui_test rules as appropriate.   |  none |
 
 
@@ -27,7 +155,7 @@ ios_ui_test(<a href="#ios_ui_test-name">name</a>, <a href="#ios_ui_test-apple_li
 ## ios_unit_snapshot_test
 
 <pre>
-ios_unit_snapshot_test(<a href="#ios_unit_snapshot_test-name">name</a>, <a href="#ios_unit_snapshot_test-apple_library">apple_library</a>, <a href="#ios_unit_snapshot_test-kwargs">kwargs</a>)
+ios_unit_snapshot_test(<a href="#ios_unit_snapshot_test-name">name</a>, <a href="#ios_unit_snapshot_test-apple_library">apple_library</a>, <a href="#ios_unit_snapshot_test-test_factory">test_factory</a>, <a href="#ios_unit_snapshot_test-kwargs">kwargs</a>)
 </pre>
 
     Builds and packages iOS Unit Snapshot Tests.
@@ -39,6 +167,7 @@ ios_unit_snapshot_test(<a href="#ios_unit_snapshot_test-name">name</a>, <a href=
 | :------------- | :------------- | :------------- |
 | <a id="ios_unit_snapshot_test-name"></a>name |  The name of the UI test.   |  none |
 | <a id="ios_unit_snapshot_test-apple_library"></a>apple_library |  The macro used to package sources into a library.   |  <code>&lt;function apple_library&gt;</code> |
+| <a id="ios_unit_snapshot_test-test_factory"></a>test_factory |  Use this to generate other variations of tests.   |  <code>struct(make_named_split = &lt;function _make_named_split&gt;, make_runner_split = &lt;function _make_runner_split&gt;, make_test = &lt;function _make_test&gt;, make_test_suite = &lt;function _make_test_suite&gt;, make_test_suite_splits = &lt;function _make_test_suite_splits&gt;, make_tests = &lt;function _make_tests&gt;)</code> |
 | <a id="ios_unit_snapshot_test-kwargs"></a>kwargs |  Arguments passed to the apple_library and ios_unit_test rules as appropriate.   |  none |
 
 
@@ -47,7 +176,7 @@ ios_unit_snapshot_test(<a href="#ios_unit_snapshot_test-name">name</a>, <a href=
 ## ios_unit_test
 
 <pre>
-ios_unit_test(<a href="#ios_unit_test-name">name</a>, <a href="#ios_unit_test-apple_library">apple_library</a>, <a href="#ios_unit_test-kwargs">kwargs</a>)
+ios_unit_test(<a href="#ios_unit_test-name">name</a>, <a href="#ios_unit_test-apple_library">apple_library</a>, <a href="#ios_unit_test-test_factory">test_factory</a>, <a href="#ios_unit_test-kwargs">kwargs</a>)
 </pre>
 
     Builds and packages iOS Unit Tests.
@@ -59,6 +188,7 @@ ios_unit_test(<a href="#ios_unit_test-name">name</a>, <a href="#ios_unit_test-ap
 | :------------- | :------------- | :------------- |
 | <a id="ios_unit_test-name"></a>name |  The name of the unit test.   |  none |
 | <a id="ios_unit_test-apple_library"></a>apple_library |  The macro used to package sources into a library.   |  <code>&lt;function apple_library&gt;</code> |
+| <a id="ios_unit_test-test_factory"></a>test_factory |  Use this to generate other variations of tests.   |  <code>struct(make_named_split = &lt;function _make_named_split&gt;, make_runner_split = &lt;function _make_runner_split&gt;, make_test = &lt;function _make_test&gt;, make_test_suite = &lt;function _make_test_suite&gt;, make_test_suite_splits = &lt;function _make_test_suite_splits&gt;, make_tests = &lt;function _make_tests&gt;)</code> |
 | <a id="ios_unit_test-kwargs"></a>kwargs |  Arguments passed to the apple_library and ios_unit_test rules as appropriate.   |  none |
 
 

--- a/rules/test.bzl
+++ b/rules/test.bzl
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_apple//apple:ios.bzl", rules_apple_ios_ui_test = "ios_ui_test", rules_apple_ios_ui_test_suite = "ios_ui_test_suite", rules_apple_ios_unit_test = "ios_unit_test", rules_apple_ios_unit_test_suite = "ios_unit_test_suite")
+load("@build_bazel_rules_apple//apple/internal/testing:ios_rules.bzl", _ios_internal_ui_test_bundle = "ios_internal_ui_test_bundle", _ios_internal_unit_test_bundle = "ios_internal_unit_test_bundle", _ios_ui_test = "ios_ui_test", _ios_unit_test = "ios_unit_test")
 load("@bazel_skylib//lib:types.bzl", "types")
 load("//rules:library.bzl", "apple_library")
 load("//rules:plists.bzl", "process_infoplists")
@@ -25,14 +25,121 @@ _IOS_TEST_KWARGS = [
     "visibility",
 ]
 
-def _ios_test(name, test_rule, test_suite_rule, apple_library, infoplists_by_build_setting = {}, split_name_to_kwargs = {}, internal_test_deps = [], **kwargs):
+_APPLE_BUNDLE_ATTRS = {
+    x: None
+    for x in [
+        "additional_contents",
+        "deps",
+        "bundle_id",
+        "bundle_name",
+        "families",
+        "frameworks",
+        "infoplists",
+        "linkopts",
+        "minimum_os_version",
+        "provisioning_profile",
+        "resources",
+        "test_host",
+    ]
+}
+
+_DEFAULT_APPLE_TEST_RUNNER = "@build_bazel_rules_apple//apple/testing/default_runner:ios_default_runner"
+
+def _make_runner_split(name, runner, **in_split):
+    split = {}
+    split.update(in_split)
+    split.pop("runners", None)
+    split["runner"] = runner
+    return split
+
+def _make_named_split(name, split_kwargs, **in_split):
+    split = {}
+    split.update(in_split)
+    split.update(split_kwargs)
+    return split
+
+def _make_test_suite_splits(factory, name, **in_kwargs):
+    """
+    Helper function to split up a test for named splits and runners splits
+
+    At the end of the day, we need to able to control how many tests / bundles
+    there are for sharding by class, otherwise it would recompile many times.
+
+    Finally - you can set the splits to be whatever you want.
+    """
+    split_name_to_kwargs = in_kwargs.pop("split_name_to_kwargs", {})
+    splits = {}
+    if split_name_to_kwargs and len(split_name_to_kwargs) > 0:
+        for suffix, split_kwargs in split_name_to_kwargs.items():
+            test_name = "{}_{}".format(name, suffix)
+            splits[test_name] = factory.make_named_split(name, split_kwargs, **in_kwargs)
+
+    runners = in_kwargs.pop("runners", [])
+    if runners and len(runners) > 0:
+        splits_by_runners = {}
+        if len(splits) == 0:
+            splits[name] = in_kwargs
+        for runner in runners:
+            runner_name = runner.rsplit(":", 1)[-1]
+            for in_test_name, in_split in splits.items():
+                test_name = "{}_{}".format(in_test_name, runner_name)
+                splits_by_runners[test_name] = factory.make_runner_split(name, runner, **in_split)
+        splits = splits_by_runners
+    return splits
+
+def _make_test_suite(factory, name, test_rule, **test_kwargs):
+    splits = factory.make_test_suite_splits(factory, name, **test_kwargs)
+    tests = []
+    for split_name, split in splits.items():
+        tests.append(split_name)
+        factory.make_test(split_name, test_rule, **split)
+    test_suite_visibility = test_kwargs.get("visibility", None)
+    test_suite_tags = test_kwargs.get("tags", [])
+    native.test_suite(name = name, tests = tests, visibility = test_suite_visibility, tags = test_suite_tags)
+
+def _make_test(name, test_rule, **kwargs):
+    """
+    Helper to create an individual test
+    """
+    runner = kwargs.pop("runner", None) or _DEFAULT_APPLE_TEST_RUNNER
+    test_attrs = {k: v for (k, v) in kwargs.items() if k not in _APPLE_BUNDLE_ATTRS}
+    test_rule(
+        name = name,
+        runner = runner,
+        test_host = kwargs.pop("test_host", None),
+        deps = kwargs.pop("deps", []),
+        testonly = kwargs.pop("testonly", True),
+        **test_attrs
+    )
+
+def _make_tests(factory, name, test_rule, **kwargs):
+    """
+    Main entry point of generating tests"
+    """
+
+    # If the user indicates they want more than one test we will generate one
+    if "runners" in kwargs or "split_name_to_kwargs" in kwargs:
+        factory.make_test_suite(factory, name, test_rule, **kwargs)
+    else:
+        factory.make_test(name, test_rule, **kwargs)
+
+default_test_factory = struct(
+    make_tests = _make_tests,
+    make_test_suite = _make_test_suite,
+    make_test_suite_splits = _make_test_suite_splits,
+    make_runner_split = _make_runner_split,
+    make_named_split = _make_named_split,
+    make_test = _make_test,
+)
+
+def _ios_test(name, bundle_rule, test_rule, test_factory, apple_library, infoplists_by_build_setting = {}, split_name_to_kwargs = {}, internal_test_deps = [], **kwargs):
     """
     Builds and packages iOS Unit/UI Tests.
 
     Args:
         name: The name of the unit test.
         test_rule: The underlying rules_apple test rule.
-        test_suite_rule: The underlying rules_apple test suite rule.
+        bundle_rule: The underlying rules_apple test suite rule.
         apple_library: The macro used to package sources into a library.
         infoplists_by_build_setting: A dictionary of infoplists grouped by bazel build setting.
 
@@ -56,10 +163,20 @@ def _ios_test(name, test_rule, test_suite_rule, apple_library, infoplists_by_bui
     if ios_test_kwargs.get("test_host", None) == True:
         ios_test_kwargs["test_host"] = "@build_bazel_rules_ios//rules/test_host_app:iOS-%s-AppHost" % ios_test_kwargs.get("minimum_os_version")
 
-    if "runner" in kwargs and "runners" in kwargs:
+    runners = kwargs.pop("runners", None)
+    runner = kwargs.pop("runner", _DEFAULT_APPLE_TEST_RUNNER)
+    if "runner" in kwargs and (runners and runners != []):
         fail("cannot specify both runner and runners for %s" % name)
+    if runners:
+        ios_test_kwargs["runners"] = runners
+    elif types.is_list(runner):
+        # `runner` attribute has unfortunately always supported a list.
+        ios_test_kwargs["runners"] = runner
+    else:
+        ios_test_kwargs["runner"] = runner
 
-    runner = kwargs.pop("runner", kwargs.pop("runners", None))
+    if split_name_to_kwargs:
+        ios_test_kwargs["split_name_to_kwargs"] = split_name_to_kwargs
 
     # Deduplicate against the test deps
     if ios_test_kwargs.get("test_host", None):
@@ -84,91 +201,56 @@ def _ios_test(name, test_rule, test_suite_rule, apple_library, infoplists_by_bui
         xcconfig_by_build_setting = kwargs.get("xcconfig_by_build_setting", {}),
     )
 
-    if split_name_to_kwargs and len(split_name_to_kwargs) > 0:
-        tests = []
-        for suffix, split_kwargs in split_name_to_kwargs.items():
-            test_name = "{}_{}".format(name, suffix)
+    # Set this to a single __internal__ test bundle.
+    test_bundle_name = name + ".__internal__.__test_bundle"
+    bundle_attrs = {k: v for (k, v) in ios_test_kwargs.items() if k in _APPLE_BUNDLE_ATTRS}
+    bundle_rule(
+        name = test_bundle_name,
+        bundle_name = name,
+        test_bundle_output = "{}.zip".format(name),
+        testonly = True,
+        frameworks = frameworks,
+        infoplists = select(infoplists),
+        deps = [dep_name] + internal_test_deps,
+        **bundle_attrs
+    )
+    ios_test_kwargs["deps"] = [test_bundle_name]
+    test_factory.make_tests(test_factory, name, test_rule, **ios_test_kwargs)
 
-            all_kwargs = {}
-            all_kwargs.update(ios_test_kwargs)
-            all_kwargs.update(split_kwargs)
-
-            if runner and ("runner" in all_kwargs or "runners" in all_kwargs):
-                fail("cannot use runner/s attribute in both split and top level kwargs for %s" % test_name)
-
-            if not runner:
-                split_runner = all_kwargs.pop("runner", all_kwargs.pop("runners", None))
-            else:
-                split_runner = runner
-
-            split_rule = test_rule
-            if split_runner:
-                if types.is_list(runner):
-                    all_kwargs["runners"] = split_runner
-                    split_rule = test_suite_rule
-                else:
-                    all_kwargs["runner"] = split_runner
-
-            tests.append(test_name)
-            split_rule(
-                name = test_name,
-                deps = [dep_name] + internal_test_deps,
-                frameworks = frameworks,
-                testonly = testonly,
-                infoplists = select(infoplists),
-                **all_kwargs
-            )
-        test_suite_visibility = ios_test_kwargs.get("visibility", None)
-        test_suite_tags = ios_test_kwargs.get("tags", [])
-        native.test_suite(name = name, tests = tests, visibility = test_suite_visibility, tags = test_suite_tags)
-    else:
-        rule = test_rule
-        if runner:
-            if types.is_list(runner):
-                ios_test_kwargs["runners"] = runner
-                rule = test_suite_rule
-            else:
-                ios_test_kwargs["runner"] = runner
-
-        rule(
-            name = name,
-            deps = [dep_name] + internal_test_deps,
-            frameworks = frameworks,
-            infoplists = select(infoplists),
-            **ios_test_kwargs
-        )
-
-def ios_unit_test(name, apple_library = apple_library, **kwargs):
+def ios_unit_test(name, apple_library = apple_library, test_factory = default_test_factory, **kwargs):
     """
     Builds and packages iOS Unit Tests.
 
     Args:
         name: The name of the unit test.
         apple_library: The macro used to package sources into a library.
+        test_factory: Use this to generate other variations of tests.
         **kwargs: Arguments passed to the apple_library and ios_unit_test rules as appropriate.
     """
-    _ios_test(name, rules_apple_ios_unit_test, rules_apple_ios_unit_test_suite, apple_library, **kwargs)
+    _ios_test(name, _ios_internal_unit_test_bundle, _ios_unit_test, test_factory, apple_library, **kwargs)
 
-def ios_ui_test(name, apple_library = apple_library, **kwargs):
+def ios_ui_test(name, apple_library = apple_library, test_factory = default_test_factory, **kwargs):
     """
     Builds and packages iOS UI Tests.
 
     Args:
         name: The name of the UI test.
         apple_library: The macro used to package sources into a library.
+        test_factory: Use this to generate other variations of tests.
         **kwargs: Arguments passed to the apple_library and ios_ui_test rules as appropriate.
     """
     if not kwargs.get("test_host", None):
         fail("test_host is required for ios_ui_test.")
-    _ios_test(name, rules_apple_ios_ui_test, rules_apple_ios_ui_test_suite, apple_library, **kwargs)
+    _ios_test(name, _ios_internal_ui_test_bundle, _ios_ui_test, test_factory, apple_library, **kwargs)
 
-def ios_unit_snapshot_test(name, apple_library = apple_library, **kwargs):
+def ios_unit_snapshot_test(name, apple_library = apple_library, test_factory = default_test_factory, **kwargs):
     """
     Builds and packages iOS Unit Snapshot Tests.
 
     Args:
         name: The name of the UI test.
         apple_library: The macro used to package sources into a library.
+        test_factory: Use this to generate other variations of tests.
         **kwargs: Arguments passed to the apple_library and ios_unit_test rules as appropriate.
     """
-    _ios_test(name, rules_apple_ios_unit_test, rules_apple_ios_unit_test_suite, apple_library, internal_test_deps = ["@bazel_tools//tools/cpp/runfiles"], **kwargs)
+    _ios_test(name, _ios_internal_unit_test_bundle, _ios_unit_test, test_factory, apple_library, internal_test_deps = ["@bazel_tools//tools/cpp/runfiles"], **kwargs)


### PR DESCRIPTION
Add the ability to override stuff.

Test rules were impossible to extend and difficult reasoning about how it worked with rules_apple - which led to issues implementing new features like shard by class.

Test rules simply accept a `test_suite_factory`. On the default one, you can override some parts if necessary. _The default one could be much more generic - but at some point, I expect people to just make their own `test_suite_factory` VS adding too many abstractions to it_

Last: normalize all into a single bundle - otherwise it would duplicate tons of data and be un-useable at scale.