### PR TITLE
Remove dependency on rules_python

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -28,10 +28,6 @@ bazel_dep(
     version = "0.0.6",
 )
 bazel_dep(
-    name = "rules_python",
-    version = "0.24.0",
-)
-bazel_dep(
     name = "rules_swift",
     version = "1.13.0",
     repo_name = "build_bazel_rules_swift",
@@ -110,15 +106,4 @@ apple_non_module_deps = use_extension("@build_bazel_rules_apple//apple:extension
 use_repo(
     apple_non_module_deps,
     "xctestrunner",
-)
-
-# Register the Python toolchain
-python = use_extension("@rules_python//python/extensions:python.bzl", "python")
-python.toolchain(
-    is_default = True,
-    python_version = "3.9",
-)
-use_repo(
-    python,
-    "python_versions",
 )

--- a/data_generators/BUILD.bazel
+++ b/data_generators/BUILD.bazel
@@ -1,8 +1,7 @@
-load("@rules_python//python:defs.bzl", "py_binary")
-
 py_binary(
     name = "xcspec_extractor",
     srcs = ["xcspec_extractor.py"],
+    srcs_version = "PY3",
 )
 
 genrule(

--- a/rules/framework/BUILD.bazel
+++ b/rules/framework/BUILD.bazel
@@ -1,9 +1,9 @@
-load("@rules_python//python:defs.bzl", "py_binary")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 py_binary(
     name = "framework_packaging",
     srcs = ["framework_packaging.py"],
+    srcs_version = "PY3",
     visibility = ["//visibility:public"],
 )
 

--- a/rules/test/lldb/BUILD.bazel
+++ b/rules/test/lldb/BUILD.bazel
@@ -1,5 +1,3 @@
-load("@rules_python//python:defs.bzl", "py_library")
-
 package(default_visibility = ["//visibility:public"])
 
 exports_files([
@@ -14,6 +12,7 @@ py_library(
     srcs = [
         ":sim_template.py",
     ],
+    srcs_version = "PY3",
 )
 
 # Wrap this to feed into py_library - doesn't like the name with the dot in it
@@ -29,6 +28,7 @@ py_library(
     srcs = [
         "lldb_sim_runner.py",
     ],
+    srcs_version = "PY3",
     deps = [
         ":ios_sim_template_lib",
     ],

--- a/rules/test/lldb/lldb_test.bzl
+++ b/rules/test/lldb/lldb_test.bzl
@@ -1,4 +1,3 @@
-load("@rules_python//python:defs.bzl", "py_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 
 # End to end "Shell" test that a breakpoint can resolve a location
@@ -98,12 +97,13 @@ def _ios_breakpoint_test_wrapper(name, application, cmds, test_spec, sdk, device
         visibility = ["//visibility:public"],
     )
 
-    py_test(
+    native.py_test(
         name = name,
         main = "@build_bazel_rules_ios//rules/test/lldb:lldb_breakpoint_test_main.py",
         srcs = [
             "@build_bazel_rules_ios//rules/test/lldb:lldb_breakpoint_test_main.py",
         ],
+        srcs_version = "PY3",
         args = [
             "--app",
             "$(execpath " + application + ").app",

--- a/tools/xcodeproj_shims/BUILD.bazel
+++ b/tools/xcodeproj_shims/BUILD.bazel
@@ -1,5 +1,3 @@
-load("@rules_python//python:defs.bzl", "py_binary")
-
 STUB_VISIBILITY = ["//visibility:public"]
 
 sh_binary(
@@ -23,6 +21,7 @@ sh_binary(
 py_binary(
     name = "print_json_leaf_nodes",
     srcs = ["print_json_leaf_nodes.py"],
+    srcs_version = "PY3",
     visibility = STUB_VISIBILITY,
 )
 


### PR DESCRIPTION
For bzlmod you must declare dependency on things you `load`, in WORKSPACE mode `rules_python` is brought in transitively but in bzlmod we need to define this in `MODULE.bazel`.

Given that `rules_python` has beta support for bzlmod and that the Python rules we use are already part of the native rules, this PR removes all `load` of `rules_python` in favor of using the rules defined in the native module.

It also updates them to define the `PY3` source version.