### PR TITLE
Add support for `extension_safe` attr

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -585,6 +585,11 @@ def apple_library(
     defines = kwargs.pop("defines", [])
     testonly = kwargs.pop("testonly", False)
     features = kwargs.pop("features", [])
+    extension_safe = kwargs.pop("extension_safe", None)
+
+    # Set extra linkopt for application extension safety
+    if extension_safe:
+        linkopts.append("-fapplication-extension")
 
     # Collect the swift_library related kwargs, these are typically only set when provided to allow
     # for wider compatibility with rule_swift versions.

--- a/tests/ios/frameworks/dynamic/b/BUILD.bazel
+++ b/tests/ios/frameworks/dynamic/b/BUILD.bazel
@@ -5,10 +5,10 @@ apple_framework(
     srcs = glob(["*.swift"]),
     bundle_id = "com.example.b",
     data = ["b_data.txt"],
+    extension_safe = True,
     infoplists = ["Info.plist"],
     link_dynamic = True,
     platforms = {"ios": "12.0"},
     visibility = ["//visibility:public"],
-    xcconfig = {"APPLICATION_EXTENSION_API_ONLY": "YES"},
     deps = ["//tests/ios/frameworks/dynamic/c"],
 )

--- a/tests/ios/xcodeproj/Test-Mixed-Dynamic-App-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-Mixed-Dynamic-App-Project.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 
 /* Begin PBXFileReference section */
 		02153936701CAAE5E5530BE4 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
-		49A50B056BD5E4179AC67F43 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		4B591E98E01C3FB1BE1C7410 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
 		4E0674CDE1D42113DF39B8D1 /* aWithResourceBundles.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = aWithResourceBundles.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6CD05C1A97322FF05C07A575 /* lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = lib.swift; sourceTree = "<group>"; };
@@ -127,7 +126,6 @@
 			children = (
 				8BD8BAFA513836E6FFFA7A8C /* b_data.txt */,
 				4B591E98E01C3FB1BE1C7410 /* BUILD.bazel */,
-				49A50B056BD5E4179AC67F43 /* Info.plist */,
 				6CD05C1A97322FF05C07A575 /* lib.swift */,
 			);
 			path = b;
@@ -407,7 +405,6 @@
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-dbg-ST-008b8551197e/bin/tests/ios/frameworks/dynamic/c/c\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-dbg-ST-008b8551197e/bin/tests/ios/frameworks/dynamic/b/b_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
-				INFOPLIST_FILE = ../../../tests/ios/frameworks/dynamic/b/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACH_O_TYPE = "$(inherited)";
 				ONLY_ACTIVE_ARCH = YES;
@@ -627,7 +624,6 @@
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-dbg-ST-008b8551197e/bin/tests/ios/frameworks/dynamic/c/c\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-dbg-ST-008b8551197e/bin/tests/ios/frameworks/dynamic/b/b_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
-				INFOPLIST_FILE = ../../../tests/ios/frameworks/dynamic/b/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACH_O_TYPE = "$(inherited)";
 				ONLY_ACTIVE_ARCH = YES;


### PR DESCRIPTION
Similar to how rules_apple supports this, add an `extension_safe` attr handling which automatically sets `-fapplication-extension`.