### PR TITLE
Update precompiled_apple_resource_bundle to not include executable_name

### DIFF
--- a/rules/precompiled_apple_resource_bundle.bzl
+++ b/rules/precompiled_apple_resource_bundle.bzl
@@ -56,10 +56,14 @@ def _precompiled_apple_resource_bundle_impl(ctx):
         platform_prerequisites_version_args = {
             "build_settings": None,
         }
+        rules_api_3_resource_partials_args = {
+            "include_executable_name": False,  # Must be set to False or bundle_name is now used if executable_name is None
+        }
     else:
         platform_prerequisites_version_args = {
             "disabled_features": ctx.disabled_features,
         }
+        rules_api_3_resource_partials_args = {}
 
     platform_prerequisites = platform_support.platform_prerequisites(
         apple_fragment = ctx.fragments.apple,
@@ -90,6 +94,7 @@ def _precompiled_apple_resource_bundle_impl(ctx):
         ),
         rule_label = fake_rule_label,
         version = None,
+        **rules_api_3_resource_partials_args
     )
 
     apple_mac_toolchain_info = ctx.attr._toolchain[AppleMacToolsToolchainInfo]


### PR DESCRIPTION
Fixes #800

Recent changes have made it so that `bundle_name` OR `executable_name` are used for the `CFExecutable` plist substitution: https://github.com/bazelbuild/rules_apple/commit/f909b0b6f31dee7ee9ba9998a92404eaeb7af727#diff-fd21ff183af5a0af8861d50117a7a377b04a0b7d9924600f424261b7db57e2deL279

This causes App store rejection, we should set `include_executable_name` to `False` to ensure its not substituted/included in the plist.