### PR TITLE
Fix rules_swift 2 compatibility issues

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -604,12 +604,13 @@ def _copy_swiftmodule(ctx, framework_files, virtualize_frameworks):
         ),
     ]
 
-def _get_merged_swift_info(ctx, framework_files, transitive_deps, virtualize_frameworks):
+def _get_merged_swift_info(ctx, swift_module_context, framework_files, transitive_deps, virtualize_frameworks):
     swift_info_fields = {
         "swift_infos": [dep[SwiftInfo] for dep in transitive_deps if SwiftInfo in dep],
+        "modules": [swift_module_context],
     }
     if framework_files.outputs.swiftmodule:
-        swift_info_fields["modules"] = _copy_swiftmodule(ctx, framework_files, virtualize_frameworks)
+        swift_info_fields["modules"] += _copy_swiftmodule(ctx, framework_files, virtualize_frameworks)
     return swift_common.create_swift_info(**swift_info_fields)
 
 def _merge_root_infoplists(ctx):
@@ -1071,11 +1072,13 @@ def _apple_framework_packaging_impl(ctx):
         # If not virtualizing the framework - then it runs a "clean"
         _get_symlinked_framework_clean_action(ctx, framework_files, compilation_context_fields)
 
+    compilation_context = cc_common.create_compilation_context(
+        **compilation_context_fields
+    )
+
     # Construct the `CcInfo` provider, the linking context here used instead of ObjcProvider in Bazel 7+.
     cc_info_provider = CcInfo(
-        compilation_context = cc_common.create_compilation_context(
-            **compilation_context_fields
-        ),
+        compilation_context = compilation_context,
         linking_context = cc_common.create_linking_context(
             linker_inputs = _get_cc_info_linker_inputs(deps = deps) if is_bazel_7 else depset([]),
         ),
@@ -1104,7 +1107,16 @@ def _apple_framework_packaging_impl(ctx):
     else:
         bundle_outs = _bundle_static_framework(ctx, is_extension_safe = is_extension_safe, current_apple_platform = current_apple_platform, outputs = outputs)
         avoid_deps_info = AvoidDepsInfo(libraries = depset(avoid_deps).to_list(), link_dynamic = False)
-    swift_info = _get_merged_swift_info(ctx, framework_files, transitive_deps, virtualize_frameworks)
+
+    # rules_swift 2.x no longers takes compilation_context from CcInfo, need to pass it in via SwiftInfo
+    swift_module_context = swift_common.create_module(
+        name = ctx.attr.name,
+        clang = swift_common.create_clang_module(
+            compilation_context = compilation_context,
+            module_map = None,
+        ),
+    )
+    swift_info = _get_merged_swift_info(ctx, swift_module_context, framework_files, transitive_deps, virtualize_frameworks)
 
     # Build out the default info provider
     out_files = _compact([outputs.binary, outputs.swiftmodule, outputs.infoplist])

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -561,7 +561,7 @@ def _create_swiftmodule(attrs):
         **kwargs
     )
 
-def _copy_swiftmodule(ctx, framework_files):
+def _copy_swiftmodule(ctx, framework_files, virtualize_frameworks):
     inputs = framework_files.inputs
     outputs = framework_files.outputs
 
@@ -578,18 +578,38 @@ def _copy_swiftmodule(ctx, framework_files):
         # original swift module/doc, so that swift can find it.
         swift_module = _create_swiftmodule(inputs)
 
+    # Setup the `clang` attr of the Swift module for non-vfs case this is required to have it locate the modulemap
+    # and headers correctly.
+    clang = None
+    if not virtualize_frameworks:
+        module_map = outputs.modulemaps[0] if outputs.modulemaps else None
+        clang = swift_common.create_clang_module(
+            module_map = module_map,
+            compilation_context = cc_common.create_compilation_context(
+                headers = depset(_compact(
+                    outputs.headers +
+                    outputs.private_headers +
+                    [module_map],
+                )),
+            ),
+        )
+
     return [
         # only add the swift module, the objc modulemap is already listed as a header,
         # and it will be discovered via the framework search path
-        swift_common.create_module(name = swiftmodule_name, swift = swift_module),
+        swift_common.create_module(
+            name = swiftmodule_name,
+            clang = clang,
+            swift = swift_module,
+        ),
     ]
 
-def _get_merged_swift_info(ctx, framework_files, transitive_deps):
+def _get_merged_swift_info(ctx, framework_files, transitive_deps, virtualize_frameworks):
     swift_info_fields = {
         "swift_infos": [dep[SwiftInfo] for dep in transitive_deps if SwiftInfo in dep],
     }
     if framework_files.outputs.swiftmodule:
-        swift_info_fields["modules"] = _copy_swiftmodule(ctx, framework_files)
+        swift_info_fields["modules"] = _copy_swiftmodule(ctx, framework_files, virtualize_frameworks)
     return swift_common.create_swift_info(**swift_info_fields)
 
 def _merge_root_infoplists(ctx):
@@ -1084,7 +1104,7 @@ def _apple_framework_packaging_impl(ctx):
     else:
         bundle_outs = _bundle_static_framework(ctx, is_extension_safe = is_extension_safe, current_apple_platform = current_apple_platform, outputs = outputs)
         avoid_deps_info = AvoidDepsInfo(libraries = depset(avoid_deps).to_list(), link_dynamic = False)
-    swift_info = _get_merged_swift_info(ctx, framework_files, transitive_deps)
+    swift_info = _get_merged_swift_info(ctx, framework_files, transitive_deps, virtualize_frameworks)
 
     # Build out the default info provider
     out_files = _compact([outputs.binary, outputs.swiftmodule, outputs.infoplist])

--- a/rules/hmap.bzl
+++ b/rules/hmap.bzl
@@ -72,20 +72,28 @@ def _make_headermap_impl(ctx):
         namespace = ctx.attr.namespace,
         hdrs_lists = hdrs_lists,
     )
-
-    cc_info_provider = CcInfo(
-        compilation_context = cc_common.create_compilation_context(
-            headers = depset([headermap]),
-        ),
+    compilation_context = cc_common.create_compilation_context(
+        headers = depset([headermap]),
     )
-
+    cc_info_provider = CcInfo(
+        compilation_context = compilation_context,
+    )
+    swift_info_provider = swift_common.create_swift_info(
+        modules = [swift_common.create_module(
+            name = ctx.attr.name,
+            clang = swift_common.create_clang_module(
+                compilation_context = compilation_context,
+                module_map = None,
+            ),
+        )],
+    )
     providers = [
         DefaultInfo(
             files = depset([headermap]),
         ),
         apple_common.new_objc_provider(),
         cc_info_provider,
-        swift_common.create_swift_info(),
+        swift_info_provider,
     ]
 
     hdrs_lists = [l for l in hdrs_lists if l]


### PR DESCRIPTION
This PR includes fixes for the following issues:

- Fixes the following issue with non-vfs on Bazel 7+:

  ```
  <unknown>:0: error: module 'CustomModuleMap' was built in directory '/bazel-bin/tests/ios/frameworks/mixed-source/custom-module-map/CustomModuleMap/CustomModuleMap.framework' but now resides in directory '/bazel-bin/tests/ios/frameworks/mixed-source/custom-module-map/CustomModuleMap/CustomModuleMap.framework/Modules'
  ```

- Fixes the following issue in Bazel 6.5.0 with both vfs/non-vfs:
  
  ```
  error: generate-pch command failed with exit code 1 (use -v to see invocation) tests/ios/unit-test/test-imports-app/TestImports-App-Bridging-Header.h:1:9: error: 'TestImports-App/Header2.h' file not found
  #import <TestImports-App/Header2.h>
        ^
  1 error generated.
  <unknown>:0: error: failed to emit precompiled header 'bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-dbg-ST-c2aefc9133a8/bin/_pch_output_dir/TestImports-App-Bridging-Header-swift_28IU2BV1DK30K-clang_1FNSWCOAS4SUQ.pch' for bridging header 'tests/ios/unit-test/test-imports-app/TestImports-App-Bridging-Header.h'
  ```
  
Fixes the following CI jobs that are failing in `master`:
- `Bazel 6.5.0 / Xcode 15.2 / VFS false / Sandbox true / Latest rules true`
- `Bazel 6.5.0 / Xcode 15.2 / VFS false / Sandbox false / Latest rules true`
- `Bazel 6.5.0 / Xcode 15.2 / VFS true / Sandbox true / Latest rules true`
- `Bazel 6.5.0 / Xcode 15.2 / VFS true / Sandbox false / Latest rules true`
- `Bazel 7.1.0 / Xcode 15.2 / VFS false / Sandbox true / Latest rules true`
- `Bazel 7.1.0 / Xcode 15.2 / VFS false / Sandbox false / Latest rules true`