### PR TITLE
Stop processing data twice in make_vfsoverlay

### DIFF
--- a/rules/framework/vfs_overlay.bzl
+++ b/rules/framework/vfs_overlay.bzl
@@ -387,7 +387,7 @@ def make_vfsoverlay(ctx, hdrs, module_map, private_hdrs, has_swift, swiftmodules
     vfs_info = _make_vfs_info(framework_name, data)
     if merge_vfsoverlays:
         vfs_info = _merge_vfs_infos(vfs_info, merge_vfsoverlays)
-        roots = _roots_from_datas(vfs_prefix, target_triple, vfs_info.values() + [data])
+        roots = _roots_from_datas(vfs_prefix, target_triple, vfs_info.values())
     else:
         roots = _make_root(
             vfs_prefix = vfs_prefix,


### PR DESCRIPTION
This `data` struct is already included in `vfs_info.values()` here: https://github.com/bazel-ios/rules_ios/blob/311ba90785a7be2445f12e677beb7d32aead22e6/rules/framework/vfs_overlay.bzl#L387