### PR TITLE
Ignore MODULE.bazel.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/MODULE.bazel.lock
 bazel-*
 .idea
 tests/macos/xcodeproj/**/xcuserdata


### PR DESCRIPTION
This file is generated by default by bazel @ HEAD but we don't really want to manage it. This way it can be generated locally and folks can build offline if they have generated it at least once.