### PR TITLE
Avoid calling to_list in _get_cc_info_linker_inputs for performance

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -562,10 +562,9 @@ def _get_cc_info_linker_inputs(*, deps):
         if not CcInfo in dep:
             continue
 
-        for linker_input in dep[CcInfo].linking_context.linker_inputs.to_list():
-            linker_inputs.append(linker_input)
+        linker_inputs.append(dep[CcInfo].linking_context.linker_inputs)
 
-    return depset(linker_inputs)
+    return depset([], transitive = linker_inputs)
 
 def _create_swiftmodule(attrs):
     kwargs = {}


### PR DESCRIPTION
This is slow for very large targets and slows down `_apple_framework_packaging_impl`.

Before:
![Screenshot 2024-12-03 at 2 51 43 PM](https://github.com/user-attachments/assets/ad253422-9afb-4fed-aab9-cb835f9fe17b)



After:
![Screenshot 2024-12-03 at 2 53 10 PM](https://github.com/user-attachments/assets/c3a79512-dae1-4bbb-812a-fa469725528d)
