### PR TITLE
Fix duplicate symbols for test rules

### DIFF
--- a/rules/test.bzl
+++ b/rules/test.bzl
@@ -142,8 +142,9 @@ def _ios_test(name, bundle_rule, test_rule, test_factory, apple_library, infopli
 
     Args:
         name: The name of the unit test.
-        test_rule: The underlying rules_apple test rule.
         bundle_rule: The underlying rules_apple test suite rule.
+        test_rule: The underlying rules_apple test rule.
+        test_factory: The factory object used to generate tests.
         apple_library: The macro used to package sources into a library.
         infoplists_by_build_setting: A dictionary of infoplists grouped by bazel build setting.
 
@@ -153,6 +154,7 @@ def _ios_test(name, bundle_rule, test_rule, test_factory, apple_library, infopli
                                      If '//conditions:default' is not set the value in 'infoplists'
                                      is set as default.
         split_name_to_kwargs: A dictionary of suffixes to kwargs that will be passed into the "split" test bundle. The suffix will be appended to the name of the suite.
+        internal_test_deps: Internal test dependencies.
         **kwargs: Arguments passed to the apple_library and test_rule rules as appropriate.
     """
 
@@ -241,7 +243,21 @@ def ios_unit_test(name, apple_library = apple_library, test_factory = default_te
         test_factory: Use this to generate other variations of tests.
         **kwargs: Arguments passed to the apple_library and ios_unit_test rules as appropriate.
     """
-    _ios_test(name, _ios_internal_unit_test_bundle, _ios_unit_test, test_factory, apple_library, **kwargs)
+    infoplists_by_build_setting = kwargs.pop("infoplists_by_build_setting", {})
+    split_name_to_kwargs = kwargs.pop("split_name_to_kwargs", {})
+    internal_test_deps = kwargs.pop("internal_test_deps", [])
+
+    _ios_test(
+        name = name,
+        bundle_rule = _ios_internal_unit_test_bundle,
+        test_rule = _ios_unit_test,
+        test_factory = test_factory,
+        apple_library = apple_library,
+        infoplists_by_build_setting = infoplists_by_build_setting,
+        split_name_to_kwargs = split_name_to_kwargs,
+        internal_test_deps = internal_test_deps,
+        **kwargs
+    )
 
 def ios_ui_test(name, apple_library = apple_library, test_factory = default_test_factory, **kwargs):
     """
@@ -255,7 +271,22 @@ def ios_ui_test(name, apple_library = apple_library, test_factory = default_test
     """
     if not kwargs.get("test_host", None):
         fail("test_host is required for ios_ui_test.")
-    _ios_test(name, _ios_internal_ui_test_bundle, _ios_ui_test, test_factory, apple_library, **kwargs)
+
+    infoplists_by_build_setting = kwargs.pop("infoplists_by_build_setting", {})
+    split_name_to_kwargs = kwargs.pop("split_name_to_kwargs", {})
+    internal_test_deps = kwargs.pop("internal_test_deps", [])
+
+    _ios_test(
+        name = name,
+        bundle_rule = _ios_internal_ui_test_bundle,
+        test_rule = _ios_ui_test,
+        test_factory = test_factory,
+        apple_library = apple_library,
+        infoplists_by_build_setting = infoplists_by_build_setting,
+        split_name_to_kwargs = split_name_to_kwargs,
+        internal_test_deps = internal_test_deps,
+        **kwargs
+    )
 
 def ios_unit_snapshot_test(name, apple_library = apple_library, test_factory = default_test_factory, **kwargs):
     """
@@ -267,4 +298,18 @@ def ios_unit_snapshot_test(name, apple_library = apple_library, test_factory = d
         test_factory: Use this to generate other variations of tests.
         **kwargs: Arguments passed to the apple_library and ios_unit_test rules as appropriate.
     """
-    _ios_test(name, _ios_internal_unit_test_bundle, _ios_unit_test, test_factory, apple_library, internal_test_deps = ["@bazel_tools//tools/cpp/runfiles"], **kwargs)
+    infoplists_by_build_setting = kwargs.pop("infoplists_by_build_setting", {})
+    split_name_to_kwargs = kwargs.pop("split_name_to_kwargs", {})
+    internal_test_deps = kwargs.pop("internal_test_deps", [])
+
+    _ios_test(
+        name = name,
+        bundle_rule = _ios_internal_unit_test_bundle,
+        test_rule = _ios_unit_test,
+        test_factory = test_factory,
+        apple_library = apple_library,
+        infoplists_by_build_setting = infoplists_by_build_setting,
+        split_name_to_kwargs = split_name_to_kwargs,
+        internal_test_deps = internal_test_deps,
+        **kwargs
+    )

--- a/rules/utils.bzl
+++ b/rules/utils.bzl
@@ -2,3 +2,6 @@
 
 def bundle_identifier_for_bundle(bundle_name):
     return "com.cocoapods." + bundle_name
+
+# This is a proxy for being on bazel 7.x.
+is_bazel_7 = not hasattr(apple_common, "apple_crosstool_transition")

--- a/tests/ios/app/BUILD.bazel
+++ b/tests/ios/app/BUILD.bazel
@@ -5,6 +5,7 @@ load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load(":analysis-tests.bzl", "make_tests")
 load("@build_bazel_rules_apple//apple:resources.bzl", "apple_bundle_import")
 load("//rules/test/output:output_test.bzl", "output_test")
+load("//rules:utils.bzl", "is_bazel_7")
 
 apple_framework(
     name = "CppLib",
@@ -256,6 +257,9 @@ ios_unit_test(
 ios_unit_snapshot_test(
     name = "TestSnapshots",
     srcs = ["snapshot_test.m"],
+    # NOTE: Bazel 7 fixed linking issues which required adding this dep here in the first place
+    #       in Bazel 7 it's now properly linked from the dep in //rules/test/snapshot:BazelRunfileBridge
+    internal_test_deps = [] if is_bazel_7 else ["@bazel_tools//tools/cpp/runfiles"],
     minimum_os_version = "12.0",
     test_exec_properties = {},
     test_host = ":AppWithInfoPlist",


### PR DESCRIPTION
This makes changes to `test.bzl` to remove the default `internal_test_deps` being added to all snapshot tests. This is causing duplicate symbol issues in Bazel 7 as framework search path logic has changed. In Bazel 7, the snapshot test target can't depend on the runfiles lib without introducing duplicate symbols at link time, this is because the `BazelRunfiles` target it depends on already links the runefiles lib. This updates the rule / usage of it to pass this dependency explicitly so it can be removed in the bazel 7 branch but maintained here for others who need it.

Changes:

- Dont set `interal_test_deps` to have a default value for snapshot tests
- Explicitly set each key word argument in each test factory, this stops issues like this from coming up again in the future