### PR TITLE
Fix extension_safe attr not passing copts

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -589,7 +589,9 @@ def apple_library(
 
     # Set extra linkopt for application extension safety
     if extension_safe:
-        linkopts.append("-fapplication-extension")
+        linkopts += ["-fapplication-extension"]
+        objc_copts += ["-fapplication-extension"]
+        swift_copts += ["-application-extension"]
 
     # Collect the swift_library related kwargs, these are typically only set when provided to allow
     # for wider compatibility with rule_swift versions.

--- a/tests/ios/frameworks/dynamic/b/lib.swift
+++ b/tests/ios/frameworks/dynamic/b/lib.swift
@@ -1,6 +1,16 @@
 import c
+import WidgetKit
 
 public struct B {
     public static func run() { C.run() }
     public static func NATURE_OF_B() { B.run() }
+
+    @available(iOS 14.0, *)
+    public static func runExtension() -> [WidgetFamily] {
+        if #available(iOSApplicationExtension 16.0, *) {
+            [.accessoryCircular]
+        } else {
+            []
+        }
+    }
 }


### PR DESCRIPTION
When using `extension_safe` the `copt` for the objc/swift library must also supply `-fapplication-extension`/`-application-extension`