### PR TITLE
Ensures the determinism of vfsoverlay file

### DIFF
--- a/rules/framework/vfs_overlay.bzl
+++ b/rules/framework/vfs_overlay.bzl
@@ -9,10 +9,10 @@ in-memory tree roots, it pre-pends the prefix of the `vfsoverlay` path
 to each of the entries.
 """
 
-load("//rules:providers.bzl", "FrameworkInfo")
-load("//rules:features.bzl", "feature_names")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_common")
+load("//rules:features.bzl", "feature_names")
+load("//rules:providers.bzl", "FrameworkInfo")
 
 FRAMEWORK_SEARCH_PATH = "/build_bazel_rules_ios/frameworks"
 
@@ -375,6 +375,12 @@ def make_vfsoverlay(ctx, hdrs, module_map, private_hdrs, has_swift, swiftmodules
     vfs_parent = _get_vfs_parent(ctx)
     vfs_parent_len = len(vfs_parent.split("/")) - 1
     vfs_prefix = _make_relative_prefix(vfs_parent_len)
+
+    # Ensures the determinism of vfsoverlay file
+    # hdrs, private_hdrs and swiftmodules of the same framework may be in different order.
+    hdrs = sorted(hdrs)
+    private_hdrs = sorted(private_hdrs)
+    swiftmodules = sorted(swiftmodules)
 
     data = struct(
         bin_dir_path = ctx.bin_dir.path,


### PR DESCRIPTION
hdrs, private_hdrs and swiftmodules of the same framework may be in different order when building with different build settings in Bazel 7. This change will ensure that the vfsoverlay file will be always the same for the same dependency graph.