### PR TITLE
Add option to disable modulemap generation

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -552,6 +552,7 @@ def apple_library(
     # * Optionally, allow the consumers to set generate_default_umbrella_header to False, so the
     #   generated umbrella header does not contain any imports
     generate_default_umbrella_header = kwargs.pop("generate_default_umbrella_header", True)
+    generate_default_modulemap = kwargs.pop("generate_default_modulemap", True)
     cc_copts = kwargs.pop("cc_copts", [])
     additional_cc_copts = []
     swift_copts = kwargs.pop("swift_copts", [])
@@ -823,16 +824,17 @@ def apple_library(
             )
             if umbrella_header:
                 objc_hdrs.append(umbrella_header)
-            module_map = library_tools["modulemap_generator"](
-                name = name,
-                library_tools = library_tools,
-                umbrella_header = paths.basename(umbrella_header),
-                public_headers = objc_hdrs,
-                private_headers = objc_private_hdrs,
-                module_name = module_name,
-                framework = True,
-                **kwargs
-            )
+            if generate_default_modulemap:
+                module_map = library_tools["modulemap_generator"](
+                    name = name,
+                    library_tools = library_tools,
+                    umbrella_header = paths.basename(umbrella_header),
+                    public_headers = objc_hdrs,
+                    private_headers = objc_private_hdrs,
+                    module_name = module_name,
+                    framework = True,
+                    **kwargs
+                )
 
     framework_vfs_overlay(
         name = framework_vfs_overlay_name_swift,

--- a/tests/ios/frameworks/no-module-map/BUILD.bazel
+++ b/tests/ios/frameworks/no-module-map/BUILD.bazel
@@ -1,0 +1,12 @@
+load("//rules:framework.bzl", "apple_framework")
+
+apple_framework(
+    name = "a",
+    srcs = glob(["*.swift"]),
+    generate_default_modulemap = False,
+    infoplists = ["//rules/test_host_app:Info.plist"],
+    platforms = {"ios": "10.0"},
+    skip_packaging = ["infoplist"],
+    visibility = ["//visibility:public"],
+    deps = ["//tests/ios/frameworks/strict-deps/b"],
+)

--- a/tests/ios/frameworks/no-module-map/lib.swift
+++ b/tests/ios/frameworks/no-module-map/lib.swift
@@ -1,0 +1,5 @@
+import b
+
+struct A {
+    public static func run() { B.run() }
+}


### PR DESCRIPTION
When maintaining two build systems (Xcode and Bazel) it's useful to be able to configure what is and isn't generated. In our case, we only generate modulemaps for frameworks which enable this feature in our Xcode setup. In bazel however, this file is generated regardless.

This leads to build inconsistency where Xcode fails to build because a missing modulemap is not found while Bazel continues to pass since these are always generated.

Instead, we should allow users to enable/disable this behavior. With this change `generate_default_modulemap` will be defaulted to `True` (so no changes here) unless you set to `False` in which case no modulemap is generated. 