### PR TITLE
Safer objc_provider assignment in apple_framework_packaging

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -1067,8 +1067,8 @@ def _apple_framework_packaging_impl(ctx):
     default_info = DefaultInfo(files = depset(out_files + bundle_outs.files.to_list()))
 
     objc_provider = objc_provider_utils.merge_objc_providers(
-        providers = [dep[apple_common.Objc] for dep in deps],
-        transitive = [dep[apple_common.Objc] for dep in transitive_deps],
+        providers = [dep[apple_common.Objc] for dep in deps if apple_common.Objc in dep],
+        transitive = [dep[apple_common.Objc] for dep in transitive_deps if apple_common.Objc in dep],
     )
     return [
         avoid_deps_info,


### PR DESCRIPTION
There's an internal use case for us that involves passing others types of deps to `apple_framework_packaging` that might not have the `apple_common.Objc` provider (`cc_library` targets). This check makes this assignment "safer" but also enables others also passing custom deps here.