### PR TITLE
Update tart to 0.35.2 to cached version

### DIFF
--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -197,8 +197,8 @@ def _rules_ios_tool_dependencies():
     _maybe(
         http_file,
         name = "tart",
-        urls = ["https://github.com/cirruslabs/tart/releases/download/0.14.0/tart"],
-        sha256 = "2c61526aa07ade30ab6534b0fdc0a0edeb56ec2084dadee587e53c46e3a8edc3",
+        urls = ["https://github.com/bazel-ios/tart/releases/download/0.35.2/tart"],
+        sha256 = "7b9f4f37054483e565c760525b7e9e9097053c361dc16306583bb2981a29a6ec",
     )
 
     _maybe(


### PR DESCRIPTION
We saw these releases get deleted - use re-hosted cached sha

Further, fix issue with disk attachment in this release