### PR TITLE
Pass compilation context via swift info in framework rule due to rules_swift 2.1.1

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -604,12 +604,13 @@ def _copy_swiftmodule(ctx, framework_files, virtualize_frameworks):
         ),
     ]
 
-def _get_merged_swift_info(ctx, framework_files, transitive_deps, virtualize_frameworks):
+def _get_merged_swift_info(ctx, swift_module_context, framework_files, transitive_deps, virtualize_frameworks):
     swift_info_fields = {
         "swift_infos": [dep[SwiftInfo] for dep in transitive_deps if SwiftInfo in dep],
+        "modules": [swift_module_context],
     }
     if framework_files.outputs.swiftmodule:
-        swift_info_fields["modules"] = _copy_swiftmodule(ctx, framework_files, virtualize_frameworks)
+        swift_info_fields["modules"] += _copy_swiftmodule(ctx, framework_files, virtualize_frameworks)
     return swift_common.create_swift_info(**swift_info_fields)
 
 def _merge_root_infoplists(ctx):
@@ -1071,11 +1072,13 @@ def _apple_framework_packaging_impl(ctx):
         # If not virtualizing the framework - then it runs a "clean"
         _get_symlinked_framework_clean_action(ctx, framework_files, compilation_context_fields)
 
+    compilation_context = cc_common.create_compilation_context(
+        **compilation_context_fields
+    )
+
     # Construct the `CcInfo` provider, the linking context here used instead of ObjcProvider in Bazel 7+.
     cc_info_provider = CcInfo(
-        compilation_context = cc_common.create_compilation_context(
-            **compilation_context_fields
-        ),
+        compilation_context = compilation_context,
         linking_context = cc_common.create_linking_context(
             linker_inputs = _get_cc_info_linker_inputs(deps = deps) if is_bazel_7 else depset([]),
         ),
@@ -1104,7 +1107,16 @@ def _apple_framework_packaging_impl(ctx):
     else:
         bundle_outs = _bundle_static_framework(ctx, is_extension_safe = is_extension_safe, current_apple_platform = current_apple_platform, outputs = outputs)
         avoid_deps_info = AvoidDepsInfo(libraries = depset(avoid_deps).to_list(), link_dynamic = False)
-    swift_info = _get_merged_swift_info(ctx, framework_files, transitive_deps, virtualize_frameworks)
+
+    # rules_swift 2.x no longers takes compilation_context from CcInfo, need to pass it in via SwiftInfo
+    swift_module_context = swift_common.create_module(
+        name = ctx.attr.name,
+        clang = swift_common.create_clang_module(
+            compilation_context = compilation_context,
+            module_map = None,
+        ),
+    )
+    swift_info = _get_merged_swift_info(ctx, swift_module_context, framework_files, transitive_deps, virtualize_frameworks)
 
     # Build out the default info provider
     out_files = _compact([outputs.binary, outputs.swiftmodule, outputs.infoplist])


### PR DESCRIPTION
same idea as https://github.com/bazel-ios/rules_ios/pull/906 this time is for framework rule.

The CI error trying to fix in this PR is:
```
# Execution platform: @local_config_platform//:host
error: generate-pch command failed with exit code 1 (use -v to see invocation)
tests/ios/unit-test/test-imports-app/TestImports-App-Bridging-Header.h:1:9: error: 'TestImports-App/Header2.h' file not found
#import <TestImports-App/Header2.h>
        ^
1 error generated.
<unknown>:0: error: failed to emit precompiled header 'bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-dbg-ST-c2aefc9133a8/bin/_pch_output_dir/TestImports-App-Bridging-Header-swift_28IU2BV1DK30K-clang_1FNSWCOAS4SUQ.pch' for bridging header 'tests/ios/unit-test/test-imports-app/TestImports-App-Bridging-Header.h'
2 errors generated.
error: fatalError
```
This time this header is brought in by the framework rule

The idea here is to create the `clang_module` based of the same compilation context as CcInfo and construct the final swift info based on it. With this no need to differentiate based on if VFS turned on or not