### PR TITLE
Removed fake_rule_label from precompiled_apple_resource_bundle_impl and using swift_module instead

### DIFF
--- a/rules/precompiled_apple_resource_bundle.bzl
+++ b/rules/precompiled_apple_resource_bundle.bzl
@@ -34,19 +34,6 @@ def _precompiled_apple_resource_bundle_impl(ctx):
     current_apple_platform = transition_support.current_apple_platform(apple_fragment = ctx.fragments.apple, xcode_config = ctx.attr._xcode_config)
     platform_type = str(current_apple_platform.platform.platform_type)
 
-    if apple_api_version == "3.0":
-        platform_prerequisites_version_args = {
-            "build_settings": None,
-        }
-        rules_api_3_resource_partials_args = {
-            "include_executable_name": False,  # Must be set to False or bundle_name is now used if executable_name is None
-        }
-    else:
-        platform_prerequisites_version_args = {
-            "disabled_features": ctx.disabled_features,
-        }
-        rules_api_3_resource_partials_args = {}
-
     platform_prerequisites = platform_support.platform_prerequisites(
         apple_fragment = ctx.fragments.apple,
         config_vars = ctx.var,

--- a/rules/precompiled_apple_resource_bundle.bzl
+++ b/rules/precompiled_apple_resource_bundle.bzl
@@ -107,6 +107,9 @@ def _precompiled_apple_resource_bundle_impl(ctx):
         paths.join("%s-intermediates" % ctx.label.name, "Info.plist"),
     )
 
+    # as fake_rule_label is being used to get module_name for compiling xibs, storyboards, core data models etc.
+    # we have to change it to target name because of clashing writing actions when we build multiple targets with same module_name
+    partials_args["rule_label"] = Label("//fake_package:" + ctx.label.name)
     resource_actions.merge_root_infoplists(
         bundle_id = ctx.attr.bundle_id or bundle_identifier_for_bundle(bundle_name),
         input_plists = ctx.files.infoplists,


### PR DESCRIPTION
**Why this is needed?**
`fake_rule_label` was as a workaround and I'd like to remove it and use swift_module.
This pr is a continuation of https://github.com/bazelbuild/rules_apple/pull/2335.
If we try to build 2 different targets with same module name - plist generation will fail due to rule name collision as `fake_rule_label` is used, which was created from `swift_module` or `bundle_name`

**What has changed?**
Using `swift_module` for compiling assets, plists, storyboards, etc. instead of `fake_rule_label`. Now, each plist generation action has it's own rule name which has no name collision

**NOTE**
This PR Requires `rules_apple` to be at least 3.2.0, so I'll fix tests once it's updated