### PR TITLE
Disable builtin CC toolchain for BCR tests

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,9 +1,17 @@
 matrix:
   bazel: ["6.x", "7.x"]
 tasks:
-  verify_build_targets:
-    name: Verify Build targets on macOS
+  verify_build_targets_bazel_6:
+    name: Verify Build targets on macOS with Bazel 6
     platform: macos_arm64
-    bazel: ${{ bazel }}
+    bazel: 6.x
     build_targets:
       - "@rules_ios//rules/..."
+  verify_build_targets_bazel_7:
+    name: Verify Build targets on macOS with Bazel 7
+    platform: macos_arm64
+    bazel: 7.x
+    build_targets:
+      - "@rules_ios//rules/..."
+    build_flags:
+      - "--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1"


### PR DESCRIPTION
Similar to https://github.com/bazelbuild/rules_apple/pull/2377, see: https://github.com/bazelbuild/bazel-central-registry/pull/1842