### PR TITLE
Ensure -import-underlying-module gets into the generated Xcode project

### DIFF
--- a/rules/legacy_xcodeproj.bzl
+++ b/rules/legacy_xcodeproj.bzl
@@ -127,6 +127,13 @@ def _xcodeproj_aspect_collect_swift_copts(deps, ctx):
     copts = None
     if ctx.rule.kind == "swift_library":
         copts = _make_swift_copts(deps)
+
+        # Ensures `-import-underlying-module` gets into the generated Xcode project if applied,
+        # otherwise indexing might fail in mixed modules
+        # https://github.com/bazel-ios/rules_ios/blob/883cc859daffb1f02bd0e153fca39177d2fa7eb4/rules/library.bzl#L923
+        if hasattr(ctx.rule.attr, "copts"):
+            if "-import-underlying-module" in ctx.rule.attr.copts:
+                copts += ["-import-underlying-module"]
     else:
         for dep in deps:
             if _SrcsInfo in dep:


### PR DESCRIPTION
So [OTHER_SWIFT_FLAGS](https://github.com/bazel-ios/rules_ios/blob/883cc859daffb1f02bd0e153fca39177d2fa7eb4/rules/legacy_xcodeproj.bzl#L836) gets `-import-underlying-module` if present. Without this indexing might fail in mixed modules.

I'm not sure why the aspect is not propagating the direct `copts` here and I'd rather not propagate everything and risk breaking the experience for folks. This legacy generator is going to be less and less maintained over time so not worth the effort of digging more here IMO (open to suggestions if anyone feels strongly about fixing all things `copts` in follow PRs).