### PR TITLE
Using target name in bundle's plist path to avoid file writing clashes of Info.plist-root-control

### DIFF
--- a/rules/precompiled_apple_resource_bundle.bzl
+++ b/rules/precompiled_apple_resource_bundle.bzl
@@ -105,6 +105,9 @@ def _precompiled_apple_resource_bundle_impl(ctx):
         paths.join("%s-intermediates" % ctx.label.name, "Info.plist"),
     )
 
+    # as fake_rule_label is being used to get module_name for compiling xibs, storyboards, core data models etc.
+    # we have to change it to target name because of clashing writing actions when we build multiple targets with same module_name
+    partials_args["rule_label"] = Label("//fake_package:" + ctx.label.name)
     resource_actions.merge_root_infoplists(
         bundle_id = ctx.attr.bundle_id or bundle_identifier_for_bundle(bundle_name),
         input_plists = ctx.files.infoplists,


### PR DESCRIPTION
When I want to build 2 frameworks with same `module_name` `bazelisk build //Path/To/Target1 //Path/To/Target2`, there is an error thrown which says about clashing writing actions to the same destination: `/Path/ModuleName/Info.plist-root-control`.
In this PR, I've changed `module_name` from the path of the merging Info.plist to `target_name` so we could avoid this clash.
So the output would be:
`/Path/Target1/Info.plist-root-control` and `/Path/Target2/Info.plist-root-control`