### PR TITLE
Allow frameworks parameter to be used in ios_application

### DIFF
--- a/rules/app.bzl
+++ b/rules/app.bzl
@@ -114,7 +114,7 @@ def ios_application(
         platform_type = "ios",
         minimum_os_version = application_kwargs.get("minimum_os_version"),
     )
-    frameworks = [fw_name] + kwargs.pop("frameworks", [])
+    frameworks = [fw_name] + application_kwargs.pop("frameworks", [])
 
     dep_name = name + ".dep_middleman"
     dep_middleman(

--- a/tests/ios/frameworks/dynamic/BUILD.bazel
+++ b/tests/ios/frameworks/dynamic/BUILD.bazel
@@ -17,6 +17,22 @@ ios_application(
 )
 
 ios_application(
+    name = "AppWithFrameworks",
+    srcs = ["App/main.m"],
+    bundle_id = "com.example.app",
+    frameworks = [
+        "//tests/ios/frameworks/dynamic/a",
+    ],
+    minimum_os_version = "10.0",
+    visibility = ["//visibility:public"],
+    # This should automatically bake in a,b
+    deps = [
+        "//tests/ios/frameworks/dynamic/a",
+        "//tests/ios/frameworks/dynamic/a:aWithResourceBundles",
+    ],
+)
+
+ios_application(
     name = "AppWithExtension",
     srcs = ["App/main.m"],
     bundle_id = "com.example.app",


### PR DESCRIPTION
- Before this change, using the "frameworks" parameter in ios_application resulted in an error: "Error in ios_application: rule(...) got multiple values for parameter 'frameworks'" because we are passing "application_kwargs" into the rules_apple rule which has the "frameworks" parameter copied over from "kwargs". Making this change actually pops the parameter from the correct dictionary which will remove the duplication error.