### PR TITLE
Drop support for Bazel 6

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,12 +1,6 @@
 matrix:
-  bazel: ["6.x", "7.x"]
+  bazel: ["7.x"]
 tasks:
-  verify_build_targets_bazel_6:
-    name: Verify Build targets on macOS with Bazel 6
-    platform: macos_arm64
-    bazel: 6.x
-    build_targets:
-      - "@rules_ios//rules/..."
   verify_build_targets_bazel_7:
     name: Verify Build targets on macOS with Bazel 7
     platform: macos_arm64

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bazel_version: [6.5.0, 7.1.0]
+        bazel_version: [7.1.0]
         xcode_version: [15.2]
         virtual_frameworks: [true, false]
         sandbox: [true, false]
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bazel_version: [6.5.0, 7.1.0]
+        bazel_version: [7.1.0]
         sandbox: [true, false]
         xcode_version: [15.2]
     env:
@@ -164,7 +164,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bazel_version: [6.5.0, 7.1.0]
+        bazel_version: [7.1.0]
         xcode_version: [15.2]
     env:
         XCODE_VERSION: ${{ matrix.xcode_version }}

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ module(
     name = "rules_ios",
     version = "0",
     bazel_compatibility = [
-        ">=6.0.0",
+        ">=7.0.0",
     ],
     compatibility_level = 1,
     repo_name = "build_bazel_rules_ios",

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ See the following table for supported release versions.
 | Bazel release | Minimum supported rules version | Final supported rules version
 |:-------------------:|:-------------------------:|:-------------------------:
 | 7.* | 4.4.0 | current
-| 6.* | 2.0.0 | current
+| 6.* | 2.0.0 | 5.3.0
 | 5.* | 1.0.0 | 3.2.2
 | 4.* | 1.0.0 | 1.0.0
 


### PR DESCRIPTION
⚠️ Bazel 6 support is being dropped from rules_ios starting release > 5.3.0

With new changes in rules_apple such as removal of legacy objc_provider, latest rules_apple and latest rules_ios are no longer compatible, the PR is up to fix but we need to drop support for Bazel 6 to move on with that PR due to rules_apple dropping support for Bazel 6

Additionally, @luispadron 's survey showed most of us are on Bazel 7. 

## Related PRs

- #934 