### PR TITLE
Update to rules_apple 3.5.1 minimum supported version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,7 +26,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "rules_apple",
-    version = "3.5.0",
+    version = "3.5.1",
     repo_name = "build_bazel_rules_apple",
 )
 bazel_dep(

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See the following table for supported rules_apple release versions.
 
 | rules_apple release | Minimum supported rules version | Final supported rules version
 |:-------------------:|:-------------------------:|:-------------------------:
-| 3.5.* | 4.3.0 | current
+| 3.5.1 | 4.3.1 | current
 | 3.* | 3.* | 4.2.1
 | 2.* | 2.* | 3.2.2
 | 1.* | 1.0.0 | 3.2.2

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -95,16 +95,16 @@ def _rules_ios_bzlmod_dependencies():
     _maybe(
         http_archive,
         name = "build_bazel_rules_apple",
-        sha256 = "c5387f966966000ab65284d4535d956491e7d31ed92ec79731c52e8fd4a49d5e",
-        url = "https://github.com/bazelbuild/rules_apple/releases/download/3.5.0/rules_apple.3.5.0.tar.gz",
+        sha256 = "b4df908ec14868369021182ab191dbd1f40830c9b300650d5dc389e0b9266c8d",
+        url = "https://github.com/bazelbuild/rules_apple/releases/download/3.5.1/rules_apple.3.5.1.tar.gz",
     )
     _maybe(
         http_archive,
         name = "bazel_skylib",
-        sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7",
+        sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
         ],
     )
 


### PR DESCRIPTION
3.5.1 [includes a fix](https://github.com/bazelbuild/rules_apple/pull/2444) we need to get in for `codesigntool` to work correctly. This increases min version of rules_apple to 3.5.1 for version 4.3.1 of rules_ios (to be released)