### PR TITLE
Remove use of struct.to_json()

### DIFF
--- a/rules/framework/vfs_overlay.bzl
+++ b/rules/framework/vfs_overlay.bzl
@@ -426,7 +426,7 @@ def make_vfsoverlay(ctx, hdrs, module_map, private_hdrs, has_swift, swiftmodules
             "contents": roots,
         }],
     }
-    vfsoverlay_yaml = struct(**vfsoverlay_object).to_json()
+    vfsoverlay_yaml = json.encode(vfsoverlay_object)
     ctx.actions.write(
         content = vfsoverlay_yaml,
         output = output,


### PR DESCRIPTION
Bazel 8 does not appear to support struct.to_json() anymore, so remove its usage in vfs_overlay. It appears this API has been around since at least 6.5 (https://bazel.build/versions/6.5.0/rules/lib/core/json), so changing to it shouldn't be an issue.