### PR TITLE
Add objc_library binary to outputs of apple_framework_packaging rule when virtualized frameworks feature is enabled

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -1,36 +1,36 @@
 """Framework rules"""
 
-load("//rules/framework:vfs_overlay.bzl", "VFSOverlayInfo", "make_vfsoverlay")
-load("//rules:features.bzl", "feature_names")
-load("//rules:library.bzl", "PrivateHeadersInfo", "apple_library")
-load("//rules:plists.bzl", "process_infoplists")
-load("//rules:providers.bzl", "AvoidDepsInfo", "FrameworkInfo")
-load("//rules:transition_support.bzl", "transition_support")
-load("//rules:utils.bzl", "is_bazel_7")
-load("//rules/internal:objc_provider_utils.bzl", "objc_provider_utils")
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
 load("@build_bazel_rules_apple//apple/internal:apple_product_type.bzl", "apple_product_type")
+load("@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl", "AppleMacToolsToolchainInfo", "AppleXPlatToolsToolchainInfo")
 load("@build_bazel_rules_apple//apple/internal:features_support.bzl", "features_support")
 load("@build_bazel_rules_apple//apple/internal:linking_support.bzl", "linking_support")
 load("@build_bazel_rules_apple//apple/internal:outputs.bzl", "outputs")
 load("@build_bazel_rules_apple//apple/internal:partials.bzl", "partials")
 load("@build_bazel_rules_apple//apple/internal:platform_support.bzl", "platform_support")
 load("@build_bazel_rules_apple//apple/internal:processor.bzl", "processor")
+load("@build_bazel_rules_apple//apple/internal:providers.bzl", "AppleBundleInfo", "ApplePlatformInfo", "IosFrameworkBundleInfo", "new_applebundleinfo", "new_iosframeworkbundleinfo")
 load("@build_bazel_rules_apple//apple/internal:resource_actions.bzl", "resource_actions")
 load("@build_bazel_rules_apple//apple/internal:resources.bzl", "resources")
 load("@build_bazel_rules_apple//apple/internal:rule_support.bzl", "rule_support")
-load("@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl", "AppleMacToolsToolchainInfo", "AppleXPlatToolsToolchainInfo")
 load("@build_bazel_rules_apple//apple/internal:swift_support.bzl", "swift_support")
-load("@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl", "clang_rt_dylibs")
-load("@build_bazel_rules_apple//apple/internal:providers.bzl", "AppleBundleInfo", "ApplePlatformInfo", "IosFrameworkBundleInfo", "new_applebundleinfo", "new_iosframeworkbundleinfo")
-load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo", "swift_clang_module_aspect", "swift_common")
 load(
     "@build_bazel_rules_apple//apple/internal/aspects:resource_aspect.bzl",
     "apple_resource_aspect",
 )
+load("@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl", "clang_rt_dylibs")
+load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo", "swift_clang_module_aspect", "swift_common")
+load("//rules:features.bzl", "feature_names")
 load("//rules:force_load_direct_deps.bzl", "force_load_direct_deps")
+load("//rules:library.bzl", "PrivateHeadersInfo", "apple_library")
+load("//rules:plists.bzl", "process_infoplists")
+load("//rules:providers.bzl", "AvoidDepsInfo", "FrameworkInfo")
+load("//rules:transition_support.bzl", "transition_support")
+load("//rules:utils.bzl", "is_bazel_7")
+load("//rules/framework:vfs_overlay.bzl", "VFSOverlayInfo", "make_vfsoverlay")
+load("//rules/internal:objc_provider_utils.bzl", "objc_provider_utils")
 
 _APPLE_FRAMEWORK_PACKAGING_KWARGS = [
     "visibility",

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -221,11 +221,6 @@ def _framework_packaging_multi(ctx, action, inputs, outputs, manifest = None):
         return []
     if inputs == [None]:
         return []
-
-    virtualize_frameworks = feature_names.virtualize_frameworks in ctx.features
-    if virtualize_frameworks:
-        return inputs
-
     if action in ctx.attr.skip_packaging:
         return []
     action_inputs = [manifest] + inputs if manifest else inputs
@@ -456,26 +451,41 @@ def _get_framework_files(ctx, deps):
     else:
         framework_manifest = None
 
-    # Package each part of the framework separately,
-    # so inputs that do not depend on compilation
-    # are available before those that do,
-    # improving parallelism
-    binary_out = _framework_packaging_single(ctx, "binary", binaries_in, binary_out, framework_manifest)
-    headers_out = _framework_packaging_multi(ctx, "header", headers_in, headers_out, framework_manifest)
-    private_headers_out = _framework_packaging_multi(ctx, "private_header", private_headers_in, private_headers_out, framework_manifest)
+    if virtualize_frameworks:
+        # When using virtualized frameworks, we skip the packaging step.
+        binaries_out = binaries_in
+        headers_out = headers_in
+        private_headers_out = private_headers_in
+        modulemap_out = modulemap_in
+        swiftmodule_out = swiftmodule_in
+        swiftinterface_out = swiftinterface_in
+        swiftdoc_out = swiftdoc_in
+        infoplist_out = infoplist_in
+        symbol_graph_out = symbol_graph_in
+    else:
+        # Package each part of the framework separately,
+        # so inputs that do not depend on compilation
+        # are available before those that do,
+        # improving parallelism
+        binaries_out = _compact([_framework_packaging_single(ctx, "binary", binaries_in, binary_out, framework_manifest)])
+        headers_out = _framework_packaging_multi(ctx, "header", headers_in, headers_out, framework_manifest)
+        private_headers_out = _framework_packaging_multi(ctx, "private_header", private_headers_in, private_headers_out, framework_manifest)
 
-    # Instead of creating a symlink of the modulemap, we need to copy it to modulemap_out.
-    # It's a hacky fix to guarantee running the clean action before compiling objc files depending on this framework in non-sandboxed mode.
-    # Otherwise, stale header files under framework_root will cause compilation failure in non-sandboxed mode.
-    modulemap_out = _framework_packaging_single(ctx, "modulemap", [modulemap_in], modulemap_out, framework_manifest)
-    swiftmodule_out = _framework_packaging_single(ctx, "swiftmodule", [swiftmodule_in], swiftmodule_out, framework_manifest)
-    swiftinterface_out = _framework_packaging_single(ctx, "swiftinterface", [swiftinterface_in], swiftinterface_out, framework_manifest)
-    swiftdoc_out = _framework_packaging_single(ctx, "swiftdoc", [swiftdoc_in], swiftdoc_out, framework_manifest)
-    infoplist_out = _framework_packaging_single(ctx, "infoplist", [infoplist_in], infoplist_out, framework_manifest)
-    symbol_graph_out = _framework_packaging_single(ctx, "symbol_graph", [symbol_graph_in], symbol_graph_out, framework_manifest)
+        # Instead of creating a symlink of the modulemap, we need to copy it to modulemap_out.
+        # It's a hacky fix to guarantee running the clean action before compiling objc files depending on this framework in non-sandboxed mode.
+        # Otherwise, stale header files under framework_root will cause compilation failure in non-sandboxed mode.
+        modulemap_out = _framework_packaging_single(ctx, "modulemap", [modulemap_in], modulemap_out, framework_manifest)
+        swiftmodule_out = _framework_packaging_single(ctx, "swiftmodule", [swiftmodule_in], swiftmodule_out, framework_manifest)
+        swiftinterface_out = _framework_packaging_single(ctx, "swiftinterface", [swiftinterface_in], swiftinterface_out, framework_manifest)
+        swiftdoc_out = _framework_packaging_single(ctx, "swiftdoc", [swiftdoc_in], swiftdoc_out, framework_manifest)
+        infoplist_out = _framework_packaging_single(ctx, "infoplist", [infoplist_in], infoplist_out, framework_manifest)
+        symbol_graph_out = _framework_packaging_single(ctx, "symbol_graph", [symbol_graph_in], symbol_graph_out, framework_manifest)
 
     outputs = struct(
-        binary = binary_out,
+        # When the virtualized frameworks feature is disabled, this contains a single binary, merged with libtool.
+        # When the virtualized frameworks feature is enabled, this contains both the objc_library and swift_library binaries, so that
+        # both binaries are included in the output files of this rule.
+        binaries = binaries_out,
         headers = headers_out,
         infoplist = infoplist_out,
         private_headers = private_headers_out,
@@ -517,10 +527,10 @@ def _get_symlinked_framework_clean_action(ctx, framework_files, compilation_cont
 
     framework_contents = _compact(
         [
-            outputs.binary,
             outputs.swiftmodule,
             outputs.swiftdoc,
         ] +
+        outputs.binaries +
         outputs.modulemaps +
         outputs.headers +
         outputs.private_headers,
@@ -988,7 +998,9 @@ def _bundle_static_framework(ctx, is_extension_safe, current_apple_platform, out
         new_applebundleinfo(
             archive = None,
             archive_root = None,
-            binary = outputs.binary,
+            # When the virtualized frameworks feature is enabled, outputs.binaries can contain two binaries:
+            # the swift_library binary and the objc_library binary. Arbitrarily use the first, matching previous behavior.
+            binary = outputs.binaries[0] if outputs.binaries else None,
             bundle_id = ctx.attr.bundle_id,
             bundle_name = ctx.attr.framework_name,
             bundle_extension = ctx.attr.bundle_extension,
@@ -1134,7 +1146,8 @@ def _apple_framework_packaging_impl(ctx):
     swift_info = _get_merged_swift_info(ctx, framework_files, transitive_deps, clang_module)
 
     # Build out the default info provider
-    out_files = _compact([outputs.binary, outputs.swiftmodule, outputs.infoplist])
+    out_files = _compact([outputs.swiftmodule, outputs.infoplist])
+    out_files.extend(outputs.binaries)
     out_files.extend(outputs.headers)
     out_files.extend(outputs.private_headers)
     out_files.extend(outputs.modulemaps)


### PR DESCRIPTION
This fixes an issue where building an `apple_framework_packaging` rule with the VFS feature enabled wouldn't trigger objc compilation for the framework.

When the VFS feature is disabled, the binaries from the `objc_library` and `swift_library` targets are merged using libtool, and that binary is included in the outputs of the `apple_framework_packaging` rule ([see packaging action](https://github.com/bazel-ios/rules_ios/blob/f7dcd0c4f90985495bba517dc8cc7d86ce7f7632/rules/framework/framework_packaging.py#L19)). 

When the VFS feature is enabled, all of the packaging actions are skipped, and the binaries from the `objc_library` and `swift_library` targets aren't merged. One of the input binaries is arbitrarily included in the rule's output files -- for a target containing swift and objc sources, this would be the `swift_library` binary.

The PR adds both input binaries to the rule outputs when the VFS feature is enabled, so building an `apple_framework_packaging` rule triggers both objc and swift compilation actions.