### PR TITLE
Update CI for latest actions and to use matrix

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -52,9 +52,6 @@ build:ios_multi_arch_test --ios_minimum_os=10.2
 # to exemplify fat binaries on the latest version
 build:ios_multi_arch_test --ios_multi_cpus=x86_64
 
-# - Remote cache configuration
-build:ci_with_caches --config=ci --config=remote_cache
-
 build:remote_cache --bes_backend=grpcs://remote.buildbuddy.io
 build:remote_cache --bes_results_url=https://app.buildbuddy.io/invocation/
 build:remote_cache --experimental_build_event_upload_strategy=local
@@ -71,6 +68,10 @@ build --noremote_upload_local_results
 build:ci --remote_upload_local_results
 
 # - CI Configuration
+# announce config values
+common:ci --announce_rc
+# enable remote cache
+build:ci --config=remote_cache
 # disable curses control since CI logs are not interactive
 common:ci --curses=no
 # turn off loading message updates
@@ -85,8 +86,8 @@ build:ci --jobs=4
 # allow extra time for simulators to boot
 test:ci --test_env=STARTUP_TIMEOUT_SEC=300
 test:ci --test_timeout=600
-test:ci --flaky_test_attempts=//tests/ios/...@3
 test:ci --local_test_jobs=1
+test:ci --flaky_test_attempts=3
 
 # Load a user.bazelrc
 try-import %workspace%/user.bazelrc

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Create Release
         run: |
           set -euo pipefail

--- a/.github/workflows/preflight_env.sh
+++ b/.github/workflows/preflight_env.sh
@@ -1,18 +1,24 @@
 #!/bin/bash
 
+set -e
+
+# Sets up the CI environment.
+#
+# Required environment variables:
+#   - XCODE_VERSION: The version of Xcode to use.
+
 # If flag --no-bzlmod is passed, writes a user.bazelrc file to disable Bzlmod.
 if [[ "$*" == *--no-bzlmod* ]]; then
   echo "build --noenable_bzlmod" >> user.bazelrc
 fi
-# If flag --use-remote-cache is passed, writes a user.bazelrc file to enable remote cache.
-if [[ "$*" == *--use-remote-cache* ]]; then
-  echo "build --config=ci_with_caches" >> user.bazelrc
-fi
 
-set -e
+# Add the ci config override.
+echo "common --config=ci" >> user.bazelrc
+
 echo "Selecting Xcode for environment"
+echo "Xcode before: $(xcode-select -p)"
+sudo xcode-select -s "/Applications/Xcode_$XCODE_VERSION.app"
+echo "Xcode after: $(xcode-select -p)"
 
+echo "Running with environment:"
 printenv
-
-sudo xcode-select -p
-sudo xcode-select -s /Applications/Xcode_15.2.app

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,14 +11,28 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+# NOTE: because matrix cannot easily be shared across jobs, it should be copied to each job
+#       when adding a new job / changing the matrix, make sure to update all jobs
 jobs:
   integration_tests:
-    name: Build and Test
+    name: Build and test (Bazel ${{ matrix.bazel_version }} / Xcode ${{ matrix.xcode_version }} / Virtual Frameworks ${{ matrix.virtual_frameworks }})
     runs-on: macos-14
+    strategy:
+      matrix:
+        bazel_version: [6.5.0]
+        xcode_version: [15.2]
+        virtual_frameworks: [true, false]
+    env:
+        XCODE_VERSION: ${{ matrix.xcode_version }}
+        USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Preflight Env
-        run: .github/workflows/preflight_env.sh --use-remote-cache
+        run: .github/workflows/preflight_env.sh
+      - if: matrix.virtual_frameworks
+        name: Add vfs config
+        run: |
+          echo "build --config=vfs" >> user.bazelrc
       - name: Build and Test
         run: |
           # non-iOS tests
@@ -39,52 +53,26 @@ jobs:
             --test_arg=--destination=platform=ios_simulator,id=$SIMULATOR_UDID \
             -- \
             //tests/ios/...
-
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: bazel-testlogs
-          path: bazel-testlogs
-
-  build_virtual_frameworks:
-    # Build the entire tree with this feature enabled. Longer term, we'll likely
-    # consider merging this feature into the default behavior and can re-align
-    # the CI job
-    name: Build and Test ( Virtual Frameworks )
-    runs-on: macos-14
-    steps:
-      - uses: actions/checkout@v3
-      - name: Preflight Env
-        run: .github/workflows/preflight_env.sh --use-remote-cache
-      - name: Build and Test
-        run: |
-          # non-iOS tests
-          bazelisk test \
-            --config=vfs \
-            -- \
-            //... \
-            -//tests/ios/...
-
-          # iOS tests
-          bazelisk test \
-            --config=ios \
-            --config=vfs \
-            -- \
-            //tests/ios/...
-
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: bazel-testlogs
           path: bazel-testlogs
 
   build_arm64_simulator:
-    name: Build arm64 Simulator
+    name: arm64 Simulator (Bazel ${{ matrix.bazel_version }} / Xcode ${{ matrix.xcode_version }})
     runs-on: macos-14
+    strategy:
+      matrix:
+        bazel_version: [6.5.0]
+        xcode_version: [15.2]
+    env:
+        XCODE_VERSION: ${{ matrix.xcode_version }}
+        USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Preflight Env
-        run: .github/workflows/preflight_env.sh --use-remote-cache
+        run: .github/workflows/preflight_env.sh
       - name: Build and Test
         run: |
           bazelisk build \
@@ -105,20 +93,26 @@ jobs:
             -- \
             //tests/ios/... \
             -//tests/ios/unit-test/test-imports-app/...
-
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: bazel-testlogs
           path: bazel-testlogs
 
-  lint:
-    name: Check Starlark and Docs
+  buildifier-and-docs:
+    name: Buildifier and Documentation (Bazel ${{ matrix.bazel_version }} / Xcode ${{ matrix.xcode_version }})
     runs-on: macos-14
+    strategy:
+      matrix:
+        bazel_version: [6.5.0]
+        xcode_version: [15.2]
+    env:
+        XCODE_VERSION: ${{ matrix.xcode_version }}
+        USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Preflight Env
-        run: .github/workflows/preflight_env.sh --use-remote-cache
+        run: .github/workflows/preflight_env.sh
         # Note: we need to pass the absolute to the Bazel run
       - name: buildifier
         run: |
@@ -129,29 +123,48 @@ jobs:
           bazelisk run \
             //docs
           git diff --exit-code docs
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: bazel-testlogs
+          path: bazel-testlogs
 
   xcodeproj_tests:
-    name: .xcodeproj Tests on Xcode 15.2.0
+    name: Legacy xcodeproj tests (Bazel ${{ matrix.bazel_version }} / Xcode ${{ matrix.xcode_version }})
     runs-on: macos-14
+    strategy:
+      matrix:
+        bazel_version: [6.5.0]
+        xcode_version: [15.2]
+    env:
+        XCODE_VERSION: ${{ matrix.xcode_version }}
+        USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Preflight Env
-        run: .github/workflows/preflight_env.sh --no-bzlmod --use-remote-cache
+        run: .github/workflows/preflight_env.sh --no-bzlmod
       - name: Run tests
         run: ./tests/xcodeproj-tests.sh --run && ./tests/test-tests.sh
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: bazel-testlogs
           path: bazel-testlogs
 
   lldb_ios_tests_xcode:
-    name: LLDB tests on Xcode 15.2.0
+    name: LLDB tests (Bazel ${{ matrix.bazel_version }} / Xcode ${{ matrix.xcode_version }})
     runs-on: macos-14
+    strategy:
+      matrix:
+        bazel_version: [6.5.0]
+        xcode_version: [15.2]
+    env:
+        XCODE_VERSION: ${{ matrix.xcode_version }}
+        USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Preflight Env
-        run: .github/workflows/preflight_env.sh --use-remote-cache
+        run: .github/workflows/preflight_env.sh
       - name: Run tests
         run: |
           bazelisk test \
@@ -159,8 +172,7 @@ jobs:
             -- \
             tests/ios/lldb/app:objc_app_po_test \
             tests/ios/lldb/app:objc_app_variable_test
-
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: bazel-testlogs
@@ -169,12 +181,19 @@ jobs:
   multi_arch_support:
     # i386 was removed on rules_apple 3.x.x - this test case needs reworking
     # to exemplify fat binaries on the latest version
-    name: Build iOS App for Multiple Architecture
+    name: iOS App Multiple Architectures (Bazel ${{ matrix.bazel_version }} / Xcode ${{ matrix.xcode_version }})
     runs-on: macos-14
+    strategy:
+      matrix:
+        bazel_version: [6.5.0]
+        xcode_version: [15.2]
+    env:
+        XCODE_VERSION: ${{ matrix.xcode_version }}
+        USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Preflight Env
-        run: .github/workflows/preflight_env.sh --use-remote-cache
+        run: .github/workflows/preflight_env.sh
       - name: Build App
         run: |
           bazelisk build \


### PR DESCRIPTION
Updates GitHub CI to make it easier to add more Bazel/Xcode Versions.

Changes:

- Update `checkout` and `upload-artifacts` actions to `v4`, this fixes warnings we get on every PR for deprecated Node versions
- Add `matrix` strategy for all jobs, this adds a `bazel_version` and `xcode_version` which each job will be configured to run against. We can add Bazel 7 once #795 is done.
- Merge the `--config=vfs` and non-vfs job, this can be set with a custom matrix without duplicating the job code.
- Remove `--remote-cache` flag, this was set by every job already.

## Example:

<img width="817" alt="Screenshot 2024-03-04 at 10 59 36 AM" src="https://github.com/bazel-ios/rules_ios/assets/13840545/ec0bf2c5-6f03-41bc-9acf-1d1501d59376">
