### PR TITLE
Add Bazel central registry files

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,14 @@
+{
+  "homepage": "https://github.com/bazel-ios/rules_ios",
+  "maintainers": [
+    {
+      "email": "rules_ios@squareup.com",
+      "name": "rules_ios Maintainers"
+    }
+  ],
+  "repository": [
+    "github:bazel-ios/rules_ios"
+  ],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "e2e/bzlmod"
+  matrix:
+    platform: ["macos"]
+  tasks:
+    build_flags:
+      - "--config=ios"
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      build_targets:
+        - "//..."

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}.{TAG}.tar.gz"
+}

--- a/.github/workflows/generate_release_notes.sh
+++ b/.github/workflows/generate_release_notes.sh
@@ -14,6 +14,12 @@ readonly release_archive="rules_ios.$new_version.tar.gz"
 sha=$(shasum -a 256 "$release_archive" | cut -d " " -f1)
 
 cat <<EOF
+### Bzlmod Snippet
+
+\`\`\`bzl
+bazel_dep(name = "rules_ios", version = "$new_version", repo_name = "build_bazel_rules_ios")
+\`\`\`
+
 ### Workspace Snippet
 
 \`\`\`bzl

--- a/README.md
+++ b/README.md
@@ -22,12 +22,21 @@ for the documentation.
 
 ## Getting started
 
+### Bzlmod setup
+
+Add the Bazel module to your `MODULE.bazel` file:
+See the [latest release](https://github.com/bazel-ios/rules_ios/releases/latest) for an up-to-date snippet!
+
+```bzl
+bazel_dep(name = "rules_ios", version = "x.x.x", repo_name = "build_bazel_rules_ios")
+```
+
 ### WORKSPACE setup
 
 Add the following lines to your `WORKSPACE` file.
 See the [latest release](https://github.com/bazel-ios/rules_ios/releases/latest) for an up-to-date snippet!
 
-```python
+```bzl
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # See https://github.com/bazel-ios/rules_ios/releases/latest


### PR DESCRIPTION
Depends on #776.

This adds the required template files for https://github.com/bazel-contrib/publish-to-bcr an action which will publish to the Bazel central registry when new releases are tagged.

We'll need someone with repository admin access to approve the action configuration I requested. 