### PR TITLE
Update toolchains support for latest rules_apple and transitions

### DIFF
--- a/rules/framework/BUILD.bazel
+++ b/rules/framework/BUILD.bazel
@@ -15,6 +15,7 @@ bzl_library(
         "//rules:features",
         "//rules:providers",
         "@bazel_tools//tools/cpp:toolchain_utils.bzl",
+        "@build_bazel_rules_apple//apple",
         "@build_bazel_rules_swift//swift",
     ],
 )

--- a/rules/framework/vfs_overlay.bzl
+++ b/rules/framework/vfs_overlay.bzl
@@ -435,6 +435,7 @@ framework_vfs_overlay = rule(
         "private_hdrs": attr.label_list(allow_files = True, default = []),
         "deps": attr.label_list(allow_files = True, default = []),
         "_cc_toolchain": attr.label(
+            providers = [cc_common.CcToolchainInfo],
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
             doc = """\
 The C++ toolchain from which linking flags and other tools needed by the Swift

--- a/rules/precompiled_apple_resource_bundle.bzl
+++ b/rules/precompiled_apple_resource_bundle.bzl
@@ -83,7 +83,7 @@ def _precompiled_apple_resource_bundle_impl(ctx):
         include_executable_name = False,
     )
 
-    apple_mac_toolchain_info = ctx.attr._toolchain[AppleMacToolsToolchainInfo]
+    apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
     partial_output = partial.call(
         partials.resources_partial(
             apple_mac_toolchain_info = apple_mac_toolchain_info,
@@ -283,9 +283,10 @@ the bundle as a dependency.""",
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
             doc = "Needed to allow this rule to have an incoming edge configuration transition.",
         ),
-        _toolchain = attr.label(
+        _mac_toolchain = attr.label(
             default = Label("@build_bazel_rules_apple//apple/internal:mac_tools_toolchain"),
             providers = [[AppleMacToolsToolchainInfo]],
+            cfg = "exec",
         ),
     )),
 )


### PR DESCRIPTION
Prepares our mac and xplat toolchains for Bazel 7

Changes:

- Replace usage of `"@bazel_tools//tools/cpp:current_cc_toolchain"` with `"@build_bazel_rules_apple//apple:default_cc_toolchain_forwarder"`
- Rename `_toolchain` to `_mac_toolchain`, this matches rules_apple and better represents that the toolchain is for the host platform
- Add `cfg = "exec"` to the mac and xplat toolchains
  - This is required to fix toolchain resolution errors on Bazel 7. These toolchains are for the host and so `exec` is correct here. This is the same cfg they use in rules_apple 