### PR TITLE
Collect .lo files from dependencies as binaries in apple_framework_pa…

### DIFF
--- a/rules/analysis_tests/default_outputs_test.bzl
+++ b/rules/analysis_tests/default_outputs_test.bzl
@@ -1,0 +1,37 @@
+"""An analysis test to assert that the default outputs of a target match a specified list."""
+
+load("@bazel_skylib//lib:sets.bzl", "sets")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+
+def _default_outputs_test(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    actual_output_paths = [
+        file.short_path
+        for file in target_under_test[DefaultInfo].files.to_list()
+    ]
+    expected_output_paths = [
+        target_under_test.label.package + "/" + path
+        for path in ctx.attr.expected_output_file_paths
+    ]
+
+    asserts.set_equals(
+        env,
+        sets.make(expected_output_paths),
+        sets.make(actual_output_paths),
+        "Expected output paths do not match actual output paths",
+    )
+
+    return analysistest.end(env)
+
+default_outputs_test = analysistest.make(
+    _default_outputs_test,
+    attrs = {
+        "expected_output_file_paths": attr.string_list(
+            mandatory = True,
+            allow_empty = False,
+            doc = """A list of expected output file paths. The paths are relative to the package of the target under test""",
+        ),
+    },
+)

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -355,7 +355,7 @@ def _get_framework_files(ctx, deps):
                 continue
 
             # collect binary files
-            if file.path.endswith(".a"):
+            if file.path.endswith(".a") or file.path.endswith(".lo"):
                 binaries_in.append(file)
 
             # collect swift specific files

--- a/tests/ios/app/analysis-tests.bzl
+++ b/tests/ios/app/analysis-tests.bzl
@@ -14,13 +14,22 @@ def make_tests():
     default_outputs_test(
         name = "test_FWOutputs",
         target_under_test = ":FW",
-        expected_output_file_paths = [
-            "FW/FW.framework/FW",
-            "FW/FW.framework/Headers/FW.h",
-            "FW/FW.framework/Headers/FW-umbrella.h",
-            "FW/FW.framework/PrivateHeaders/FW_Private.h",
-            "FW/FW.framework/Modules/module.modulemap",
-        ],
+        expected_output_file_paths = select({
+            "//:virtualize_frameworks": [
+                "libFW_objc.lo",
+                "FW/FW.h",
+                "FW-modulemap/FW-umbrella.h",
+                "FW/FW_Private.h",
+                "FW-modulemap/FW.modulemap",
+            ],
+            "//conditions:default": [
+                "FW/FW.framework/FW",
+                "FW/FW.framework/Headers/FW.h",
+                "FW/FW.framework/Headers/FW-umbrella.h",
+                "FW/FW.framework/PrivateHeaders/FW_Private.h",
+                "FW/FW.framework/Modules/module.modulemap",
+            ],
+        }),
     )
 
     native.test_suite(

--- a/tests/ios/app/analysis-tests.bzl
+++ b/tests/ios/app/analysis-tests.bzl
@@ -1,3 +1,4 @@
+load("//rules/analysis_tests:default_outputs_test.bzl", "default_outputs_test")
 load("//rules/analysis_tests:identical_outputs_test.bzl", "identical_outputs_test")
 
 def make_tests():
@@ -8,6 +9,18 @@ def make_tests():
         # These inputs *must* be passed seperately, in order to
         # have different transitions applied by Skyframe.
         deps = [":AppWithSelectableCopts", ":SwiftLib"],
+    )
+
+    default_outputs_test(
+        name = "test_FWOutputs",
+        target_under_test = ":FW",
+        expected_output_file_paths = [
+            "FW/FW.framework/FW",
+            "FW/FW.framework/Headers/FW.h",
+            "FW/FW.framework/Headers/FW-umbrella.h",
+            "FW/FW.framework/PrivateHeaders/FW_Private.h",
+            "FW/FW.framework/Modules/module.modulemap",
+        ],
     )
 
     native.test_suite(


### PR DESCRIPTION
…ckaging

When `alwayslink` is `True`, `objc_library` can produce an `.lo` file instead of an `.a` file.

From the `cc_library` docs (which I believe also apply to `objc_library`):

https://bazel.build/reference/be/c-cpp#cc_library
> Use cc_library() for C++-compiled libraries. The result is either a .so, .lo, or .a, depending on what is needed.
> 
> If you build something with static linking that depends on a cc_library, the output of a depended-on library rule is the .a file. If you specify alwayslink=True, you get the .lo file.
>
> The actual output file name is libfoo.so for the shared library, where foo is the name of the rule. The other kinds of libraries end with .lo and .a, respectively. If you need a specific shared library name, for example, to define a Python module, use a genrule to copy the library to the desired name.

I'm not 100% sure if this is valid (does a .framework bundle with an .lo file as its binary make sense?), and the non-VFS codepath that [uses libtool to merge the `objc_library` and `swift_library` binary might break](https://github.com/bazel-ios/rules_ios/blob/f7dcd0c4f90985495bba517dc8cc7d86ce7f7632/rules/framework/framework_packaging.py#L19). But if [no binary is set in the `AppleBundleInfo` provider, `rules_xcodeproj` treats `apple_framework_packaging` targets as unsupported.](https://github.com/MobileNativeFoundation/rules_xcodeproj/blob/41929acc4c7c1da973c77871d0375207b9d0806f/xcodeproj/internal/automatic_target_info.bzl#L497)