### PR TITLE
Drop support for Bazel 5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,32 +81,6 @@ jobs:
           name: bazel-testlogs
           path: bazel-testlogs
 
-  bazel_5_ios_integration_tests:
-    name: Build and Test ( Virtual Frameworks + Bazel 5 )
-    runs-on: macos-12
-    env:
-      USE_BAZEL_VERSION: 5.3.2
-    steps:
-      - uses: actions/checkout@v3
-      - name: Preflight Env
-        # Dont test Bazel 5 with bzlmod
-        run: .github/workflows/preflight_env.sh --no-bzlmod --use-remote-cache
-      - name: Build and Test
-        run: |
-          # iOS tests without bzlmod on Bazel 5
-          bazelisk build \
-            --noexperimental_enable_bzlmod \
-            --config=ios \
-            --config=vfs \
-            -- \
-            //tests/ios/...
-
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: bazel-testlogs
-          path: bazel-testlogs
-
   rules_apple_2_ios_integration_tests:
     name: Build and Test ( Virtual Frameworks + rules_apple 2.x )
     runs-on: macos-12

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ module(
     name = "rules_ios",
     version = "0",
     bazel_compatibility = [
-        ">=5.0.0",
+        ">=6.0.0",
         # Temporarily limit the usage of Bazel 7+ until
         # https://github.com/bazel-ios/rules_ios/issues/795
         # is complete.


### PR DESCRIPTION
This stops testing Bazel 5 in CI and bumps the support Bazel version in MODULE.bazel. It does not include any of the Bazel 5 related cleanup that is now possible.