### PR TITLE
Handle multiple alwayslink error in objc_library

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -1106,6 +1106,7 @@ def apple_library(
     if module_map:
         objc_hdrs.append(module_map)
 
+    default_alwayslink = kwargs.pop("alwayslink", True) # By default set it to True to ensure symbols from static deps are always included
     native.objc_library(
         name = objc_libname,
         srcs = objc_sources + objc_private_hdrs + objc_non_exported_hdrs,
@@ -1124,7 +1125,7 @@ def apple_library(
         defines = defines + objc_defines,
         testonly = testonly,
         features = features,
-        alwayslink = True,  # ensure symbols from any static deps are always included (see https://github.com/bazelbuild/rules_apple/issues/1938)
+        alwayslink = default_alwayslink,  # ensure symbols from any static deps are always included (see https://github.com/bazelbuild/rules_apple/issues/1938)
         **kwargs
     )
     launch_screen_storyboard_name = name + "_launch_screen_storyboard"

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -1106,7 +1106,7 @@ def apple_library(
     if module_map:
         objc_hdrs.append(module_map)
 
-    default_alwayslink = kwargs.pop("alwayslink", True) # By default set it to True to ensure symbols from static deps are always included
+    default_alwayslink = kwargs.pop("alwayslink", True)  # By default set it to True to ensure symbols from static deps are always included
     native.objc_library(
         name = objc_libname,
         srcs = objc_sources + objc_private_hdrs + objc_non_exported_hdrs,

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -1106,7 +1106,7 @@ def apple_library(
     if module_map:
         objc_hdrs.append(module_map)
 
-    default_alwayslink = kwargs.pop("alwayslink", True)  # By default set it to True to ensure symbols from static deps are always included
+    default_alwayslink = kwargs.pop("alwayslink", True)  # ensure symbols from any static deps are always included (see https://github.com/bazelbuild/rules_apple/issues/1938)
     native.objc_library(
         name = objc_libname,
         srcs = objc_sources + objc_private_hdrs + objc_non_exported_hdrs,
@@ -1125,7 +1125,7 @@ def apple_library(
         defines = defines + objc_defines,
         testonly = testonly,
         features = features,
-        alwayslink = default_alwayslink,  # ensure symbols from any static deps are always included (see https://github.com/bazelbuild/rules_apple/issues/1938)
+        alwayslink = default_alwayslink,
         **kwargs
     )
     launch_screen_storyboard_name = name + "_launch_screen_storyboard"


### PR DESCRIPTION
Allow `alwayslink` to be passed in `apple_framework` but set a default value to True so we handle errors as such

```sh
	File "/Users/ssarad/.bazel_cache/output/external/BUILD.bazel", line 5, column 16, in <toplevel>
		apple_framework(
	File "/Users/ssarad/.bazel_cache/output/external/rules_ios~/rules/framework.bzl", line 98, column 28, in apple_framework
		library = apple_library(
	File "/Users/ssarad/.bazel_cache/output/external/rules_ios~/rules/library.bzl", line 1109, column 24, in apple_library
		native.objc_library(
Error in objc_library: rule(...) got multiple values for parameter 'alwayslink'
```