### PR TITLE
Fix pkg_resources module not found in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,9 @@ jobs:
           # Clean up after simctl (https://github.com/bazelbuild/rules_apple/issues/185)
           pgrep Simulator | xargs kill || true
 
+          # GitHub runners are hitting 'module not found pkg_resources' required by prepare_sim.py
+          pip install setuptools
+
           # Create single ephemeral iOS sim
           SIMULATOR_UDID=$(./tools/tests/prepare_sim.py)
 


### PR DESCRIPTION
This script seems to be failing [here](https://github.com/bazel-ios/rules_ios/actions/runs/6788374457/job/18454172023?pr=803), this works locally so trying to re-install the module before.
