### PR TITLE
Update usage of `to_json` to `json.encode`

### DIFF
--- a/rules/plists.bzl
+++ b/rules/plists.bzl
@@ -110,7 +110,7 @@ def write_info_plists_if_needed(name, plists):
             write_file(
                 name = plist_name,
                 out = plist_name + ".plist",
-                content = [struct(**plist).to_json()],
+                content = [json.encode(struct(**plist))],
             )
             written_plists.append(plist_name)
         else:

--- a/rules/precompiled_apple_resource_bundle.bzl
+++ b/rules/precompiled_apple_resource_bundle.bzl
@@ -164,7 +164,7 @@ def _precompiled_apple_resource_bundle_impl(ctx):
     )
     ctx.actions.write(
         output = bundletool_instructions_file,
-        content = bundletool_instructions.to_json(),
+        content = json.encode(bundletool_instructions),
     )
     bundletool_experimental = apple_mac_toolchain_info.bundletool_experimental
 

--- a/rules/test/lldb/lldb_test.bzl
+++ b/rules/test/lldb/lldb_test.bzl
@@ -81,7 +81,7 @@ def _ios_breakpoint_test_wrapper(name, application, cmds, test_spec, sdk, device
     write_file(
         name = name + "_test_spec",
         out = name + ".test_spec.json",
-        content = [test_spec.to_json()],
+        content = [json.encode(test_spec)],
     )
 
     lldbinit_deps = ["@build_bazel_rules_ios//rules/test/lldb:breakpoint.py"]


### PR DESCRIPTION
`to_json` was removed from `struct` in latest Bazel versions. This is backwards compatible from Bazel 6+