### PR TITLE
Bazel 7: Set framework_includes in import_middleman

### DIFF
--- a/rules/import_middleman.bzl
+++ b/rules/import_middleman.bzl
@@ -269,6 +269,15 @@ def _file_collector_rule_impl(ctx):
     cc_info = None
     if is_bazel_7:
         cc_info = CcInfo(
+            compilation_context = cc_common.create_compilation_context(
+                framework_includes = depset(
+                    transitive = [
+                        dep[CcInfo].compilation_context.framework_includes
+                        for dep in ctx.attr.deps
+                        if CcInfo in dep
+                    ],
+                ),
+            ),
             linking_context = cc_common.create_linking_context(
                 linker_inputs = depset([
                     cc_common.create_linker_input(


### PR DESCRIPTION
Continuation of: https://github.com/bazel-ios/rules_ios/pull/873

While testing Bazel 7 hit some build failures due to missing `-F` flags in the invocation.

I could set other attributes here too but since I'm not super familiar with this rule I'd rather add what is missing progressively as I run tests in Bazel 7.