### PR TITLE
fix bazel7 sim_arm64 dynamic framework link error, pass dynamic framework info

### DIFF
--- a/rules/import_middleman.bzl
+++ b/rules/import_middleman.bzl
@@ -286,6 +286,16 @@ def _file_collector_rule_impl(ctx):
                                 alwayslink = False,
                             )
                             for static_library in replaced_static_framework.replaced.values()
+                        ] + [
+                            # Bazel7 should speficy dynamic library for link
+                            cc_common.create_library_to_link(
+                                actions = ctx.actions,
+                                cc_toolchain = cc_toolchain,
+                                feature_configuration = cc_features,
+                                dynamic_library = dynamic_library,
+                                alwayslink = False,
+                            )
+                            for dynamic_library in replaced_dynamic_framework.values()
                         ]),
                     ),
                 ]),

--- a/tests/ios/in-tree-vendor-prebuilt-deps/dynamic/app/App/main.m
+++ b/tests/ios/in-tree-vendor-prebuilt-deps/dynamic/app/App/main.m
@@ -1,5 +1,6 @@
 @import FW;
 @import OnlySources;
+@import MobileFlow;
 
 int main(int argc, char **argv) {
     return UIApplicationMain(argc, argv, nil, nil);


### PR DESCRIPTION
When the "apple.arm64_simulator_use_device_deps" feature is enabled, dynamic framework information is not passed to Bazel. As a result, the linker encounters errors when attempting to link dynamic frameworks.