### PR TITLE
Remove split_transition_rule_attrs to simplify transition_support

### DIFF
--- a/rules/force_load_direct_deps.bzl
+++ b/rules/force_load_direct_deps.bzl
@@ -1,6 +1,5 @@
 load("//rules:providers.bzl", "AvoidDepsInfo")
-load("//rules:transition_support.bzl", "split_transition_rule_attrs", "transition_support")
-load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("//rules:transition_support.bzl", "transition_support")
 
 def _impl(ctx):
     if not ctx.attr.should_force_load:
@@ -32,7 +31,7 @@ def _impl(ctx):
 
 force_load_direct_deps = rule(
     implementation = _impl,
-    attrs = dicts.add(split_transition_rule_attrs, {
+    attrs = {
         "deps": attr.label_list(
             cfg = transition_support.split_transition,
             mandatory = True,
@@ -55,7 +54,11 @@ force_load_direct_deps = rule(
                 """Internal - currently rules_ios the dict `platforms`
 """,
         ),
-    }),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+            doc = "Needed to allow this rule to have an incoming edge configuration transition.",
+        ),
+    },
     doc = """
 A rule to link with `-force_load` for direct`deps`
 

--- a/rules/internal/framework_middleman.bzl
+++ b/rules/internal/framework_middleman.bzl
@@ -6,7 +6,6 @@ load(
     "new_applebundleinfo",
     "new_iosframeworkbundleinfo",
 )
-load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(
     "@build_bazel_rules_apple//apple/internal:partials.bzl",
     "partials",
@@ -32,7 +31,7 @@ load(
     "//rules/internal:objc_provider_utils.bzl",
     "objc_provider_utils",
 )
-load("//rules:transition_support.bzl", "split_transition_rule_attrs", "transition_support")
+load("//rules:transition_support.bzl", "transition_support")
 
 def _framework_middleman(ctx):
     resource_providers = []
@@ -121,7 +120,7 @@ def _framework_middleman(ctx):
 
 framework_middleman = rule(
     implementation = _framework_middleman,
-    attrs = dicts.add(split_transition_rule_attrs, {
+    attrs = {
         "framework_deps": attr.label_list(
             cfg = transition_support.split_transition,
             mandatory = True,
@@ -153,7 +152,11 @@ framework_middleman = rule(
                 """Internal - The product type of the framework
 """,
         ),
-    }),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+            doc = "Needed to allow this rule to have an incoming edge configuration transition.",
+        ),
+    },
     doc = """
         This is a volatile internal rule to make frameworks work with
         rules_apples bundling logic
@@ -255,7 +258,7 @@ def _dep_middleman(ctx):
 
 dep_middleman = rule(
     implementation = _dep_middleman,
-    attrs = dicts.add(split_transition_rule_attrs, {
+    attrs = {
         "deps": attr.label_list(
             cfg = transition_support.split_transition,
             mandatory = True,
@@ -275,7 +278,11 @@ dep_middleman = rule(
                 """Internal - currently rules_ios the dict `platforms`
 """,
         ),
-    }),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+            doc = "Needed to allow this rule to have an incoming edge configuration transition.",
+        ),
+    },
     doc = """
         This is a volatile internal rule to make frameworks work with
         rules_apples bundling logic

--- a/rules/transition_support.bzl
+++ b/rules/transition_support.bzl
@@ -368,11 +368,3 @@ transition_support = struct(
     split_transition = _split_transition,
     current_apple_platform = _current_apple_platform,
 )
-
-# For the above comment
-split_transition_rule_attrs = {
-    "_allowlist_function_transition": attr.label(
-        default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-        doc = "Needed to allow this rule to have an incoming edge configuration transition.",
-    ),
-}


### PR DESCRIPTION
I'm trying to reduce custom stuff in `transition_support.bzl` so we can copy it again from `rules_apple` directly because its changed a lot for Bazel 7. 

This removes the constant to add transition support, ive seen this just copy-pasted into the rules in other repos, it simplifies it and removes the need to use `dicts`