### PR TITLE
Pass compilation context via swift info in hmap creation due to rules_swift 2.1.1

### DIFF
--- a/rules/hmap.bzl
+++ b/rules/hmap.bzl
@@ -72,20 +72,28 @@ def _make_headermap_impl(ctx):
         namespace = ctx.attr.namespace,
         hdrs_lists = hdrs_lists,
     )
-
-    cc_info_provider = CcInfo(
-        compilation_context = cc_common.create_compilation_context(
-            headers = depset([headermap]),
-        ),
+    compilation_context = cc_common.create_compilation_context(
+        headers = depset([headermap]),
     )
-
+    cc_info_provider = CcInfo(
+        compilation_context = compilation_context,
+    )
+    swift_info_provider = swift_common.create_swift_info(
+        modules = [swift_common.create_module(
+            name = ctx.attr.name,
+            clang = swift_common.create_clang_module(
+                compilation_context = compilation_context,
+                module_map = None,
+            ),
+        )],
+    )
     providers = [
         DefaultInfo(
             files = depset([headermap]),
         ),
         apple_common.new_objc_provider(),
         cc_info_provider,
-        swift_common.create_swift_info(),
+        swift_info_provider,
     ]
 
     hdrs_lists = [l for l in hdrs_lists if l]


### PR DESCRIPTION
One of the CI error is:
```
error: generate-pch command failed with exit code 1 (use -v to see invocation)
tests/ios/unit-test/test-imports-app/TestImports-App-Bridging-Header.h:1:9: error: 'TestImports-App/Header2.h' file not found
#import <TestImports-App/Header2.h>
        ^
1 error generated.
<unknown>:0: error: failed to emit precompiled header 'bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-dbg-ST-c2aefc9133a8/bin/_pch_output_dir/TestImports-App-Bridging-Header-swift_28IU2BV1DK30K-clang_1FNSWCOAS4SUQ.pch' for bridging header 'tests/ios/unit-test/test-imports-app/TestImports-App-Bridging-Header.h'
```
This is because this header was suppose to be an input to Swift compile via hmap creation rule. But in this breaking change https://github.com/bazelbuild/rules_swift/commit/d68b21471e4e9d922b75e2b0621082b8ce017d11 rules_swift stopped collecting compilation context from `CcInfo` if the target is Swift code (line 1555 of `swift/internal/compiling.bzl`). Instead it depends on reading the same info from `clang_module.compilation_context` which is available from `SwiftInfo` provider (SwiftInfo -> modules -> clang)

This PR deals with header maps side where we propagate compilation context via this `clang` module

Next step is to do the same for other places where we need to pass the compilation context 

CI for this PR should no longer produce this error (but will still fail on some other tests)