### PR TITLE
Produce an alias for an xcframework's `ios_sim_arm64` slice if available

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -345,14 +345,13 @@ def _xcframework(*, library_name, name, slices):
                 elif arch == "arm64":
                     if platform_variant == "simulator":
                         arm64_simulator_slice = name
-
-                        # Skip this - it's later defined
-                        continue
                     else:
                         arm64_ios_device_slice = name
 
             rules_apple_platfrom = "darwin" if platform == "macos" else platform
-            arch_setting = "@build_bazel_rules_apple//apple:{}_{}".format(rules_apple_platfrom, arch)
+            arch_prefix = "sim_" if platform_variant == "simulator" and arch == "arm64" else ""
+            arch_setting = "@build_bazel_rules_apple//apple:{}_{}{}".format(rules_apple_platfrom, arch_prefix, arch)
+
             config_setting_name = "{}-{}".format(
                 xcframework_name,
                 "_".join([x for x in (platform, platform_variant, arch) if x]),


### PR DESCRIPTION
If `apple.arm64_simulator_use_device_deps` is False, an xcframework providing slices for `ios-arm64` and `ios-arm64_x86_64-simulator` wouldn't select the second slice for an `ios_sim_arm64` build.  

```
ERROR: SomeFramework/BUILD.bazel:11:15: configurable attribute "actual" in //SomeFramework:SomeFramework-import-SomeFramework.xcframeworkdefault_vfs doesn't match this configuration. Would a default condition help?

Conditions checked:
 //SomeFramework:SomeFramework-import-SomeFramework.xcframework-ios_arm64
 //SomeFramework:SomeFramework-import-SomeFramework.xcframework-ios_simulator_x86_64
```

The configuration being built had these values:

```
FragmentOptions com.google.devtools.build.lib.analysis.config.CoreOptions {
  cpu: ios_sim_arm64
  host_cpu: darwin_arm64
  ...
}

FragmentOptions com.google.devtools.build.lib.rules.apple.AppleCommandLineOptions {
  apple_platform_type: ios
  apple_split_cpu: sim_arm64
  ios_multi_cpus: [sim_arm64]
  ...
}
```

This change emits a new condtion for `//SomeFramework:SomeFramework-import-SomeFramework.xcframework-ios_simulator_arm64` that matches `@build_bazel_rules_apple//apple:ios_sim_arm64` to the `SomeFrameowrk.xcframework-ios-arm64_x86_64-simulator` slice.