### PR TITLE
Make update_in_place opt-in (true by default)

### DIFF
--- a/rules/import_middleman.bzl
+++ b/rules/import_middleman.bzl
@@ -16,6 +16,9 @@ _FindImportsAspectInfo = provider(fields = {
 })
 
 def _update_framework(ctx, framework):
+    if not ctx.attr.should_update_in_place:
+        return framework
+
     # Updates the `framework` for Apple Silicon
     out_file = ctx.actions.declare_file(ctx.attr.name + "/" + framework.basename + ".framework" + "/" + framework.basename)
     out_dir = ctx.actions.declare_file(ctx.attr.name + "/" + framework.basename + ".framework")
@@ -296,6 +299,7 @@ import_middleman = rule(
         "deps": attr.label_list(aspects = [find_imports]),
         "test_deps": attr.label_list(aspects = [find_imports], allow_empty = True),
         "update_in_place": attr.label(executable = True, default = Label("//tools/m1_utils:update_in_place"), cfg = "exec"),
+        "should_update_in_place": attr.bool(default = True),
     },
     doc = """
 This rule adds the ability to update the Mach-o header on imported

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -777,8 +777,9 @@ def apple_library(
         fail("no support for dynamic library: %s" % vendored_dynamic_library)
 
     # TODO(jmarino)Perhaps it uses a import_middleman here
+    should_update_in_place = kwargs.pop("should_update_in_place", True)
     if len(vendored_deps):
-        import_middleman(name = name + ".import_middleman", deps = vendored_deps, tags = ["manual"])
+        import_middleman(name = name + ".import_middleman", deps = vendored_deps, tags = ["manual"], should_update_in_place = should_update_in_place)
         deps += select({
             "@build_bazel_rules_ios//:arm64_simulator_use_device_deps": [name + ".import_middleman"],
             "//conditions:default": vendored_deps,


### PR DESCRIPTION
Due to the `codesign` issues being redirected [here](https://github.com/bazel-ios/rules_ios/blob/master/tools/m1_utils/update_dynamic.sh#L24-L29) SwiftUI Previews will crash in Xcode (using `rules_xcodeproj`) with
```sh
Exception Type:  EXC_BAD_ACCESS (SIGKILL (Code Signature Invalid))
```

This happens only in `vendored_xcframeworks` that already provide the slices I need for Apple Silicon so planning to conditionally disable this `update_in_place` logic only in "SwiftUI Previews" builds.

More generally how are we supposed to handle this `codesign` errors in `Debug` builds where a `provisioning_profile` is not set? My suggestion is to allow this conditional behavior while we discuss this, happy to file an issue if needed.