### PR TITLE
Update dependencies and use latest archives

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -174,10 +174,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Preflight Env
-        # stardoc latest version and bzlmod is broken with this in a few ways
-        # Please revert this to the version which worked reasonablly:
-        # https://github.com/bazelbuild/stardoc/issues/192
-        run: .github/workflows/preflight_env.sh --no-bzlmod
+        run: .github/workflows/preflight_env.sh
         # Note: we need to pass the absolute to the Bazel run
       - name: buildifier
         run: |

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,12 +15,12 @@ module(
 # Declare the bzlmod dependencies needed by rules_ios and users of rules_ios
 bazel_dep(
     name = "apple_support",
-    version = "1.6.0",
+    version = "1.11.1",
     repo_name = "build_bazel_apple_support",
 )
 bazel_dep(
     name = "rules_apple",
-    version = "3.0.0",
+    version = "3.1.1",
     repo_name = "build_bazel_rules_apple",
 )
 bazel_dep(
@@ -33,7 +33,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "rules_swift",
-    version = "1.8.0",
+    version = "1.13.0",
     repo_name = "build_bazel_rules_swift",
 )
 

--- a/data/BUILD.bazel
+++ b/data/BUILD.bazel
@@ -13,6 +13,5 @@ bzl_library(
         "xcspec_evals.bzl",
         "xcspecs.bzl",
     ],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
 )

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -33,7 +33,6 @@ _DOC_SRCS = [
         out = file + ".gen.md",
         input = "//rules:%s.bzl" % file,
         tags = [
-            "manual",
             "no-cache",
             "no-sandbox",  # https://github.com/bazelbuild/stardoc/issues/112
         ],
@@ -45,7 +44,6 @@ _DOC_SRCS = [
 filegroup(
     name = "_all_docs",
     srcs = ["%s.gen.md" % name for name in _DOC_SRCS],
-    tags = ["manual"],
 )
 
 genrule(
@@ -71,5 +69,4 @@ for s in $(SRCS); do
 done
     """,
     executable = 1,
-    tags = ["manual"],
 )

--- a/rules/BUILD.bazel
+++ b/rules/BUILD.bazel
@@ -14,14 +14,12 @@ genrule(
 bzl_library(
     name = "providers",
     srcs = ["providers.bzl"],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 
 bzl_library(
     name = "transition_support",
     srcs = ["transition_support.bzl"],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
         "@build_bazel_apple_support//lib:apple_support",
@@ -32,7 +30,6 @@ bzl_library(
 bzl_library(
     name = "hmap",
     srcs = ["hmap.bzl"],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = ["@build_bazel_rules_swift//swift"],
 )
@@ -40,21 +37,18 @@ bzl_library(
 bzl_library(
     name = "features",
     srcs = ["features.bzl"],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 
 bzl_library(
     name = "substitute_build_settings",
     srcs = ["substitute_build_settings.bzl"],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 
 bzl_library(
     name = "force_load_direct_deps",
     srcs = ["force_load_direct_deps.bzl"],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
         ":providers",
@@ -66,7 +60,6 @@ bzl_library(
 bzl_library(
     name = "xcconfig.doc",
     srcs = ["xcconfig.doc.bzl"],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = ["//rules/library:xcconfig"],
 )
@@ -74,7 +67,6 @@ bzl_library(
 bzl_library(
     name = "plists",
     srcs = ["plists.bzl"],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
         ":substitute_build_settings",
@@ -88,7 +80,6 @@ bzl_library(
 bzl_library(
     name = "vfs_overlay.doc",
     srcs = ["vfs_overlay.doc.bzl"],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = ["//rules/framework:vfs_overlay"],
 )
@@ -96,7 +87,6 @@ bzl_library(
 bzl_library(
     name = "precompiled_apple_resource_bundle",
     srcs = ["precompiled_apple_resource_bundle.bzl"],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
         ":transition_support",
@@ -111,7 +101,6 @@ bzl_library(
 bzl_library(
     name = "import_middleman",
     srcs = ["import_middleman.bzl"],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
         ":features",
@@ -124,7 +113,6 @@ bzl_library(
 bzl_library(
     name = "library",
     srcs = ["library.bzl"],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
         ":hmap",
@@ -149,7 +137,6 @@ bzl_library(
 bzl_library(
     name = "framework",
     srcs = ["framework.bzl"],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
         ":features",
@@ -172,7 +159,6 @@ bzl_library(
 bzl_library(
     name = "apple_patched",
     srcs = ["apple_patched.bzl"],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
         ":features",
@@ -186,7 +172,6 @@ bzl_library(
 bzl_library(
     name = "app_clip",
     srcs = ["app_clip.bzl"],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
         ":force_load_direct_deps",
@@ -199,7 +184,6 @@ bzl_library(
 bzl_library(
     name = "app",
     srcs = ["app.bzl"],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
         ":force_load_direct_deps",
@@ -213,7 +197,6 @@ bzl_library(
 bzl_library(
     name = "extension",
     srcs = ["extension.bzl"],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
         ":force_load_direct_deps",
@@ -228,7 +211,6 @@ bzl_library(
 bzl_library(
     name = "test",
     srcs = ["test.bzl"],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
         ":library",

--- a/rules/framework/BUILD.bazel
+++ b/rules/framework/BUILD.bazel
@@ -10,7 +10,6 @@ py_binary(
 bzl_library(
     name = "vfs_overlay",
     srcs = ["vfs_overlay.bzl"],
-    tags = ["manual"],
     visibility = ["//rules:__pkg__"],
     deps = [
         "//rules:features",

--- a/rules/internal/BUILD.bazel
+++ b/rules/internal/BUILD.bazel
@@ -3,14 +3,12 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 bzl_library(
     name = "objc_provider_utils",
     srcs = ["objc_provider_utils.bzl"],
-    tags = ["manual"],
     visibility = ["//rules:__pkg__"],
 )
 
 bzl_library(
     name = "framework_middleman",
     srcs = ["framework_middleman.bzl"],
-    tags = ["manual"],
     visibility = ["//rules:__pkg__"],
     deps = [
         ":objc_provider_utils",

--- a/rules/library/BUILD.bazel
+++ b/rules/library/BUILD.bazel
@@ -8,7 +8,6 @@ exports_files([
 bzl_library(
     name = "xcconfig",
     srcs = ["xcconfig.bzl"],
-    tags = ["manual"],
     visibility = ["//rules:__pkg__"],
     deps = [
         "//data:xcspecs",
@@ -21,6 +20,5 @@ bzl_library(
 bzl_library(
     name = "resources",
     srcs = ["resources.bzl"],
-    tags = ["manual"],
     visibility = ["//rules:__pkg__"],
 )

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -186,21 +186,17 @@ def _rules_ios_bzlmod_dependencies():
         # you'd like to set it. If you want to use a different rules_apple than
         # we have here - define rules_apple_api - to the value you'd like
         _maybe(
-            github_repo,
+            http_archive,
             name = "build_bazel_rules_swift",
-            project = "bazelbuild",
-            ref = "267512835d70610865aa00300d317c3ef1e1f8bf",
-            repo = "rules_swift",
-            sha256 = "4fdeb69da7a40155b2e10f431a6624bd767fb8983effba630cf12b7f34d24c83",
+            sha256 = "28a66ff5d97500f0304f4e8945d936fe0584e0d5b7a6f83258298007a93190ba",
+            url = "https://github.com/bazelbuild/rules_swift/releases/download/1.13.0/rules_swift.1.13.0.tar.gz",
         )
 
         _maybe(
-            github_repo,
+            http_archive,
             name = "build_bazel_rules_apple",
-            ref = "55cf5c2bec04b05b9ab435e24174834c5681be12",
-            project = "bazelbuild",
-            repo = "rules_apple",
-            sha256 = "11422f86bf0dd6503b8b6b3eb0e9ab29e8c84db15ca38ea000935d1d020107e0",
+            sha256 = "34c41bfb59cdaea29ac2df5a2fa79e5add609c71bb303b2ebb10985f93fa20e7",
+            url = "https://github.com/bazelbuild/rules_apple/releases/download/3.1.1/rules_apple.3.1.1.tar.gz",
         )
         _maybe(
             rules_apple_api,

--- a/rules/rules_apple_api/1_0/BUILD.bazel
+++ b/rules/rules_apple_api/1_0/BUILD.bazel
@@ -7,6 +7,8 @@ bzl_library(
         "providers.bzl",
         "version.bzl",
     ],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
+    deps = [
+        "@build_bazel_rules_apple//apple",
+    ],
 )

--- a/rules/rules_apple_api/2_0/BUILD.bazel
+++ b/rules/rules_apple_api/2_0/BUILD.bazel
@@ -7,6 +7,8 @@ bzl_library(
         "providers.bzl",
         "version.bzl",
     ],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
+    deps = [
+        "@build_bazel_rules_apple//apple",
+    ],
 )

--- a/rules/rules_apple_api/3_0/BUILD.bazel
+++ b/rules/rules_apple_api/3_0/BUILD.bazel
@@ -7,10 +7,8 @@ bzl_library(
         "providers.bzl",
         "version.bzl",
     ],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
-        "@build_bazel_apple_support//lib:apple_support",
         "@build_bazel_rules_apple//apple",
     ],
 )


### PR DESCRIPTION
Updates the dependencies of the latest versions, fixes some bzlmod warnings introduced by rules_apple 3 PR

```
WARNING: For repository 'build_bazel_apple_support', the root module requires module version apple_support@1.6.0, but got apple_support@1.11.0 in the resolved dependency graph.
WARNING: For repository 'build_bazel_rules_swift', the root module requires module version rules_swift@1.8.0, but got rules_swift@1.12.0 in the resolved dependency graph.
```

Additionally, moves the latest versions in `repositories.bzl` back to using the release archive instead of a GitHub on-demand archive. Not sure why those were changed

Finally, fixes issues with stardoc and rules_apple 3 + bzlmod.
It re-enables bzlmod for stardoc in CI

Fixes #783 