### PR TITLE
Update MODULE.bazel to exclude Bazel 7 and newer

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,13 @@ Defines all the external repositories and dependencies for rules_ios.
 module(
     name = "rules_ios",
     version = "0",
-    bazel_compatibility = [">=5.0.0"],
+    bazel_compatibility = [
+        ">=5.0.0",
+        # Temporarily limit the usage of Bazel 7+ until
+        # https://github.com/bazel-ios/rules_ios/issues/795
+        # is complete.
+        "<7.0.0",
+    ],
     compatibility_level = 1,
     repo_name = "build_bazel_rules_ios",
 )


### PR DESCRIPTION
This is more correct but also an attempt to fix the BCR issues in, for example, https://github.com/bazelbuild/bazel-central-registry/pull/1250.