### PR TITLE
Allow select in test_host parameter

### DIFF
--- a/rules/internal/framework_middleman.bzl
+++ b/rules/internal/framework_middleman.bzl
@@ -216,11 +216,6 @@ def _dep_middleman(ctx):
             for lib_dep in dep[AvoidDepsInfo].libraries:
                 _collect_providers(lib_dep)
 
-    # Pull AvoidDeps from test deps
-    for dep in (ctx.attr.test_deps if ctx.attr.test_deps else []):
-        if AvoidDepsInfo in dep:
-            _process_avoid_deps(dep[AvoidDepsInfo].libraries)
-
     # Merge the entire provider here
     objc_provider_fields = objc_provider_utils.merge_objc_providers_dict(providers = objc_providers, merge_keys = [
         "force_load_library",
@@ -270,10 +265,6 @@ dep_middleman = rule(
             doc =
                 """Deps that may contain frameworks
 """,
-        ),
-        "test_deps": attr.label_list(
-            cfg = transition_support.split_transition,
-            allow_empty = True,
         ),
         "platform_type": attr.string(
             mandatory = False,

--- a/rules/test.bzl
+++ b/rules/test.bzl
@@ -184,11 +184,6 @@ def _ios_test(name, bundle_rule, test_rule, test_factory, apple_library, infopli
     if split_name_to_kwargs:
         ios_test_kwargs["split_name_to_kwargs"] = split_name_to_kwargs
 
-    # Deduplicate against the test deps
-    if ios_test_kwargs.get("test_host", None):
-        host_args = [ios_test_kwargs["test_host"]]
-    else:
-        host_args = []
     library = apple_library(name = name, namespace_is_module_name = False, platforms = {"ios": ios_test_kwargs.get("minimum_os_version")}, testonly = testonly, **kwargs)
 
     # Setup framework middlemen - need to process deps and libs
@@ -209,7 +204,6 @@ def _ios_test(name, bundle_rule, test_rule, test_factory, apple_library, infopli
         deps = kwargs.get("deps", []) + library.lib_names,
         testonly = testonly,
         tags = ["manual"],
-        test_deps = host_args,
         platform_type = "ios",
         minimum_os_version = ios_test_kwargs.get("minimum_os_version"),
     )

--- a/tests/ios/unit-test/BUILD.bazel
+++ b/tests/ios/unit-test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("//rules:test.bzl", "ios_unit_test")
 
 ios_unit_test(
@@ -31,6 +32,33 @@ ios_unit_test(
     ],
     minimum_os_version = "12.0",
     test_host = "//rules/test_host_app:iOS-9.3-AppHost",
+    # Adding visibility so the xcodeproject tests can depend on this target
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "other_test_host",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "use_other_test_host",
+    flag_values = {
+        "//tests/ios/unit-test:other_test_host": "True",
+    },
+)
+
+ios_unit_test(
+    name = "ExplicitHostedWithSelect",
+    srcs = [
+        "empty.m",
+        "empty.swift",
+    ],
+    minimum_os_version = "12.0",
+    test_host = select({
+        "//tests/ios/unit-test:use_other_test_host": "//rules/test_host_app:iOS-9.3-AppHost",
+        "//conditions:default": "//rules/test_host_app:iOS-14.0-AppHost",
+    }),
     # Adding visibility so the xcodeproject tests can depend on this target
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Previously, using a `select` in the `test_host` parameter would result in the error:

```
ERROR: rules_ios/tests/ios/unit-test/BUILD.bazel:51:14: //tests/ios/unit-test:ExplicitHostedWithSelect.dep_middleman: expected value of type 'string' for element 0 of attribute 'test_deps' in 'dep_middleman' rule, but got select({"//tests/ios/unit-test:use_other_test_host": "//rules/test_host_app:iOS-9.3-AppHost", "//conditions:default": "//rules/test_host_app:iOS-14.0-AppHost"}) (select)
```

I simply removed the `test_deps` parameter as that wasn't really being used for anything of value that I could see. It was only ever being set to the `test_host` parameter or an empty list of which neither contain the `AvoidDepsInfo` information that was being deduplicated.