### PR TITLE
Make xcframework slices visibility public

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -289,6 +289,7 @@ def _xcframework_slice(*, xcframework_name, identifier, platform, platform_varia
             deps = [],
             dsym_imports = dsym_imports,
             tags = _MANUAL,
+            visibility = ["//visibility:public"],
         )
         import_headers, import_module_map, import_swiftmodules = _xcframework_slice_imports(path)
         _make_xcframework_vfs(import_headers, import_module_map, import_swiftmodules)
@@ -301,6 +302,7 @@ def _xcframework_slice(*, xcframework_name, identifier, platform, platform_varia
             ),
             deps = [],
             tags = _MANUAL,
+            visibility = ["//visibility:public"],
         )
         import_headers, import_module_map, import_swiftmodules = _xcframework_slice_imports(path)
         _make_xcframework_vfs(import_headers, import_module_map, import_swiftmodules)
@@ -316,6 +318,7 @@ def _xcframework_slice(*, xcframework_name, identifier, platform, platform_varia
             hdrs = import_headers,
             includes = includes,
             tags = _MANUAL,
+            visibility = ["//visibility:public"],
         )
         _make_xcframework_vfs(import_headers, import_module_map, import_swiftmodules, static = True)
     else:


### PR DESCRIPTION
The binary produced by the `apple_framework` that wraps `vendored_xcframeworks` is always empty instead of containing the symbols for the current architecture/platform like the underlying xcframeworks do.

My use case is "SwiftUI Previews", when depending on a target that transitively depends on such frameworks previews in Xcode crash due to missing symbols.

After navigating the code I'm not 100% sure if the empty binary is by design or not so proposing we make these public so consumers can take a dependency directly on the desired slice if needed.