### PR TITLE
Drop support for Bazel 5 & rules_apple 2

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -28,10 +28,6 @@ build --features swift.index_while_building
 # Prevents leaking unexpected binaries via PATH to tests
 build --test_env=PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
-# Enable device deps when the build matches the arm64 simulator
-# Bazel 5 - matches ios_sim_arm64 CPU, Bazel 4 - needs "override" flags
-build --features apple.arm64_simulator_use_device_deps
-
 # Delete the VM test suite for github
 build --deleted_packages tests/ios/vmd
 
@@ -53,7 +49,9 @@ build:ios_lldb_test --define=apple.experimental.tree_artifact_outputs=1
 # - iOS multi arch test configuration
 build:ios_multi_arch_test --config=ios
 build:ios_multi_arch_test --ios_minimum_os=10.2
-build:ios_multi_arch_test --ios_multi_cpus=i386,x86_64
+# i386 was removed on rules_apple 3.x.x - this test case needs reworking
+# to exemplify fat binaries on the latest version
+build:ios_multi_arch_test --ios_multi_cpus=x86_64
 
 # - Remote cache configuration
 build:ci_with_caches --config=ci --config=remote_cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,57 +81,6 @@ jobs:
           name: bazel-testlogs
           path: bazel-testlogs
 
-  bazel_5_ios_integration_tests:
-    name: Build and Test ( Virtual Frameworks + Bazel 5 )
-    runs-on: macos-12
-    env:
-      USE_BAZEL_VERSION: 5.3.2
-    steps:
-      - uses: actions/checkout@v3
-      - name: Preflight Env
-        # Dont test Bazel 5 with bzlmod
-        run: .github/workflows/preflight_env.sh --no-bzlmod --use-remote-cache
-      - name: Build and Test
-        run: |
-          # iOS tests without bzlmod on Bazel 5
-          bazelisk build \
-            --noexperimental_enable_bzlmod \
-            --config=ios \
-            --config=vfs \
-            -- \
-            //tests/ios/...
-
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: bazel-testlogs
-          path: bazel-testlogs
-
-  rules_apple_2_ios_integration_tests:
-    name: Build and Test ( Virtual Frameworks + rules_apple 2.x )
-    runs-on: macos-12
-    env:
-      USE_BAZEL_VERSION: 6.1.2
-    steps:
-      - uses: actions/checkout@v3
-      - name: Preflight Env
-        run: .github/workflows/preflight_env.sh --no-bzlmod --use-remote-cache
-      - name: Build and Test
-        run: |
-          # iOS tests
-          sed -i '' 's/LOAD_RULES_APPLE_2_DEPS = False/LOAD_RULES_APPLE_2_DEPS = True/' WORKSPACE && \
-          bazelisk build \
-            --config=ios \
-            --config=vfs \
-            -- \
-            //tests/ios/...
-
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: bazel-testlogs
-          path: bazel-testlogs
-
   build_arm64_simulator:
     name: Build arm64 Simulator
     runs-on: macos-12
@@ -143,6 +92,7 @@ jobs:
         run: |
           bazelisk build \
             --config=vfs \
+            --features apple.arm64_simulator_use_device_deps \
             --ios_multi_cpus=sim_arm64  \
             -- \
             //... \
@@ -153,6 +103,7 @@ jobs:
           bazelisk build \
             --config=ios \
             --config=vfs \
+            --features apple.arm64_simulator_use_device_deps \
             --ios_multi_cpus=sim_arm64 \
             -- \
             //tests/ios/... \
@@ -223,15 +174,12 @@ jobs:
     # to exemplify fat binaries on the latest version
     name: Build iOS App for Multiple Architecture
     runs-on: macos-12
-    env:
-      USE_BAZEL_VERSION: 6.1.2
     steps:
       - uses: actions/checkout@v3
       - name: Preflight Env
-        run: .github/workflows/preflight_env.sh --no-bzlmod --use-remote-cache
+        run: .github/workflows/preflight_env.sh --use-remote-cache
       - name: Build App
         run: |
-          sed -i '' 's/LOAD_RULES_APPLE_2_DEPS = False/LOAD_RULES_APPLE_2_DEPS = True/' WORKSPACE && \
           bazelisk build \
             --config=ios_multi_arch_test \
             -- \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,35 +18,3 @@ We automate publishing to the [Bazel Central Registry](https://registry.bazel.bu
 It will create a [PR like this one](https://github.com/bazelbuild/bazel-central-registry/pull/1063) whenever a new release is created. As such, there is no extra action required from the maintainers. Simply create a release and let the app publish it to the BCR.
 
 If you need more reviews in the BCR repository you can ask in the [#bzlmod channel of the Bazel Slack](https://bazelbuild.slack.com/archives/C014RARENH0).
-
-## Bazel 6 & LTS Support
-
-### 5.x.x LTS Support on HEAD
-
-LTS is a concept in [Bazel for versions](https://blog.bazel.build/2020/11/10/long-term-support-release.html)
-and we currently support 5.x.x only for a brief time. _The rough ETA for
-removing Bazel 5.x.x LTS support is end of Q2 2023 and if it's an issue we can
-correct course sooner._
-
-Because `rules_ios` should be loosely coupled to a given Bazel version, we can
-often handle several Bazel versions concurrently on `HEAD` without significant
-change and without having to have CI and review for LTS branches. Because we
-want to keep running on `HEAD`, LTS support is added with branches where
-necessary.  _The idea is paralleled to other to large scale migrations or python
-code which supported 2.x.x and 3.x.x concurrently_.
-
-We have a Bazel 5.x.x CI job which is the source of truth for vetting this.
-
-### rules_apple: What's up with rules_ios_1.0
-
-For `rules_apple` we attempt to achieve multi versions and smoothing over
-maintainer velocity issues on a patched tag. For instance we may back-ported
-some features to our tag like [framework_import_support](https://github.com/bazel-ios/rules_apple/commit/78476e542160be2c32d467ef856ccc2e9152f187)
-
-### Maintainer concerns and rules_apple compatibility
-
-We may shim APIs, back port patches from `rules_apple` to add features and
-smooth over integration. The unstable tag `rules_ios_1.0` has it all. If you're
-just bumping `rules_apple` for Bazel 6.0 you shouldn't need to worry about the
-LTS support if it passes CI. The burden to be an outlier should fall on the
-outliers here - if you've got an issue we can look into it together.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ module(
     name = "rules_ios",
     version = "0",
     bazel_compatibility = [
-        ">=5.0.0",
+        ">=6.0.0",
         # Temporarily limit the usage of Bazel 7+ until
         # https://github.com/bazel-ios/rules_ios/issues/795
         # is complete.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,33 @@ _Looking for the CocoaPods/Carthage rules?_ [See this section](#cocoapods-and-ca
 [Click here](https://github.com/bazel-ios/rules_ios/tree/master/docs)
 for the documentation.
 
+## Supported Bazel versions
+
+rules_ios depends on [rules_apple](https://github.com/bazelbuild/rules_apple) and [rules_swift](https://github.com/bazelbuild/rules_swift) which are often affected by changes in Bazel
+itself. This means you generally need to update these rules and rules_ios as you
+update Bazel.
+
+See the following table for supported release versions.
+
+| Bazel release | Minimum supported rules version | Final supported rules version
+|:-------------------:|:-------------------------:|:-------------------------:
+| 6.* | 2.0.0 | current
+| 5.* | 1.0.0 | 3.2.2
+| 4.* | 1.0.0 | 1.0.0
+
+## Supported [rules_apple](https://github.com/bazelbuild/rules_apple) versions
+
+rules_ios depends on [rules_apple](https://github.com/bazelbuild/rules_apple), we attempt to maintain compatibility with
+most versions of rules_apple until it becomes too difficult to do so.
+
+See the following table for supported rules_apple release versions.
+
+| rules_apple release | Minimum supported rules version | Final supported rules version
+|:-------------------:|:-------------------------:|:-------------------------:
+| 3.* | 3.* | current
+| 2.* | 2.* | 3.2.2
+| 1.* | 1.0.0 | 3.2.2
+
 ## Getting started
 
 ### Bzlmod setup


### PR DESCRIPTION
This stops testing Bazel 5/rules_apple 2 in CI and bumps the support Bazel version in MODULE.bazel. It does not include any of the Bazel 5 related cleanup that is now possible. This is for an upcoming version 4.0.0.

Adds a table like the following to the read me:

## Supported Bazel versions

| Bazel release | Minimum supported rules version | Final supported rules version
|:-------------------:|:-------------------------:|:-------------------------:
| 6.* | 2.0.0 | current
| 5.* | 1.0.0 | 3.2.2
| 4.* | 1.0.0 | 1.0.0

## Supported [rules_apple](https://github.com/bazelbuild/rules_apple) versions

| rules_apple release | Minimum supported rules version | Final supported rules version
|:-------------------:|:-------------------------:|:-------------------------:
| 3.* | 3.* | current
| 2.* | 2.* | 3.2.2
| 1.* | 1.0.0 | 3.2.2