### PR TITLE
Allow library tool resource handling to be disabled

### DIFF
--- a/tests/ios/frameworks/bundle-in-data-resources/BUILD.bazel
+++ b/tests/ios/frameworks/bundle-in-data-resources/BUILD.bazel
@@ -1,0 +1,29 @@
+load("//rules:framework.bzl", "apple_framework")
+load("//rules:precompiled_apple_resource_bundle.bzl", "precompiled_apple_resource_bundle")
+load("//rules:test.bzl", "ios_unit_test")
+
+precompiled_apple_resource_bundle(
+    name = "BundleInDataResources",
+    bundle_id = "com.example.BundleInDataResources",
+    bundle_name = "BundleInDataResources",
+    platforms = {"ios": "12.0"},
+    resources = ["fake-data.txt"],
+)
+
+apple_framework(
+    name = "BundleInDataResourcesFramework",
+    srcs = ["BundleInData.swift"],
+    data = [":BundleInDataResources"],
+    # Because the `library.bzl` wraps `data` in a filegroup by default, the `rules_apple` aspects
+    # seem to fail to find the resource bundle. It seems in order to directly use a resource bundle rule
+    # within `data`, it must be directly referenced vs. wrapped in a filegroup.
+    library_tools = {"wrap_resources_in_filegroup": None},
+    platforms = {"ios": "12.0"},
+)
+
+ios_unit_test(
+    name = "BundleInDataTests",
+    srcs = ["BundleInDataTests.swift"],
+    minimum_os_version = "12.0",
+    deps = [":BundleInDataResourcesFramework"],
+)

--- a/tests/ios/frameworks/bundle-in-data-resources/BundleInData.swift
+++ b/tests/ios/frameworks/bundle-in-data-resources/BundleInData.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+private class BundleInDataBundleFinder {}
+
+// Helper for finding the bundle named "BundleInDataResources"
+public extension Bundle {
+    static let bundleInDataResources: Bundle = {
+        let container = Bundle(for: BundleInDataBundleFinder.self)
+        let bundlePath = container.path(forResource: "BundleInDataResources", ofType: "bundle")!
+        return Bundle(path: bundlePath)!
+    }()
+}
+

--- a/tests/ios/frameworks/bundle-in-data-resources/BundleInDataTests.swift
+++ b/tests/ios/frameworks/bundle-in-data-resources/BundleInDataTests.swift
@@ -1,0 +1,17 @@
+import Foundation
+import XCTest
+
+@testable import BundleInDataResourcesFramework
+
+class BundleInDataTests: XCTestCase {
+
+    func testBundleInData() throws {
+        let fakeDataPath = try XCTUnwrap(Bundle.bundleInDataResources.path(forResource: "fake-data", ofType: "txt"))
+        let fakeDataContents = try XCTUnwrap(String(contentsOfFile: fakeDataPath))
+
+        XCTAssertEqual(
+            fakeDataContents,
+            "fake-data\n"
+        )
+    }
+}

--- a/tests/ios/frameworks/bundle-in-data-resources/fake-data.txt
+++ b/tests/ios/frameworks/bundle-in-data-resources/fake-data.txt
@@ -1,0 +1,1 @@
+fake-data


### PR DESCRIPTION
This allows the wrap resource in filegroups and resource bundle generators to be disabled completely. It allows users to just pass in `data` and have the rule just forward that to the underlying libraries.

This cleans up the code a bit too since we use `data` directly instead of `module_data` which had to be converted into a list in a few places.

I added a test showcasing where this ability would be required. It fails without this change and passes when disabling the library tools