### PR TITLE
Fix warnings for a missing base class and pointer mismatch

### DIFF
--- a/tests/macos/xcodeproj/NonArcObject.h
+++ b/tests/macos/xcodeproj/NonArcObject.h
@@ -1,2 +1,2 @@
-@interface NonArcObject
+@interface NonArcObject: NSObject
 @end

--- a/tools/xctest_absolute_source_locations/xctest_absolute_source_locations.m
+++ b/tools/xctest_absolute_source_locations/xctest_absolute_source_locations.m
@@ -11,7 +11,7 @@
 // @testBundle a string with the path:
 // e.g. "/Users/some/Library/Developer/Xcode/DerivedData/bazel-project-*/Build/Products/Debug-iphonesimulator/Some.xctest";
 // Note: this code is effectively a noop on other test runners than Xcode's GUI
-static NSURL *getWorkspacePath(NSURL *testBundle)
+static NSURL *getWorkspacePath(NSString *testBundle)
 {
     NSArray *components = testBundle.pathComponents;
     if (components.count < 4) {


### PR DESCRIPTION
Fixes warnings for a missing base case:

```
tests/macos/xcodeproj/NonArcObject.h:1:12: warning: class 'NonArcObject' defined without specifying a base class [-Wobjc-root-class]
@interface NonArcObject
           ^
tests/macos/xcodeproj/NonArcObject.h:1:24: note: add a super class to fix this problem
@interface NonArcObject
```

and a pointer mismatch:

```
tools/xctest_absolute_source_locations/xctest_absolute_source_locations.m:39:44: warning: incompatible pointer types passing 'NSString *' to parameter of type 'NSURL *' [-Wincompatible-pointer-types]
    NSURL *workspaceURL = getWorkspacePath(testBundlePath);
                                           ^~~~~~~~~~~~~~
tools/xctest_absolute_source_locations/xctest_absolute_source_locations.m:14:39: note: passing argument to parameter 'testBundle' here
static NSURL *getWorkspacePath(NSURL *testBundle)
```