### PR TITLE
Move resource generation below framework vfs

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -819,14 +819,6 @@ def apple_library(
     if vendored_deps_arm64_sim:
         deps += vendored_deps_arm64_sim
 
-    resource_bundles = library_tools["resource_bundle_generator"](
-        name = name,
-        library_tools = library_tools,
-        resource_bundles = kwargs.pop("resource_bundles", {}),
-        platforms = platforms,
-    )
-    deps += resource_bundles
-
     objc_libname = "%s_objc" % name
     swift_libname = "%s_swift" % name
     cpp_libname = "%s_cpp" % name
@@ -936,8 +928,6 @@ def apple_library(
     if swift_version:
         additional_swift_copts += ["-swift-version", swift_version]
 
-    module_data = library_tools["wrap_resources_in_filegroup"](name = name + "_wrapped_resources_filegroup", srcs = data, testonly = testonly)
-
     if has_swift_sources:
         additional_swift_copts += ["-Xcc", "-I."]
         if module_map:
@@ -987,6 +977,20 @@ def apple_library(
         deps = deps + private_deps + private_dep_names + lib_names + import_vfsoverlays,
         #enable_framework_vfs = enable_framework_vfs
     )
+
+    # Generate resource bundles
+    module_data = library_tools["wrap_resources_in_filegroup"](
+        name = name + "_wrapped_resources_filegroup",
+        srcs = data,
+        testonly = testonly,
+    )
+    resource_bundles = library_tools["resource_bundle_generator"](
+        name = name,
+        library_tools = library_tools,
+        resource_bundles = kwargs.pop("resource_bundles", {}),
+        platforms = platforms,
+    )
+    deps += resource_bundles
 
     if has_swift_sources:
         # Forward the kwargs and the swift specific kwargs to the swift_library


### PR DESCRIPTION
This moves resource generation (and being added to `deps`) below the `framework_vfs` creation which uses the `deps`

With the change in #879 to add the vfs to the `swiftc_inputs`  instead of the `deps` of the `swift_library` the `framework_vfs` was now also forwarding the resources (because it gets added to `deps` after generation) to other rules (like `rules_xcodeproj`) which collect extra files from this the `swiftc_inputs` attr. This led to duplicated resources in the project as they're collected from `resources` and now the transitive `deps` of the `framework_vfs`

AFAIK resources aren't needed for the `framework_vfs` rules and so this change should resolve the new `rules_xcodeproj` incompatibility while making the `deps` to the `framework_vfs` more scoped.