### PR TITLE
Add `direct_public_headers` to CcInfo `compilation_context`

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -1017,6 +1017,11 @@ def _apple_framework_packaging_impl(ctx):
     objc_provider_utils.add_to_dict_if_present(compilation_context_fields, "headers", depset(
         direct = outputs.headers + outputs.private_headers + outputs.modulemaps,
     ))
+    objc_provider_utils.add_to_dict_if_present(
+        compilation_context_fields,
+        "direct_public_headers",
+        outputs.headers + outputs.modulemaps,
+    )
     objc_provider_utils.add_to_dict_if_present(compilation_context_fields, "defines", depset(
         direct = [],
         transitive = [getattr(cc_info.compilation_context, "defines") for cc_info in dep_cc_infos],

--- a/rules/framework/vfs_overlay.bzl
+++ b/rules/framework/vfs_overlay.bzl
@@ -283,6 +283,7 @@ def _framework_vfs_overlay_impl(ctx):
     cc_info = CcInfo(
         compilation_context = cc_common.create_compilation_context(
             headers = headers,
+            direct_public_headers = [vfs.vfsoverlay_file],
         ),
     )
     return [


### PR DESCRIPTION
Adds the public headers to the `CcInfo` compilation contexts