### PR TITLE
Decouple CI & remote cache config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -56,17 +56,18 @@ build:ios_multi_arch_test --ios_minimum_os=10.2
 build:ios_multi_arch_test --ios_multi_cpus=i386,x86_64
 
 # - Remote cache configuration
-build:ci_with_caches --bes_backend=grpcs://remote.buildbuddy.io
-build:ci_with_caches --bes_results_url=https://app.buildbuddy.io/invocation/
-build:ci_with_caches --experimental_build_event_upload_strategy=local
-build:ci_with_caches --experimental_remote_cache_compression
-build:ci_with_caches --experimental_remote_merkle_tree_cache
-build:ci_with_caches --modify_execution_info=^(BitcodeSymbolsCopy|BundleApp|BundleTreeApp|DsymDwarf|DsymLipo|GenerateAppleSymbolsFile|ObjcBinarySymbolStrip|CppLink|ObjcLink|ProcessAndSign|SignBinary|SwiftArchive|SwiftStdlibCopy)$=+no-remote,^(BundleResources|ImportedDynamicFrameworkProcessor)$=+no-remote-exec
-build:ci_with_caches --nolegacy_important_outputs
-build:ci_with_caches --noslim_profile
-build:ci_with_caches --remote_cache=grpcs://remote.buildbuddy.io
-build:ci_with_caches --remote_timeout=3600
-build:ci_with_caches --config=ci
+build:ci_with_caches --config=ci --config=remote_cache
+
+build:remote_cache --bes_backend=grpcs://remote.buildbuddy.io
+build:remote_cache --bes_results_url=https://app.buildbuddy.io/invocation/
+build:remote_cache --experimental_build_event_upload_strategy=local
+build:remote_cache --experimental_remote_cache_compression
+build:remote_cache --experimental_remote_merkle_tree_cache
+build:remote_cache --modify_execution_info=^(BitcodeSymbolsCopy|BundleApp|BundleTreeApp|DsymDwarf|DsymLipo|GenerateAppleSymbolsFile|ObjcBinarySymbolStrip|CppLink|ObjcLink|ProcessAndSign|SignBinary|SwiftArchive|SwiftStdlibCopy)$=+no-remote,^(BundleResources|ImportedDynamicFrameworkProcessor)$=+no-remote-exec
+build:remote_cache --nolegacy_important_outputs
+build:remote_cache --noslim_profile
+build:remote_cache --remote_cache=grpcs://remote.buildbuddy.io
+build:remote_cache --remote_timeout=3600
 
 # By default don't upload local results to remote cache, only CI does this.
 build --noremote_upload_local_results


### PR DESCRIPTION
Allow users to add `--config=remote_cache` to `user.bazelrc` without all the other `ci` config flags from `ci_with_caches`.