### PR TITLE
Fix apple_library rule not working in sandbox when do `SwiftCompile` in mixed sources

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -931,6 +931,7 @@ def apple_library(
 
     if has_swift_sources:
         additional_swift_copts += ["-Xcc", "-I."]
+        swiftc_inputs = other_inputs + objc_hdrs + objc_private_hdrs
         if module_map:
             # Frameworks find the modulemap file via the framework vfs overlay
             if not namespace_is_module_name:
@@ -940,8 +941,8 @@ def apple_library(
                 "@build_bazel_rules_ios//:swift_disable_import_underlying_module": [],
                 "//conditions:default": ["-import-underlying-module"] if not feature_names.swift_disable_import_underlying_module in features else [],
             })
+            swiftc_inputs += [module_map]
 
-        swiftc_inputs = other_inputs + objc_hdrs + objc_private_hdrs
         if swift_objc_bridging_header:
             if swift_objc_bridging_header not in objc_hdrs:
                 swiftc_inputs.append(swift_objc_bridging_header)
@@ -952,6 +953,8 @@ def apple_library(
         generated_swift_header_name = module_name + "-Swift.h"
 
         if module_map:
+            # TODO: now that we always add module_map as a swiftc_input,
+            # we should consider removing this one if it's not needed
             extend_modulemap(
                 name = module_map + ".extended." + name,
                 destination = "%s.extended.modulemap" % name,


### PR DESCRIPTION
To repro, run `bazel clean; bazel build //tests/ios/frameworks/mixed-source/only-source:SwiftLibrary -s --sandbox_debug --strategy=SwiftCompile=sandboxed` and got 
`<unknown>:0: error: underlying Objective-C module 'SwiftLibrary' not found` error

using`bazel aquery //tests/ios/frameworks/mixed-source/only-source:SwiftLibrary_swift` to look at input list, realized `bazel-out/darwin_arm64-dbg/bin/tests/ios/frameworks/mixed-source/only-source/SwiftLibrary-modulemap/SwiftLibrary.modulemap`  entry is not there even though that's sth generated by the module_map generator

So adding this fixed the issue because sandbox can now pick up this file 

Next step: setup CI job here that run everything in sandbox mode, try to fix anything that is broken in another PR