### PR TITLE
Increase max compatibility level for rules_swift to 2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -32,6 +32,7 @@ bazel_dep(
 bazel_dep(
     name = "rules_swift",
     version = "1.18.0",
+    max_compatibility_level = 2,
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(


### PR DESCRIPTION
This is required to support both rules_swift 1.x and 2.x