### PR TITLE
[DNR][DNM] LLDB crash Xcode 15.x

### DIFF
--- a/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Single-Static-Framework-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -103,3 +103,7 @@ then
 settings append target.source-map ./external/ "$BAZEL_EXTERNAL_DIRNAME"
 END
 fi
+
+# Xcode 15.x: Fixes a problem in the flag parser of LLDB 15.1 potentially causing LLDB to crash
+sed -i '' 's, -vfsoverlay, -vfsoverlay ,g' $BAZEL_LLDB_INIT_FILE
+sed -i '' 's, -ivfsoverlay, -ivfsoverlay ,g' $BAZEL_LLDB_INIT_FILE

--- a/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-BuildForDevice-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -103,3 +103,7 @@ then
 settings append target.source-map ./external/ "$BAZEL_EXTERNAL_DIRNAME"
 END
 fi
+
+# Xcode 15.x: Fixes a problem in the flag parser of LLDB 15.1 potentially causing LLDB to crash
+sed -i '' 's, -vfsoverlay, -vfsoverlay ,g' $BAZEL_LLDB_INIT_FILE
+sed -i '' 's, -ivfsoverlay, -ivfsoverlay ,g' $BAZEL_LLDB_INIT_FILE

--- a/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-Imports-App-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -103,3 +103,7 @@ then
 settings append target.source-map ./external/ "$BAZEL_EXTERNAL_DIRNAME"
 END
 fi
+
+# Xcode 15.x: Fixes a problem in the flag parser of LLDB 15.1 potentially causing LLDB to crash
+sed -i '' 's, -vfsoverlay, -vfsoverlay ,g' $BAZEL_LLDB_INIT_FILE
+sed -i '' 's, -ivfsoverlay, -ivfsoverlay ,g' $BAZEL_LLDB_INIT_FILE

--- a/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -103,3 +103,7 @@ then
 settings append target.source-map ./external/ "$BAZEL_EXTERNAL_DIRNAME"
 END
 fi
+
+# Xcode 15.x: Fixes a problem in the flag parser of LLDB 15.1 potentially causing LLDB to crash
+sed -i '' 's, -vfsoverlay, -vfsoverlay ,g' $BAZEL_LLDB_INIT_FILE
+sed -i '' 's, -ivfsoverlay, -ivfsoverlay ,g' $BAZEL_LLDB_INIT_FILE

--- a/tests/ios/xcodeproj/Test-Mixed-Dynamic-App-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-Mixed-Dynamic-App-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -103,3 +103,7 @@ then
 settings append target.source-map ./external/ "$BAZEL_EXTERNAL_DIRNAME"
 END
 fi
+
+# Xcode 15.x: Fixes a problem in the flag parser of LLDB 15.1 potentially causing LLDB to crash
+sed -i '' 's, -vfsoverlay, -vfsoverlay ,g' $BAZEL_LLDB_INIT_FILE
+sed -i '' 's, -ivfsoverlay, -ivfsoverlay ,g' $BAZEL_LLDB_INIT_FILE

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project-WithTransitiveFlag.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -103,3 +103,7 @@ then
 settings append target.source-map ./external/ "$BAZEL_EXTERNAL_DIRNAME"
 END
 fi
+
+# Xcode 15.x: Fixes a problem in the flag parser of LLDB 15.1 potentially causing LLDB to crash
+sed -i '' 's, -vfsoverlay, -vfsoverlay ,g' $BAZEL_LLDB_INIT_FILE
+sed -i '' 's, -ivfsoverlay, -ivfsoverlay ,g' $BAZEL_LLDB_INIT_FILE

--- a/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-MultipleConfigs-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -103,3 +103,7 @@ then
 settings append target.source-map ./external/ "$BAZEL_EXTERNAL_DIRNAME"
 END
 fi
+
+# Xcode 15.x: Fixes a problem in the flag parser of LLDB 15.1 potentially causing LLDB to crash
+sed -i '' 's, -vfsoverlay, -vfsoverlay ,g' $BAZEL_LLDB_INIT_FILE
+sed -i '' 's, -ivfsoverlay, -ivfsoverlay ,g' $BAZEL_LLDB_INIT_FILE

--- a/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/Test-With-Host-App-With-AdditionalPrebuildScript.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -103,3 +103,7 @@ then
 settings append target.source-map ./external/ "$BAZEL_EXTERNAL_DIRNAME"
 END
 fi
+
+# Xcode 15.x: Fixes a problem in the flag parser of LLDB 15.1 potentially causing LLDB to crash
+sed -i '' 's, -vfsoverlay, -vfsoverlay ,g' $BAZEL_LLDB_INIT_FILE
+sed -i '' 's, -ivfsoverlay, -ivfsoverlay ,g' $BAZEL_LLDB_INIT_FILE

--- a/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/TestWithHostApp.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -103,3 +103,7 @@ then
 settings append target.source-map ./external/ "$BAZEL_EXTERNAL_DIRNAME"
 END
 fi
+
+# Xcode 15.x: Fixes a problem in the flag parser of LLDB 15.1 potentially causing LLDB to crash
+sed -i '' 's, -vfsoverlay, -vfsoverlay ,g' $BAZEL_LLDB_INIT_FILE
+sed -i '' 's, -ivfsoverlay, -ivfsoverlay ,g' $BAZEL_LLDB_INIT_FILE

--- a/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/ios/xcodeproj/custom_output_path/Test-LLDB-Logs-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -103,3 +103,7 @@ then
 settings append target.source-map ./external/ "$BAZEL_EXTERNAL_DIRNAME"
 END
 fi
+
+# Xcode 15.x: Fixes a problem in the flag parser of LLDB 15.1 potentially causing LLDB to crash
+sed -i '' 's, -vfsoverlay, -vfsoverlay ,g' $BAZEL_LLDB_INIT_FILE
+sed -i '' 's, -ivfsoverlay, -ivfsoverlay ,g' $BAZEL_LLDB_INIT_FILE

--- a/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-AllTargets.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -103,3 +103,7 @@ then
 settings append target.source-map ./external/ "$BAZEL_EXTERNAL_DIRNAME"
 END
 fi
+
+# Xcode 15.x: Fixes a problem in the flag parser of LLDB 15.1 potentially causing LLDB to crash
+sed -i '' 's, -vfsoverlay, -vfsoverlay ,g' $BAZEL_LLDB_INIT_FILE
+sed -i '' 's, -ivfsoverlay, -ivfsoverlay ,g' $BAZEL_LLDB_INIT_FILE

--- a/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Single-Application-Project-DirectTargetsOnly.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -103,3 +103,7 @@ then
 settings append target.source-map ./external/ "$BAZEL_EXTERNAL_DIRNAME"
 END
 fi
+
+# Xcode 15.x: Fixes a problem in the flag parser of LLDB 15.1 potentially causing LLDB to crash
+sed -i '' 's, -vfsoverlay, -vfsoverlay ,g' $BAZEL_LLDB_INIT_FILE
+sed -i '' 's, -ivfsoverlay, -ivfsoverlay ,g' $BAZEL_LLDB_INIT_FILE

--- a/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/lldb-settings.sh
+++ b/tests/macos/xcodeproj/Test-Target-With-Test-Host-Project.xcodeproj/bazelinstallers/lldb-settings.sh
@@ -103,3 +103,7 @@ then
 settings append target.source-map ./external/ "$BAZEL_EXTERNAL_DIRNAME"
 END
 fi
+
+# Xcode 15.x: Fixes a problem in the flag parser of LLDB 15.1 potentially causing LLDB to crash
+sed -i '' 's, -vfsoverlay, -vfsoverlay ,g' $BAZEL_LLDB_INIT_FILE
+sed -i '' 's, -ivfsoverlay, -ivfsoverlay ,g' $BAZEL_LLDB_INIT_FILE

--- a/tools/xcodeproj_shims/installers/lldb-settings.sh
+++ b/tools/xcodeproj_shims/installers/lldb-settings.sh
@@ -103,3 +103,7 @@ then
 settings append target.source-map ./external/ "$BAZEL_EXTERNAL_DIRNAME"
 END
 fi
+
+# Xcode 15.x: Fixes a problem in the flag parser of LLDB 15.1 potentially causing LLDB to crash
+sed -i '' 's, -vfsoverlay, -vfsoverlay ,g' $BAZEL_LLDB_INIT_FILE
+sed -i '' 's, -ivfsoverlay, -ivfsoverlay ,g' $BAZEL_LLDB_INIT_FILE


### PR DESCRIPTION
Works around a LLDB crash happening on Sonoma + Xcode 15.x.

Pulling into `rules_ios` a change @jerrymarino did internally to fix the crash for us. I don't think there's an easy way to find a small repro since it was hard to repro even in our internal setup.

@jerrymarino let me know if you want to add more details here in the comments, maybe you can share a more detailed explanation of what was going on for future readers?