### PR TITLE
Add sandbox mode to CI testing matrix

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,7 +2,7 @@
 common --enable_bzlmod
 
 # Spawn strategy required for some tests
-build --spawn_strategy=standalone
+build --spawn_strategy=local
 
 # Setup Xcode configuration.
 build --xcode_version_config=//:host_xcodes
@@ -61,6 +61,16 @@ build:remote_cache --nolegacy_important_outputs
 build:remote_cache --noslim_profile
 build:remote_cache --remote_cache=grpcs://remote.buildbuddy.io
 build:remote_cache --remote_timeout=3600
+
+build:sandboxed --spawn_strategy=sandboxed
+# Otherwise it still use the worker strategy
+build:sandboxed --strategy=SwiftCompile=sandboxed
+build:sandboxed --strategy=Genrule=sandboxed,local
+build:sandboxed --strategy=StoryboardCompile=sandboxed,local
+build:sandboxed --strategy=CleaningFramework=sandboxed,local
+build:sandboxed --strategy=StoryboardLink=sandboxed,local
+build:sandboxed --strategy=ProcessAndSign=sandboxed,local
+build:sandboxed --strategy=AssetCatalogCompile=sandboxed,local
 
 # By default don't upload local results to remote cache, only CI does this.
 build --noremote_upload_local_results

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ concurrency:
 #       when adding a new job / changing the matrix, make sure to update all jobs
 jobs:
   integration_tests:
-    name: Build and test (Bazel ${{ matrix.bazel_version }} / Xcode ${{ matrix.xcode_version }} / Virtual Frameworks ${{ matrix.virtual_frameworks }})
+    name: Build and test (Bazel ${{ matrix.bazel_version }} / Xcode ${{ matrix.xcode_version }} / Virtual Frameworks ${{ matrix.virtual_frameworks }}) / Sandbox ${{ matrix.sandbox }}
     runs-on: macos-14
     strategy:
       fail-fast: false
@@ -23,6 +23,7 @@ jobs:
         bazel_version: [6.5.0, 7.1.0]
         xcode_version: [15.2]
         virtual_frameworks: [true, false]
+        sandbox: [true, false]
     env:
         XCODE_VERSION: ${{ matrix.xcode_version }}
         USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
@@ -34,6 +35,10 @@ jobs:
         name: Add vfs config
         run: |
           echo "build --config=vfs" >> user.bazelrc
+      - if: matrix.sandbox
+        name: Enable sandbox mode
+        run: |
+          echo "build --config=sandboxed" >> user.bazelrcc
       - name: Build and Test
         run: |
           # non-iOS tests

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -953,8 +953,6 @@ def apple_library(
         generated_swift_header_name = module_name + "-Swift.h"
 
         if module_map:
-            # TODO: now that we always add module_map as a swiftc_input,
-            # we should consider removing this one if it's not needed
             extend_modulemap(
                 name = module_map + ".extended." + name,
                 destination = "%s.extended.modulemap" % name,

--- a/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests-Bridging-Header.h
+++ b/tests/ios/unit-test/test-imports-app/TestImports-Unit-Tests-Bridging-Header.h
@@ -1,2 +1,1 @@
 #import <TestImports-Unit-Tests/testhelper.h>
-#import <TestImports-App/Header2.h>

--- a/tests/ios/unit-test/test-imports-app/test.swift
+++ b/tests/ios/unit-test/test-imports-app/test.swift
@@ -5,6 +5,6 @@ class SwiftTests : XCTestCase {
   func testPasses() {
       _ = EmptyStruct()
       XCTAssertTrue(true)
-      XCTAssertEqual(TestHelper.createString(), "ObjcTestHelperString_EnumValue=1")
+      XCTAssertEqual(TestHelper.createString(), "ObjcTestHelperString_EnumValue=\(AppErrorCode.unknown.rawValue)")
   }
 }


### PR DESCRIPTION
What changed:
1. Add sandbox on/off to testing matrix, so we have 2 bazel version * VFS on/off * sandbox on off = 8 tests in total ATM
2. Fix redefinition of `AppErrorCode` enum error in sandbox mode by removing the extra import in bridging header. The tests still works and can catch renaming of the enum for example. Why it was working in non sandbox mode is unknown
3. Add `sandbox` config to include all settings needed to pass CI. specifically allow a small set of actions to run locally.

Why this change:
To add CI coverage to sandbox mode to ensure no regression on it, now that we have fixed issues with sandbox mode in https://github.com/bazel-ios/rules_ios/pull/894

Discussion:
CI duration might be a concern, we can exclude certain combo in the test matrix if we want, it's possible with `exclude` keyword