### PR TITLE
Pin BCR presubmit CI to Bazel 6.4.0

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,3 +1,4 @@
+bazel: 6.4.0
 tasks:
   verify_build_targets:
     name: Verify Build targets on macOS


### PR DESCRIPTION
This allowed https://github.com/bazelbuild/bazel-central-registry/pull/1250 to get through Bazel CI.