### PR TITLE
Add `toolchains` to rules that use `@bazel_tools//tools/cpp:toolchain_type`

### DIFF
--- a/rules/apple_patched.bzl
+++ b/rules/apple_patched.bzl
@@ -144,6 +144,7 @@ def _apple_framework_import_modulemap_impl(ctx):
 
 _apple_framework_import_modulemap = rule(
     implementation = _apple_framework_import_modulemap_impl,
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
     fragments = ["apple"],
     attrs = {
         "legacy_target": attr.label(

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -1191,6 +1191,7 @@ def _apple_framework_packaging_impl(ctx):
 
 apple_framework_packaging = rule(
     implementation = _apple_framework_packaging_impl,
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
     cfg = transition_support.apple_rule_transition,
     fragments = ["apple", "cpp", "objc"],
     output_to_genfiles = True,

--- a/rules/framework/vfs_overlay.bzl
+++ b/rules/framework/vfs_overlay.bzl
@@ -424,6 +424,7 @@ def make_vfsoverlay(ctx, hdrs, module_map, private_hdrs, has_swift, swiftmodules
 
 framework_vfs_overlay = rule(
     implementation = _framework_vfs_overlay_impl,
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
     attrs = {
         "framework_name": attr.string(mandatory = True),
         "extra_search_paths": attr.string(mandatory = False),


### PR DESCRIPTION
Fix the following from https://github.com/bazel-ios/rules_ios/issues/795:
```
Error in fail: In order to use find_cpp_toolchain, you must include the '@bazel_tools//tools/cpp:toolchain_type' in the toolchains argument to your rule.
```