### PR TITLE
Mark non_module_deps as reproducible

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -39,7 +39,6 @@ bazel_dep(
     name = "bazel_skylib",
     version = "1.4.2",
 )
-
 bazel_dep(
     name = "bazel_features",
     version = "1.9.0",

--- a/rules/module_extensions.bzl
+++ b/rules/module_extensions.bzl
@@ -11,7 +11,6 @@ load(
 )
 load("@bazel_features//:features.bzl", "bazel_features")
 
-
 def _non_module_deps_impl(module_ctx):
     rules_ios_dependencies(
         load_bzlmod_dependencies = False,
@@ -23,7 +22,6 @@ def _non_module_deps_impl(module_ctx):
     return module_ctx.extension_metadata(
         **metadata_kwargs
     )
-
 
 non_module_deps = module_extension(implementation = _non_module_deps_impl)
 


### PR DESCRIPTION
Dependencies are checked for integrity so this change would mark an entry in the MODULE.bazel.lock file 