### PR TITLE
Remove missing `output_discriminator` attribute usage

### DIFF
--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -136,7 +136,6 @@ def ios_application(
         deps = deps,
         frameworks = frameworks,
         families = families,
-        output_discriminator = None,
         infoplists = select(processed_infoplists),
         testonly = testonly,
         **application_kwargs

--- a/rules/app_clip.bzl
+++ b/rules/app_clip.bzl
@@ -84,7 +84,6 @@ def ios_app_clip(
         deps = deps,
         frameworks = frameworks,
         families = families,
-        output_discriminator = None,
         infoplists = select(processed_infoplists),
         testonly = testonly,
         **kwargs

--- a/rules/extension.bzl
+++ b/rules/extension.bzl
@@ -87,7 +87,6 @@ def ios_extension(
         deps = deps,
         families = families,
         frameworks = frameworks,
-        output_discriminator = None,
         infoplists = select(processed_infoplists),
         testonly = testonly,
         **kwargs


### PR DESCRIPTION
Fixes https://github.com/bazel-ios/rules_ios/issues/795. Bazel 7 seems to validate the usage of non-defined attributes better than Bazel 6 and lower.

~Testing Bazel 7 in CI using https://github.com/bazel-ios/rules_ios/pull/797.~ This gets us one step closer to being prepared for Bazel 7.