### PR TITLE
Conditionally handle `--apple_compiler` & `--apple_grte_top`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -61,6 +61,12 @@ use_repo(
     "rules_apple_api",
 )
 
+rules_ios_bazel_version_deps = use_extension("//rules:module_extensions.bzl", "rules_ios_bazel_version_deps")
+use_repo(
+    rules_ios_bazel_version_deps,
+    "rules_ios_bazel_version",
+)
+
 # Load non-bzlmod dependencies from rules_ios
 non_module_deps = use_extension("//rules:module_extensions.bzl", "non_module_deps")
 use_repo(

--- a/rules/BUILD.bazel
+++ b/rules/BUILD.bazel
@@ -22,6 +22,7 @@ bzl_library(
     srcs = ["transition_support.bzl"],
     visibility = ["//visibility:public"],
     deps = [
+        "//rules/internal:bazel_version",
         "@build_bazel_apple_support//lib:apple_support",
         "@rules_apple_api//:api",
     ],

--- a/rules/BUILD.bazel
+++ b/rules/BUILD.bazel
@@ -25,6 +25,7 @@ bzl_library(
         "//rules/internal:bazel_version",
         "@build_bazel_apple_support//lib:apple_support",
         "@rules_apple_api//:api",
+        "@rules_ios_bazel_version//:api",
     ],
 )
 

--- a/rules/internal/BUILD.bazel
+++ b/rules/internal/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 bzl_library(
+    name = "bazel_version",
+    srcs = ["bazel_version.bzl"],
+    visibility = ["//rules:__pkg__"],
+)
+
+bzl_library(
     name = "objc_provider_utils",
     srcs = ["objc_provider_utils.bzl"],
     visibility = ["//rules:__pkg__"],

--- a/rules/internal/bazel_version.bzl
+++ b/rules/internal/bazel_version.bzl
@@ -1,0 +1,20 @@
+"Bazel version parsing"
+
+def get_bazel_version(bazel_version = getattr(native, "bazel_version", "")):
+    """
+    Parse the Bazel version into a `struct`.
+
+    Args:
+        bazel_version: String representing the Bazel version.
+
+    Returns:
+        Bazel version represented as a `struct` with the major, minor, and path
+        attributes.
+    """
+    if bazel_version:
+        parts = bazel_version.split(".")
+        if len(parts) > 2:
+            return struct(major = parts[0], minor = parts[1], patch = parts[2])
+
+    # Unknown, but don't crash
+    return struct(major = 0, minor = 0, patch = 0)

--- a/rules/module_extensions.bzl
+++ b/rules/module_extensions.bzl
@@ -3,6 +3,7 @@
 load(
     "//rules:repositories.bzl",
     "rules_apple_api",
+    "rules_ios_bazel_version",
     "rules_ios_dependencies",
     "rules_ios_dev_dependencies",
 )
@@ -18,6 +19,13 @@ def _rules_apple_api(_):
     )
 
 rules_apple_api_deps = module_extension(implementation = _rules_apple_api)
+
+def _rules_ios_bazel_version(_):
+    rules_ios_bazel_version(
+        name = "rules_ios_bazel_version",
+    )
+
+rules_ios_bazel_version_deps = module_extension(implementation = _rules_ios_bazel_version)
 
 def _non_module_deps_impl(_):
     rules_ios_dependencies(

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -93,8 +93,8 @@ def _rules_apple_api_impl(ctx):
     # the interface.
     base_path = str(ctx.path(ctx.attr.rules_ios).dirname)
 
-    rules_apple_path = base_path + "/rules/rules_apple_api/" + ctx.attr.version
-    ctx.symlink(rules_apple_path, "")
+    path = base_path + "/rules/rules_apple_api/" + ctx.attr.version
+    ctx.symlink(path, "")
 
 rules_apple_api = repository_rule(
     implementation = _rules_apple_api_impl,
@@ -106,7 +106,17 @@ rules_apple_api = repository_rule(
 )
 
 def _rules_ios_bazel_version_impl(ctx):
-    ctx.file("BUILD.bazel", content = "")
+    ctx.file("BUILD.bazel", content = """
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "api",
+    srcs = [
+        "version.bzl",
+    ],
+    visibility = ["//visibility:public"],
+)
+""")
 
     # Write Bazel version to a file
     ctx.file("version.bzl", content = "bazel_version = \"{}\"".format(ctx.attr._bazel_version))


### PR DESCRIPTION
- Create a new repo rule that contains the Bazel version for access in the analysis phase (`rules_ios_bazel_version`). This will just write the version from `getattr(native, "bazel_version", “”)` into a variable in `@rules_ios_bazel_version//:version.bzl`
- Use the Bazel version to conditionally handle the (now removed in Bazel 7) `--apple_compiler` & `--apple_grte_top` command line options.
  - `apple_grte_top` removed in https://github.com/bazelbuild/bazel/commit/fb4106bdbd23c365337ea99704921ada7b86c2df
  - `apple_compiler` removed in https://github.com/bazelbuild/bazel/commit/1acdfc422e724b4fe12c7bf5248086ab514ec4be

Work towards https://github.com/bazel-ios/rules_ios/issues/795.