### PR TITLE
Remove usage of predeclared outputs from rules

### DIFF
--- a/rules/framework/vfs_overlay.bzl
+++ b/rules/framework/vfs_overlay.bzl
@@ -267,6 +267,8 @@ def _framework_vfs_overlay_impl(ctx):
             if VFSOverlayInfo in dep:
                 vfsoverlays.append(dep[VFSOverlayInfo].vfs_info)
 
+    vfs_overlay_file = ctx.actions.declare_file(ctx.label.name + ".yaml")
+
     vfs = make_vfsoverlay(
         ctx,
         hdrs = ctx.files.hdrs,
@@ -275,7 +277,7 @@ def _framework_vfs_overlay_impl(ctx):
         has_swift = ctx.attr.has_swift,
         swiftmodules = ctx.files.swiftmodules,
         merge_vfsoverlays = vfsoverlays,
-        output = ctx.outputs.vfsoverlay_file,
+        output = vfs_overlay_file,
         extra_search_paths = ctx.attr.extra_search_paths,
     )
 
@@ -287,6 +289,9 @@ def _framework_vfs_overlay_impl(ctx):
         ),
     )
     return [
+        DefaultInfo(
+            files = depset([vfs_overlay_file]),
+        ),
         apple_common.new_objc_provider(),
         cc_info,
         VFSOverlayInfo(
@@ -447,7 +452,4 @@ toolchain (such as `clang`) will be retrieved.
     fragments = [
         "apple",
     ],
-    outputs = {
-        "vfsoverlay_file": "%{name}.yaml",
-    },
 )


### PR DESCRIPTION
Predelcared outputs are deprecated and discouraged, instead use `declare_file` to explicitly declare these outputs. See: https://bazel.build/extending/rules#deprecated_predeclared_outputs