### PR TITLE
CI: Bazel 7 tests use Build without the Bytes

### DIFF
--- a/.github/workflows/preflight_env.sh
+++ b/.github/workflows/preflight_env.sh
@@ -12,7 +12,14 @@ pip3 install setuptools==69.5.1 --break-system-packages
 
 # If flag --no-bzlmod is passed, writes a user.bazelrc file to disable Bzlmod.
 if [[ "$*" == *--no-bzlmod* ]]; then
-  echo "build --noenable_bzlmod" >> user.bazelrc
+  echo "common --noenable_bzlmod" >> user.bazelrc
+fi
+
+# For Bazel versions 7+ enable Build without the Bytes to test that feature.
+bazel_major_version=${USE_BAZEL_VERSION:0:1}
+if [[ "$bazel_major_version" -ge 7 ]]; then
+  echo "common --remote_download_outputs=minimal" >> user.bazelrc
+  echo "common --experimental_remote_cache_eviction_retries=2" >> user.bazelrc
 fi
 
 # Add the ci config override.


### PR DESCRIPTION
This should let us ensure our rules have no issues with BwtB in Bazel 7+. The Bazel 6 job remains the same.