### PR TITLE
Add Jonathan Schear as a maintainer

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -5,6 +5,11 @@
       "email": "rules_ios@squareup.com",
       "name": "rules_ios Maintainers"
     },
+    {
+      "name": "Jonathan Schear",
+      "email": "jschear@block.xyz",
+      "github": "jschear"
+    }
   ],
   "repository": [
     "github:bazel-ios/rules_ios"


### PR DESCRIPTION
Trying to figure out why the release automation isn't publishing to BCR; current theory is we're missing a maintainer with a Github username, or the trailing comma in the maintainers list is a problem. Whatever the case, add me 😄 