### PR TITLE
Update to rules_apple 3.0.0

### DIFF
--- a/rules/import_middleman.bzl
+++ b/rules/import_middleman.bzl
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_apple//apple:providers.bzl", "AppleFrameworkImportInfo")
+load("@build_bazel_rules_apple//apple/internal:providers.bzl", "new_appleframeworkimportinfo")
 load("//rules:features.bzl", "feature_names")
 load("//rules/internal:objc_provider_utils.bzl", "objc_provider_utils")
 
@@ -69,7 +70,7 @@ def _make_imports(transitive_sets):
 
     # TODO: consider passing along the dsyms
     provider_fields["dsym_imports"] = depset()
-    return [AppleFrameworkImportInfo(**provider_fields)]
+    return [new_appleframeworkimportinfo(**provider_fields)]
 
 def _find_imports_impl(target, ctx):
     static_framework_file = []
@@ -211,10 +212,10 @@ def _file_collector_rule_impl(ctx):
     deduped_dynamic_framework = depset(_deduplicate_test_deps(test_linker_deps[2], exisiting_dynamic_framework.to_list()))
     dynamic_framework_file = []
     dynamic_framework_dirs = []
-    replaced_dyanmic_framework = {}
+    replaced_dynamic_framework = {}
     for f in input_dynamic_frameworks:
         out = _update_framework(ctx, f)
-        replaced_dyanmic_framework[f] = out
+        replaced_dynamic_framework[f] = out
         dynamic_framework_file.append(out)
         dynamic_framework_dirs.append(out)
 
@@ -226,12 +227,12 @@ def _file_collector_rule_impl(ctx):
         dynamic_framework_dirs.extend(ad_hoc_file)
 
     for f in deduped_dynamic_framework.to_list():
-        if not replaced_dyanmic_framework.get(f, False):
+        if not replaced_dynamic_framework.get(f, False):
             dynamic_framework_file.append(f)
             dynamic_framework_dirs.append(f)
     objc_provider_fields["dynamic_framework_file"] = depset(dynamic_framework_file)
 
-    replaced_frameworks = replaced_dyanmic_framework.values() + replaced_static_framework.replaced.values()
+    replaced_frameworks = replaced_dynamic_framework.values() + replaced_static_framework.replaced.values()
 
     compat_link_opt = ["-L__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator", "-Wl,-weak-lswiftCompatibility51"]
 

--- a/rules/internal/framework_middleman.bzl
+++ b/rules/internal/framework_middleman.bzl
@@ -1,9 +1,13 @@
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBundleInfo",
     "AppleResourceInfo",
     "IosFrameworkBundleInfo",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "new_applebundleinfo",
+    "new_iosframeworkbundleinfo",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:partials.bzl",
@@ -81,8 +85,8 @@ def _framework_middleman(ctx):
         dynamic_framework_provider,
         cc_info_provider,
         objc_provider,
-        IosFrameworkBundleInfo(),
-        AppleBundleInfo(
+        new_iosframeworkbundleinfo(),
+        new_applebundleinfo(
             archive = None,
             archive_root = None,
             binary = None,

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -344,8 +344,10 @@ def _xcframework(*, library_name, name, slices):
 
         for arch in archs:
             if platform == "ios":
-                if (arch == "armv7s" or arch == "arm64e"):
-                    # unsupported platform-arch by rules_apple
+                # unsupported platform-arch by rules_apple
+                unsupported_platforms = ["armv7", "armv7s", "i386"]
+
+                if arch in unsupported_platforms:
                     continue
                 elif platform_variant == "maccatalyst":
                     # TODO: support maccatalyst

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -57,22 +57,25 @@ def _get_bazel_version():
 
 def rules_ios_dependencies():
     """Fetches repositories that are dependencies of `rules_ios`"""
+
+    # rules_swift 1.10.0
     _maybe(
         github_repo,
         name = "build_bazel_rules_swift",
         project = "bazelbuild",
-        ref = "17e20f7edf27e647f1b45f11ed75d51c17820c3b",
+        ref = "267512835d70610865aa00300d317c3ef1e1f8bf",
         repo = "rules_swift",
-        sha256 = "d50c2cb6f1c2c30cf44a8ea60469cd399f7458061169bde76a177b63d6b74330",
+        sha256 = "4fdeb69da7a40155b2e10f431a6624bd767fb8983effba630cf12b7f34d24c83",
     )
 
+    # rules_apple 3.0.0
     _maybe(
         github_repo,
         name = "build_bazel_rules_apple",
-        ref = "915ac30a9fa1fd3809599a5ab90fa1c6640fe8dc",
+        ref = "55cf5c2bec04b05b9ab435e24174834c5681be12",
         project = "bazelbuild",
         repo = "rules_apple",
-        sha256 = "0204016496a39d5c70247650e098905d129f25347c7e1f019f838ca74252ce2d",
+        sha256 = "11422f86bf0dd6503b8b6b3eb0e9ab29e8c84db15ca38ea000935d1d020107e0",
     )
 
     _maybe(

--- a/rules/test.bzl
+++ b/rules/test.bzl
@@ -109,6 +109,7 @@ def _make_test(name, test_rule, **kwargs):
         test_host = kwargs.pop("test_host", None),
         deps = kwargs.pop("deps", []),
         testonly = kwargs.pop("testonly", True),
+        minimum_os_version = kwargs.pop("minimum_os_version"),
         **test_attrs
     )
 

--- a/rules/test/lldb/BUILD.bazel
+++ b/rules/test/lldb/BUILD.bazel
@@ -19,7 +19,7 @@ py_library(
 # Wrap this to feed into py_library - doesn't like the name with the dot in it
 genrule(
     name = "sim_template",
-    srcs = ["@build_bazel_rules_apple//apple/internal/templates:ios_sim_template"],
+    srcs = ["@build_bazel_rules_apple//apple/internal/templates:apple_simulator_template"],
     outs = ["sim_template.py"],
     cmd = "cp $(SRCS) $(OUTS)",
 )

--- a/tests/ios/app/BUILD.bazel
+++ b/tests/ios/app/BUILD.bazel
@@ -32,6 +32,7 @@ apple_framework(
 
 apple_framework(
     name = "Empty",
+    platforms = {"ios": "10.0"},
 )
 
 apple_framework(

--- a/tools/vmd/vm_test_runner.bzl
+++ b/tools/vmd/vm_test_runner.bzl
@@ -19,7 +19,7 @@
 """iOS test runner rule."""
 
 load(
-    "@build_bazel_rules_apple//apple/testing:apple_test_rules.bzl",
+    "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleTestRunnerInfo",
 )
 


### PR DESCRIPTION
## Changes
- **Uses new provider initialization pattern**
This is now private API in rules_apple as of https://github.com/bazelbuild/rules_apple/pull/2184 but visibility was relaxed in https://github.com/bazelbuild/rules_apple/pull/2225 to avoid breaking us.

- **Drops support for i386 slices in xcframeworks**
Dropped upstream in https://github.com/bazelbuild/rules_apple/pull/2155.

- **Passes through `minimum_os_version` to all test rules**
Required upstream in https://github.com/bazelbuild/rules_apple/pull/2124.

- **Uses new split transition**
Core's `apple_common.multi_arch_split` was removed in Bazel 7 and replaced by rules_apple's `apple_platform_split_transition`: https://github.com/bazelbuild/rules_apple/pull/2034

## Remaining work
- [ ] ~Update project generation rules~
- [x] Run buildifier
- [x] Decide if we should try to make these changes backwards-compatible **no**
- [x] Decide if this is a good time to drop Bazel 5 support **yes**