### PR TITLE
Remove redundant modulemap in `swiftc_inputs`

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -951,8 +951,6 @@ def apple_library(
             })
 
         swiftc_inputs = other_inputs + objc_hdrs + objc_private_hdrs
-        if module_map:
-            swiftc_inputs.append(module_map)
         if swift_objc_bridging_header:
             if swift_objc_bridging_header not in objc_hdrs:
                 swiftc_inputs.append(swift_objc_bridging_header)


### PR DESCRIPTION
In #879 we added the extended modulemap to the `swiftc_inputs` below this line. This PR removes the non extended modulemap from being added as an input as we only need the extended version.