### PR TITLE
Relanding of `Add swift.experimental_rules_swift_package_manager flag` back to master branch

### DIFF
--- a/rules/features.bzl
+++ b/rules/features.bzl
@@ -26,4 +26,9 @@ feature_names = struct(
 
     # When set disable passing the `-import-underlying-module` copt to `swift_library` targets
     swift_disable_import_underlying_module = "swift.swift_disable_import_underlying_module",
+
+    # Allows consumers to depend on targets from https://github.com/cgrindel/rules_swift_package_manager.
+    #
+    # Note: This is a work in progress, and the flag will remain experimental until full support is ready.
+    experimental_rules_swift_package_manager = "swift.experimental_rules_swift_package_manager",
 )

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -267,7 +267,27 @@ def _get_virtual_framework_info(ctx, framework_files, compilation_context_fields
 
     # We need to map all the deps here - for both swift headers and others
     fw_dep_vfsoverlays = []
+
+    # Whether or not to collect SwiftInfo providers from rules_swift_package_manager targets
+    enable_rules_swift_package_manager = feature_names.experimental_rules_swift_package_manager in ctx.features
+
     for dep in transitive_deps + deps:
+        if enable_rules_swift_package_manager and SwiftInfo in dep:
+            if dep.label.workspace_name.startswith("swiftpkg"):
+                for spm_dep in dep[SwiftInfo].transitive_modules.to_list():
+                    if spm_dep.swift:
+                        spm_dep_vfs = make_vfsoverlay(
+                            ctx,
+                            hdrs = [],
+                            module_map = [],
+                            swiftmodules = [spm_dep.swift.swiftmodule, spm_dep.swift.swiftdoc],
+                            private_hdrs = [],
+                            has_swift = True,
+                            merge_vfsoverlays = [],
+                            framework_name = spm_dep.name,
+                        )
+                        fw_dep_vfsoverlays.append(spm_dep_vfs.vfs_info)
+
         # Collect transitive headers. For now, this needs to include all of the
         # transitive headers
         if CcInfo in dep:


### PR DESCRIPTION
already approved at https://github.com/bazel-ios/rules_ios/pull/917

Now it's about landing it in master and since it is guarded by a flag, it's no op unless you enable this feature