### PR TITLE
Revert "Avoid calling to_list in _get_cc_info_linker_inputs for performance (#930)

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -562,9 +562,10 @@ def _get_cc_info_linker_inputs(*, deps):
         if not CcInfo in dep:
             continue
 
-        linker_inputs.append(dep[CcInfo].linking_context.linker_inputs)
+        for linker_input in dep[CcInfo].linking_context.linker_inputs.to_list():
+            linker_inputs.append(linker_input)
 
-    return depset([], transitive = linker_inputs)
+    return depset(linker_inputs)
 
 def _create_swiftmodule(attrs):
     kwargs = {}


### PR DESCRIPTION
This reverts commit 77c4afab96331d48138f090cd1e395f4db8bd644.

We're seeing some behavior changes in tests caused by this change. I haven't figured out the underlying issue yet, but I'm reverting this change until we can figure it out.