### PR TITLE
Fix BCR presubmit for new requirements

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -4,6 +4,11 @@
     {
       "email": "rules_ios@squareup.com",
       "name": "rules_ios Maintainers"
+    },
+    {
+      "email": "heyluispadron@gmail.com",
+      "github": "luispadron",
+      "name": "Luis Padron"
     }
   ],
   "repository": [

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,7 +1,9 @@
-bazel: 6.4.0
+matrix:
+  bazel: ["6.x"]
 tasks:
   verify_build_targets:
     name: Verify Build targets on macOS
-    platform: macos
+    platform: macos_arm64
+    bazel: ${{ bazel }}
     build_targets:
       - "@rules_ios//rules/..."


### PR DESCRIPTION
Now requires bazel version to be set, also switches to arm64 for the machines