### PR TITLE
[Bazel 6.x.x] sdk_dylib at _end_ of the linker invocation

### DIFF
--- a/tests/ios/unit-test/test-imports-app/BUILD.GoogleMobileAds
+++ b/tests/ios/unit-test/test-imports-app/BUILD.GoogleMobileAds
@@ -10,7 +10,7 @@ apple_static_framework_import(
         allow_empty = False,
     ),
     sdk_dylibs = [
-        "libsqlite3",
+        "libsqlite3.dylib",
         "libz",
     ],
     sdk_frameworks = [


### PR DESCRIPTION
Apple's > Xcode 4.x linkers have problems when SDK dylibs are first - Bazel 6.0 broke this due to refactoring. see changes in ( https://github.com/bazelbuild/bazel/blob/283ed362e6ccceb047553c2517a0331afd02db90/tools/osx/crosstool/cc_toolchain_config.bzl#L261 )

So this PR, is adding sdk_dylib to _end_ of the linker invocation to make this work as it did